### PR TITLE
QuantityInput: clear input onFocus

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,7 @@
 Special thanks to everyone who has contributed to Farmhand's development!
 
 - Luke Stebner ([@lstebner](https://github.com/lstebner))
+- Chris Wolff ([@seawolff](https://github.com/seawolff))
 
 Take a look at the GitHub repo's [Contributors page](https://github.com/jeremyckahn/farmhand/graphs/contributors) to see who's contributed what.
 

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -291,7 +291,8 @@ export const Item = ({
                 color: 'primary',
                 disabled:
                   purchaseQuantity === 0 ||
-                  adjustedValue * purchaseQuantity > money,
+                  adjustedValue * purchaseQuantity > money ||
+                  !purchaseQuantity,
                 onClick: handleItemPurchase,
                 variant: 'contained',
               }}
@@ -315,7 +316,7 @@ export const Item = ({
               {...{
                 className: 'sell',
                 color: 'secondary',
-                disabled: sellQuantity === 0,
+                disabled: sellQuantity === 0 || !sellQuantity,
                 onClick: handleItemSell,
                 variant: 'contained',
               }}

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -290,9 +290,7 @@ export const Item = ({
                 className: 'purchase',
                 color: 'primary',
                 disabled:
-                  purchaseQuantity === 0 ||
-                  adjustedValue * purchaseQuantity > money ||
-                  !purchaseQuantity,
+                  !purchaseQuantity || adjustedValue * purchaseQuantity > money,
                 onClick: handleItemPurchase,
                 variant: 'contained',
               }}

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -42,7 +42,7 @@ const QuantityTextInput = ({
       },
       onChange: handleUpdateNumber,
       onFocus: () => {
-        // clear the input when input is first selected so we don't have to fight with clearing out default values
+        // clear the input when input is first selected so the user doesn't have to fight with clearing out default values
         handleUpdateNumber(undefined)
       },
       // Bind to keyup to prevent spamming the event handler.

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -41,6 +41,10 @@ const QuantityTextInput = ({
         max: maxQuantity,
       },
       onChange: handleUpdateNumber,
+      onFocus: () => {
+        // clear the input when input is first selected so we don't have to fight with clearing out default values
+        handleUpdateNumber(undefined)
+      },
       // Bind to keyup to prevent spamming the event handler.
       onKeyUp: ({ which }) => {
         // Enter
@@ -101,7 +105,11 @@ QuantityInput.propTypes = {
   handleUpdateNumber: func.isRequired,
   maxQuantity: number.isRequired,
   setQuantity: func.isRequired,
-  value: number.isRequired,
+  value: number,
+}
+
+QuantityInput.defaultProps = {
+  value: 1,
 }
 
 export default QuantityInput

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -77,6 +77,7 @@ const QuantityInput = ({
     </span>
     <div className="number-nudger-container">
       <Fab
+        disabled={!value}
         {...{
           'aria-label': 'Increment',
           color: 'primary',
@@ -87,6 +88,7 @@ const QuantityInput = ({
         <KeyboardArrowUp />
       </Fab>
       <Fab
+        disabled={!value}
         {...{
           'aria-label': 'Decrement',
           color: 'primary',

--- a/src/components/Recipe/Recipe.js
+++ b/src/components/Recipe/Recipe.js
@@ -66,7 +66,9 @@ const Recipe = ({
   const [quantity, setQuantity] = useState(1)
 
   useEffect(() => {
-    setQuantity(Math.min(maxYieldOfRecipe(recipe, inventory), 1, quantity))
+    setQuantity(
+      Math.min(maxYieldOfRecipe(recipe, inventory), Math.max(1, quantity))
+    )
   }, [inventory, recipe, quantity])
 
   // Fixes https://github.com/jeremyckahn/farmhand/issues/25

--- a/src/components/Recipe/Recipe.js
+++ b/src/components/Recipe/Recipe.js
@@ -66,8 +66,8 @@ const Recipe = ({
   const [quantity, setQuantity] = useState(1)
 
   useEffect(() => {
-    setQuantity(Math.min(maxYieldOfRecipe(recipe, inventory), 1))
-  }, [inventory, recipe])
+    setQuantity(Math.min(maxYieldOfRecipe(recipe, inventory), 1, quantity))
+  }, [inventory, recipe, quantity])
 
   // Fixes https://github.com/jeremyckahn/farmhand/issues/25
   const spaceFreedByIngredientsConsumed =
@@ -123,7 +123,7 @@ const Recipe = ({
           {...{
             className: 'make-recipe',
             color: 'primary',
-            disabled: !canBeMade,
+            disabled: !canBeMade || !quantity,
             onClick: handleMakeRecipe,
             variant: 'contained',
           }}


### PR DESCRIPTION
#### What does this PR do?
Sorry this is somewhat of an opinionated change. But I found it annoying that I couldn't clear the default value of the controlled component completely when writing out a desired amount. i.e. if the value amount was `1` and I wanted `50` I'd have to start typing my desired amount and clear the value. So I am proposing we just clear the quantity input value on focus.

![Screenflick Movie 135](https://user-images.githubusercontent.com/147572/122461462-0235ba00-cf79-11eb-9e72-967c3fdbc3d3.gif)
![Screenflick Movie 134](https://user-images.githubusercontent.com/147572/122461473-0530aa80-cf79-11eb-868f-3eb330b75651.gif)


#### How can this change be manually tested?
Select the Quantity Input for both buying and selling an item and notice that when you select the input the previous default value clears. The Buy/Sell button should be disabled if an undefined value is current set.

#### Questions or concerns about this change?
I could perhaps make the disabled item button check a bit cleaner but for now I just added to the conditional to check if the purchase or sell quantity isn't defined.
