### PR TITLE
Lstebner/achievement i am rich

### DIFF
--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -21,6 +21,7 @@ import {
   getFinalCropItemFromSeedItem,
   getItemCurrentValue,
   getResaleValue,
+  getSalePriceMultiplier,
   moneyString,
   integerString,
 } from '../../utils'
@@ -145,6 +146,9 @@ export const Item = ({
 
   const avatar = <img {...{ src: items[id] }} alt={name} />
 
+  const sellPrice =
+    adjustedValue * getSalePriceMultiplier(completedAchievements)
+
   return (
     <Card
       {...{
@@ -221,7 +225,7 @@ export const Item = ({
                     <span>
                       Sell price:{' '}
                       <AnimatedNumber
-                        {...{ number: adjustedValue, formatter: moneyString }}
+                        {...{ number: sellPrice, formatter: moneyString }}
                       />
                     </span>
                   </Tooltip>

--- a/src/constants.js
+++ b/src/constants.js
@@ -110,6 +110,8 @@ export const DAILY_FINANCIAL_HISTORY_RECORD_LENGTH = 7
 
 export const RECIPE_INGREDIENT_VALUE_MULTIPLIER = 1.25
 
+export const I_AM_RICH_BONUSES = [0.05, 0.1, 0.25]
+
 export const PERSISTED_STATE_KEYS = [
   'completedAchievements',
   'cowBreedingPen',

--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -7,9 +7,10 @@ import {
   integerString,
   memoize,
   moneyTotal,
+  percentageString,
 } from '../utils'
 import { cropLifeStage, standardCowColors } from '../enums'
-import { COW_FEED_ITEM_ID } from '../constants'
+import { COW_FEED_ITEM_ID, I_AM_RICH_BONUSES } from '../constants'
 import { addItemToInventory } from '../reducers'
 
 import { itemsMap } from './maps'
@@ -240,6 +241,39 @@ const achievements = [
       ...state,
       inventoryLimit: state.inventoryLimit + reward,
     }),
+  }))(),
+
+  ((goal = 500000) => ({
+    id: 'i-am-rich-1',
+    name: 'I am Rich!',
+    description: `Earn ${dollarString(goal)}.`,
+    rewardDescription: `All sales receive a ${percentageString(
+      I_AM_RICH_BONUSES[0]
+    )} bonus`,
+    condition: state => state.revenue >= goal,
+    reward: state => state,
+  }))(),
+
+  ((goal = 1000000) => ({
+    id: 'i-am-rich-2',
+    name: 'Millionaire',
+    description: `Earn ${dollarString(goal)}.`,
+    rewardDescription: `All sales receive a ${percentageString(
+      I_AM_RICH_BONUSES[1]
+    )} bonus`,
+    condition: state => state.revenue >= goal,
+    reward: state => state,
+  }))(),
+
+  ((goal = 1000000000) => ({
+    id: 'i-am-rich-3',
+    name: 'Billionaire',
+    description: `Earn ${dollarString(goal)}.`,
+    rewardDescription: `All sales receive a ${percentageString(
+      I_AM_RICH_BONUSES[2]
+    )} bonus`,
+    condition: state => state.revenue >= goal,
+    reward: state => state,
   }))(),
 ]
 

--- a/src/data/achievements.test.js
+++ b/src/data/achievements.test.js
@@ -43,3 +43,47 @@ describe('harvest-crop', () => {
     })
   })
 })
