### PR TITLE
Group crow notifications

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -362,6 +362,8 @@ export const applyCrows = state => {
   const { field } = state
   const newDayNotifications = [...state.newDayNotifications]
 
+  let notificationMessages = []
+
   const updatedField = fieldHasScarecrow(field)
     ? field
     : updateField(field, plotContent => {
@@ -372,14 +374,20 @@ export const applyCrows = state => {
         const destroyCrop = Math.random() <= CROW_CHANCE
 
         if (destroyCrop) {
-          newDayNotifications.push({
-            message: CROW_ATTACKED`${itemsMap[plotContent.itemId]}`,
-            severity: 'error',
-          })
+          notificationMessages.push(
+            CROW_ATTACKED`${itemsMap[plotContent.itemId]}`
+          )
         }
 
         return destroyCrop ? null : plotContent
       })
+
+  if (notificationMessages.length) {
+    newDayNotifications.push({
+      message: notificationMessages.join('\n\n'),
+      severity: 'error',
+    })
+  }
 
   return { ...state, field: updatedField, newDayNotifications }
 }

--- a/src/reducers.test.js
+++ b/src/reducers.test.js
@@ -1031,6 +1031,35 @@ describe('processNerfs', () => {
         ])
       })
 
+      test('multiple messages are grouped', () => {
+        jest.resetModules()
+        jest.mock('./constants', () => ({
+          CROW_CHANCE: 1,
+        }))
+
+        const { processNerfs } = jest.requireActual('./reducers')
+        const state = processNerfs({
+          field: [
+            [
+              testCrop({ itemId: 'sample-crop-1' }),
+              testCrop({ itemId: 'sample-crop-2' }),
+            ],
+          ],
+          newDayNotifications: [],
+        })
+
+        expect(state.field[0][0]).toBe(null)
+        expect(state.newDayNotifications).toEqual([
+          {
+            message: [
+              CROW_ATTACKED`${itemsMap['sample-crop-1']}`,
+              CROW_ATTACKED`${itemsMap['sample-crop-2']}`,
+            ].join('\n\n'),
+            severity: 'error',
+          },
+        ])
+      })
+
       describe('there is a scarecrow', () => {
         test('crow attack is prevented', () => {
           jest.resetModules()


### PR DESCRIPTION
Fixes #42. This PR keeps multiple crow attacks from spamming the player by grouping them all into a single batch notification.

<img width="268" alt="Screen Shot 2021-06-20 at 6 24 12 PM" src="https://user-images.githubusercontent.com/366330/122691434-43d29900-d1f5-11eb-8e2f-a557fdad95e4.png">
