### PR TITLE
[closes #27] refactor: using floor instead of round

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -71,7 +71,7 @@ const shopInventoryMap = shopInventory.reduce((acc, item) => {
 }, {})
 
 export const chooseRandom = list =>
-  list[Math.round(Math.random() * (list.length - 1))]
+  list[Math.floor(Math.random() * list.length)]
 
 // Ensures that the condition argument to memoize() is not ignored, per
 // https://github.com/caiogondim/fast-memoize.js#function-arguments

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,7 +71,7 @@ const shopInventoryMap = shopInventory.reduce((acc, item) => {
 }, {})
 
 export const chooseRandom = list =>
-  list[Math.floor(Math.random() * list.length)]
+  list[Math.floor(Math.random() * (list.length - 1))]
 
 // Ensures that the condition argument to memoize() is not ignored, per
 // https://github.com/caiogondim/fast-memoize.js#function-arguments


### PR DESCRIPTION
  when choosing a random item from the list, use Math.floor and multiply
  by the list length to produce more evenly dispersed results.