### PR TITLE
[closes #95] feat: make cows look in moove direction

### DIFF
--- a/src/components/CowPen/CowPen.js
+++ b/src/components/CowPen/CowPen.js
@@ -33,7 +33,7 @@ export class Cow extends Component {
   // This MUST be kept in sync with $hug-animation-duration in CowPen.sass.
   static hugAnimationDuration = 750
 
-  // Only moves the cow withing the middle 80% of the pen
+  // Only moves the cow within the middle 80% of the pen
   static randomPosition = () => 10 + Math.random() * 80
 
   get waitVariance() {
@@ -163,7 +163,6 @@ export class Cow extends Component {
   componentWillUnmount() {
     ;[
       this.repositionTimeoutId,
-      this.animateMovementTimeoutId,
       this.animateHugTimeoutId,
     ].forEach(clearTimeout)
 

--- a/src/components/CowPen/CowPen.js
+++ b/src/components/CowPen/CowPen.js
@@ -27,8 +27,8 @@ export class Cow extends Component {
   animateHugTimeoutId = null
   tweenable = new Tweenable()
 
-  static movementAnimationDuration = 3000
   static flipAnimationDuration = 1000
+  static transitionAnimationDuration = 3000
 
   // This MUST be kept in sync with $hug-animation-duration in CowPen.sass.
   static hugAnimationDuration = 750
@@ -125,7 +125,7 @@ export class Cow extends Component {
       await this.tweenable.tween({
         from: { x, y },
         to: { x: newX, y: Cow.randomPosition() },
-        duration: Cow.movementAnimationDuration,
+        duration: Cow.transitionAnimationDuration,
         render: ({ x, y }) => {
           this.setState({ x, y })
         },

--- a/src/components/CowPen/CowPen.js
+++ b/src/components/CowPen/CowPen.js
@@ -23,7 +23,6 @@ export class Cow extends Component {
   }
 
   repositionTimeoutId = null
-  animateMovementTimeoutId = null
   animateHugTimeoutId = null
   tweenable = new Tweenable()
   rotate = 0
@@ -67,16 +66,15 @@ export class Cow extends Component {
     }
   }
 
-  animateTimeoutHandler = () => {
-    this.animateMovementTimeoutId = null
-    this.finishMoving()
-  }
-
   move = async () => {
     const newX = Cow.randomPosition()
 
     const { moveDirection: oldDirection } = this.state
     const newDirection = newX < this.state.x ? LEFT : RIGHT
+
+    this.setState({
+      moveDirection: newDirection,
+    })
 
     if (oldDirection !== newDirection) {
       const render = ({ rotate }) => {
@@ -115,17 +113,23 @@ export class Cow extends Component {
       } catch (e) {}
     }
 
-    this.animateMovementTimeoutId = setTimeout(
-      this.animateTimeoutHandler,
-      Cow.movementAnimationDuration
-    )
-
     this.setState({
       isMoving: true,
-      moveDirection: newDirection,
-      x: newX,
-      y: Cow.randomPosition(),
     })
+
+    const { x, y } = this.state
+
+    await this.tweenable.tween({
+      from: { x, y },
+      to: { x: newX, y: Cow.randomPosition() },
+      duration: 3000,
+      render: ({ x, y }) => {
+        this.setState({ x, y })
+      },
+      easing: 'linear',
+    })
+
+    this.finishMoving()
   }
 
   finishMoving = () => {
@@ -175,8 +179,6 @@ export class Cow extends Component {
           className: classNames('cow', {
             'is-moving': isMoving,
             'is-selected': isSelected,
-            faceLeft: this.state.moveDirection === LEFT,
-            faceRight: this.state.moveDirection === RIGHT,
           }),
           onClick: () => handleCowClick(cow),
           style: {

--- a/src/components/CowPen/CowPen.js
+++ b/src/components/CowPen/CowPen.js
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHeart } from '@fortawesome/free-solid-svg-icons'
 
 import { cowColors } from '../../enums'
+import { LEFT, RIGHT } from '../../constants'
 import FarmhandContext from '../../Farmhand.context'
 import { animals } from '../../img'
 
@@ -14,6 +15,7 @@ import './CowPen.sass'
 export class Cow extends Component {
   state = {
     isMoving: false,
+    moveDirection: RIGHT,
     showHugAnimation: false,
     x: Cow.randomPosition(),
     y: Cow.randomPosition(),
@@ -68,6 +70,8 @@ export class Cow extends Component {
   }
 
   move = () => {
+    const newX = Cow.randomPosition()
+
     this.animateMovementTimeoutId = setTimeout(
       this.animateTimeoutHandler,
       Cow.movementAnimationDuration
@@ -75,7 +79,8 @@ export class Cow extends Component {
 
     this.setState({
       isMoving: true,
-      x: Cow.randomPosition(),
+      moveDirection: newX < this.state.x ? LEFT : RIGHT,
+      x: newX,
       y: Cow.randomPosition(),
     })
   }
@@ -125,11 +130,13 @@ export class Cow extends Component {
           className: classNames('cow', {
             'is-moving': isMoving,
             'is-selected': isSelected,
+            faceLeft: this.state.moveDirection === LEFT,
+            faceRight: this.state.moveDirection === RIGHT,
           }),
           onClick: () => handleCowClick(cow),
           style: {
-            left: `${y}%`,
-            top: `${x}%`,
+            left: `${x}%`,
+            top: `${y}%`,
           },
         }}
       >

--- a/src/components/CowPen/CowPen.sass
+++ b/src/components/CowPen/CowPen.sass
@@ -6,15 +6,11 @@
   &:hover
     cursor: pointer
 
-  // This MUST be kept in sync with Cow.movementAnimationDuration in CowPen.js.
-  $movement-animation-duration: 3000ms
-
   // This MUST be kept in sync with Cow.hugAnimationDuration in CowPen.js.
   $hug-animation-duration: 750ms
 
   .cow
     position: absolute
-    transition: all $movement-animation-duration linear
     z-index: 20
 
     &::before

--- a/src/components/CowPen/CowPen.sass
+++ b/src/components/CowPen/CowPen.sass
@@ -3,15 +3,15 @@
 .CowPen
   overflow: hidden
 
-  &:hover
-    cursor: pointer
-
   // This MUST be kept in sync with Cow.hugAnimationDuration in CowPen.js.
   $hug-animation-duration: 750ms
 
   .cow
     position: absolute
     z-index: 20
+
+    &:hover
+      cursor: pointer
 
     &::before
       background: rgba(128, 128, 128, 0.5)
@@ -25,6 +25,9 @@
       z-index: -20
 
     &.is-selected
+      // Render the selected cow on top of all others
+      z-index: 40
+
       &::before
         background: rgba(128, 128, 128, 1)
         // This is slightly off center to account for the balance of the cow
@@ -53,9 +56,9 @@
           animation-timing-function: ease-out
           animation-iteration-count: 1
 
-  .is-moving
+  .is-transitioning
     img
-      animation-name: is-moving-keyframes
+      animation-name: is-transitioning-keyframes
       animation-duration: 500ms
       animation-fill-mode: forwards
       animation-timing-function: linear
@@ -70,7 +73,7 @@
     width: 80%
     z-index: -1
 
-  @keyframes is-moving-keyframes
+  @keyframes is-transitioning-keyframes
     0%,
     100%
       transform: translate(0px, 0px)

--- a/src/components/CowPen/CowPen.sass
+++ b/src/components/CowPen/CowPen.sass
@@ -65,13 +65,6 @@
       animation-timing-function: linear
       animation-iteration-count: infinite
 
-  .faceLeft
-    transform: scaleX(-1)
-
-  .faceRight
-    transform: scaleX(1)
-
-
   .happiness-boosts-today
     bottom: -12px
     display: flex

--- a/src/components/CowPen/CowPen.sass
+++ b/src/components/CowPen/CowPen.sass
@@ -58,13 +58,19 @@
           animation-iteration-count: 1
 
   .is-moving
-
     img
       animation-name: is-moving-keyframes
       animation-duration: 500ms
       animation-fill-mode: forwards
       animation-timing-function: linear
       animation-iteration-count: infinite
+
+  .faceLeft
+    transform: scaleX(-1)
+
+  .faceRight
+    transform: scaleX(1)
+
 
   .happiness-boosts-today
     bottom: -12px

--- a/src/components/CowPen/CowPen.test.js
+++ b/src/components/CowPen/CowPen.test.js
@@ -135,15 +135,7 @@ describe('Cow', () => {
     describe('move', () => {
       test('updates state', () => {
         component.instance().move()
-        expect(component.state().isMoving).toEqual(true)
-      })
-    })
-
-    describe('finishMoving', () => {
-      test('updates state', () => {
-        component.setState({ isMoving: true })
-        component.instance().finishMoving()
-        expect(component.state().isMoving).toEqual(false)
+        expect(component.state().isTransitioning).toEqual(true)
       })
     })
   })

--- a/src/constants.js
+++ b/src/constants.js
@@ -173,3 +173,6 @@ export const DEFAULT_ROOM = 'global'
 
 export const MAX_PENDING_PEER_MESSAGES = 5
 export const MAX_LATEST_PEER_MESSAGES = 30
+
+export const LEFT = 'left'
+export const RIGHT = 'right'

--- a/src/enums.js
+++ b/src/enums.js
@@ -80,11 +80,7 @@ export const itemType = enumify([
  * @property farmhand.module:enums.fertilizerType
  * @enum {string}
  */
-export const fertilizerType = enumify([
-  'NONE',
-  'STANDARD',
-  'RAINBOW',
-])
+export const fertilizerType = enumify(['NONE', 'STANDARD', 'RAINBOW'])
 
 /**
  * @property farmhand.module:enums.genders
@@ -124,3 +120,4 @@ export const dialogView = enumify([
   'SETTINGS',
   'STATS',
 ])
+


### PR DESCRIPTION
  cows currently face right all the time, but this change adds some
  logic so that when they are moving left, they also look to the left.
  this was doing with CSS using transform, so it also inherited a nice
  little transition property that adds some animation to the whole
  thing.

  additionally: it was noticed that X position was being applied as the
  `top` style and Y as the `left` so this was flipped which seems more
  expected.

## here's a little gif of it in action

![happycows](https://user-images.githubusercontent.com/628757/120368244-b1f70080-c2c6-11eb-899b-e998a3b60e16.gif)



