### PR TITLE
fix [closes #74] updating icons in Achievement component

### DIFF
--- a/src/components/Achievement/Achievement.js
+++ b/src/components/Achievement/Achievement.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
+
+import AssignmentLateIcon from '@material-ui/icons/AssignmentLate'
 import Card from '@material-ui/core/Card'
 import CardHeader from '@material-ui/core/CardHeader'
 import CardContent from '@material-ui/core/CardContent'
@@ -21,9 +23,7 @@ const Achievement = ({
   >
     <CardHeader
       {...{
-        avatar: (
-          <BeenhereIcon className={classNames({ completed: isComplete })} />
-        ),
+        avatar: isComplete ? <BeenhereIcon /> : <AssignmentLateIcon />,
         title: name,
         subheader: <p>Reward: {rewardDescription}</p>,
       }}

--- a/src/components/Achievement/Achievement.js
+++ b/src/components/Achievement/Achievement.js
@@ -3,8 +3,7 @@ import classNames from 'classnames'
 import Card from '@material-ui/core/Card'
 import CardHeader from '@material-ui/core/CardHeader'
 import CardContent from '@material-ui/core/CardContent'
-import AssignmentIcon from '@material-ui/icons/Assignment'
-import AssignmentTurnedInIcon from '@material-ui/icons/AssignmentTurnedIn'
+import BeenhereIcon from '@material-ui/icons/Beenhere'
 import { bool, object } from 'prop-types'
 
 import FarmhandContext from '../../Farmhand.context'
@@ -22,7 +21,9 @@ const Achievement = ({
   >
     <CardHeader
       {...{
-        avatar: isComplete ? <AssignmentTurnedInIcon /> : <AssignmentIcon />,
+        avatar: (
+          <BeenhereIcon className={classNames({ completed: isComplete })} />
+        ),
         title: name,
         subheader: <p>Reward: {rewardDescription}</p>,
       }}


### PR DESCRIPTION
  a recent change to the navigation icons caused this one to no longer
  match. this change updates the icon, and also changes the 'completed'
  state to be completely CSS based instead of using another icon.

current mismatched version:

<img width="477" alt="Screen Shot 2021-05-27 at 7 03 43 PM" src="https://user-images.githubusercontent.com/628757/119919866-2e34c100-bf20-11eb-979d-efed9ce6e637.png">

updated states:

<img width="473" alt="Screen Shot 2021-05-28 at 10 37 57 AM" src="https://user-images.githubusercontent.com/628757/120022204-ef931b00-bfa0-11eb-9b0d-2cc8de8c14f2.png">