+
+const iAmRichVariants = [
+  ['i-am-rich-1', 500000, 'Earn $500,000.', 'All sales receive a 5% bonus'],
+  ['i-am-rich-2', 1000000, 'Earn $1,000,000.', 'All sales receive a 10% bonus'],
+  [
+    'i-am-rich-3',
+    1000000000,
+    'Earn $1,000,000,000.',
+    'All sales receive a 25% bonus',
+  ],
+]
+
+describe.each(iAmRichVariants)(
+  'I am Rich variants',
+  (id, goal, description, rewardDescription) => {
+    describe(id, () => {
+      test('has the expected description', () => {
+        expect(achievementsMap[id].description).toEqual(description)
+      })
+
+      test('has the expected rewardDescription', () => {
+        expect(achievementsMap[id].rewardDescription).toEqual(rewardDescription)
+      })
+
+      test(`is achieved when revenue is greater than or equal to ${goal}`, () => {
+        const achievement = achievementsMap[id]
+        const state = {
+          revenue: goal,
+        }
+
+        expect(achievement.condition(state)).toEqual(true)
+      })
+
+      test(`is not achieved when revenue is less than ${goal}`, () => {
+        const achievement = achievementsMap[id]
+        const state = {
+          revenue: goal - 1,
+        }
+
+        expect(achievement.condition(state)).toEqual(false)
+      })
+    })
+  }
+)

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -41,6 +41,7 @@ import {
   getRandomUnlockedCrop,
   getRangeCoords,
   getResaleValue,
+  getSalePriceMultiplier,
   getSeedItemIdFromFinalStageCropItemId,
   inventorySpaceRemaining,
   isItemAFarmProduct,
@@ -1120,7 +1121,12 @@ export const sellItem = (state, { id }, howMany = 1) => {
   }
 
   const item = itemsMap[id]
-  const { itemsSold, money: initialMoney, valueAdjustments } = state
+  const {
+    completedAchievements,
+    itemsSold,
+    money: initialMoney,
+    valueAdjustments,
+  } = state
   const oldLevel = levelAchieved(farmProductsSold(itemsSold))
   let { loanBalance } = state
 
@@ -1129,7 +1135,6 @@ export const sellItem = (state, { id }, howMany = 1) => {
     : getAdjustedItemValue(valueAdjustments, id)
   const saleIsGarnished = isItemAFarmProduct(item)
   let saleValue = 0
-
   for (let i = 0; i < howMany; i++) {
     const loanGarnishment = saleIsGarnished
       ? Math.min(
@@ -1137,7 +1142,9 @@ export const sellItem = (state, { id }, howMany = 1) => {
           castToMoney(adjustedItemValue * LOAN_GARNISHMENT_RATE)
         )
       : 0
-    const garnishedProfit = adjustedItemValue - loanGarnishment
+    const garnishedProfit =
+      adjustedItemValue * getSalePriceMultiplier(completedAchievements) -
+      loanGarnishment
     loanBalance = moneyTotal(loanBalance, -loanGarnishment)
     saleValue = moneyTotal(saleValue, garnishedProfit)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,7 @@ import {
   COW_WEIGHT_MULTIPLIER_MINIMUM,
   DAILY_FINANCIAL_HISTORY_RECORD_LENGTH,
   HUGGING_MACHINE_ITEM_ID,
+  I_AM_RICH_BONUSES,
   INITIAL_FIELD_HEIGHT,
   INITIAL_FIELD_WIDTH,
   INITIAL_SPRINKLER_RANGE,
@@ -191,6 +192,12 @@ export const dollarString = number => formatNumber(number, '$0,0')
  * @returns {string} Number string with commas.
  */
 export const integerString = number => formatNumber(number, '0,0')
+
+/**
+ * @param {number} number A float
+ * @returns {string} the float converted to a full number with a % added
+ */
+export const percentageString = number => `${Math.round(number * 100)}%`
 
 /**
  * @param {string} itemId
@@ -989,3 +996,21 @@ export const getCostOfNextStorageExpansion = currentInventoryLimit => {
  * @returns {Promise}
  */
 export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * @param {object} completedAchievements from game state
+ * @returns {number} multiplier to be used for sales price adjustments based on completedAchievements
+ */
+export const getSalePriceMultiplier = (completedAchievements = {}) => {
+  let salePriceMultiplier = 1
+
+  if (completedAchievements['i-am-rich-3']) {
+    salePriceMultiplier += I_AM_RICH_BONUSES[2]
+  } else if (completedAchievements['i-am-rich-2']) {
+    salePriceMultiplier += I_AM_RICH_BONUSES[1]
+  } else if (completedAchievements['i-am-rich-1']) {
+    salePriceMultiplier += I_AM_RICH_BONUSES[0]
+  }
+
+  return salePriceMultiplier
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -24,12 +24,14 @@ import {
   getPlotImage,
   getPriceEventForCrop,
   getRangeCoords,
+  getSalePriceMultiplier,
   integerString,
   isItemAFarmProduct,
   levelAchieved,
   maxYieldOfRecipe,
   moneyString,
   moneyTotal,
+  percentageString,
 } from './utils'
 import fruitNames from './data/fruit-names'
 import { testCrop } from './test-utils'
@@ -55,6 +57,7 @@ import {
   COW_STARTING_WEIGHT_VARIANCE,
   COW_WEIGHT_MULTIPLIER_MAXIMUM,
   COW_WEIGHT_MULTIPLIER_MINIMUM,
+  I_AM_RICH_BONUSES,
   MALE_COW_WEIGHT_MULTIPLIER,
 } from './constants'
 
@@ -908,4 +911,57 @@ describe('computeMarketPositions', () => {
       'sample-item-6': -1,
     })
   })
+})
+
+const percentageStringTests = [
+  [0.5, '50%'],
+  [0.05, '5%'],
+  [1, '100%'],
+  [10, '1000%'],
+  [-0.3, '-30%'],
+]
+
+describe.each(percentageStringTests)(
+  'percentageString',
+  (percent, expectedString) => {
+    test(`it converts ${percent} to a ${expectedString}`, () => {
+      expect(percentageString(percent)).toEqual(expectedString)
+    })
+  }
+)
+
+describe('getSalePriceMultiplier', () => {
+  test('it returns 1 when there are no completedAchievements', () => {
+    expect(getSalePriceMultiplier({})).toEqual(1)
+  })
+
+  test('it returns 1 when there are no relevant completedAchievements', () => {
+    const completedAchievements = {
+      irrelevant: true,
+      'also-irrelevant': true,
+    }
+
+    expect(getSalePriceMultiplier(completedAchievements)).toEqual(1)
+  })
+
+  const iAmRichAchievements = [
+    ['i-am-rich-1', 1 + I_AM_RICH_BONUSES[0]],
+    ['i-am-rich-2', 1 + I_AM_RICH_BONUSES[1]],
+    ['i-am-rich-3', 1 + I_AM_RICH_BONUSES[2]],
+  ]
+
+  describe.each(iAmRichAchievements)(
+    'with I am Rich achievements completed',
+    (achievementId, expectedMultiplier) => {
+      test(`${achievementId} returns ${expectedMultiplier}`, () => {
+        const completedAchievements = {
+          [achievementId]: true,
+        }
+
+        expect(getSalePriceMultiplier(completedAchievements)).toEqual(
+          expectedMultiplier
+        )
+      })
+    }
+  )
 })


### PR DESCRIPTION
This PR implements 3 new achievements in a series referred to as "I am Rich". this closes issue #73 , and can be tested here https://farmhand-git-lstebner-achievement-i-am-rich-jeremyckahn.vercel.app/

this PR also adds a few new utils which were used to implement this feature

- `percentageString` util to convert a floating percent to a string value
- `getSalePriceMultiplier` looks at achievements and returns a multiplier value

completed achievements:

<img width="459" alt="Screen Shot 2021-05-29 at 2 37 17 PM" src="https://user-images.githubusercontent.com/628757/120085264-76bcbd80-c08b-11eb-8cff-3d53b3daeaf8.png">

incomplete achievements:

<img width="482" alt="Screen Shot 2021-05-30 at 9 35 01 AM" src="https://user-images.githubusercontent.com/628757/120112366-60b20a00-c12a-11eb-9be0-3be9cec27b80.png">

increased price in sell view:

<img width="342" alt="Screen Shot 2021-05-29 at 2 34 28 PM" src="https://user-images.githubusercontent.com/628757/120085248-4d039680-c08b-11eb-9f75-3da713668077.png">

unit tests:

<img width="743" alt="Screen Shot 2021-05-29 at 1 32 34 PM" src="https://user-images.githubusercontent.com/628757/120085223-234a6f80-c08b-11eb-9a4a-47a4d2dded93.png">

<img width="1072" alt="Screen Shot 2021-05-29 at 1 33 03 PM" src="https://user-images.githubusercontent.com/628757/120085227-280f2380-c08b-11eb-80fa-ab609117b006.png">