### PR TITLE
Add support for enabling features via query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ REACT_APP_ENABLE_MINING=true
 
 Would enable the `MINING` feature only for the local development environment. You can access the enabled feature flags at runtime by `import`ing the `features` Object from [`config.js`](https://github.com/jeremyckahn/farmhand/blob/develop/src/config.js). See [Adding Custom Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables/) for more information on how to use environment variables.
 
+In addition to enabling features via environment variables, players can manually enable them in the browser (such as for beta testing). This can be done by manually constructing a URL query parameter that looks like `?enable_[FEATURE_NAME]=true`. For example, to enable the `MINING` feature, players could use the URL https://jeremyckahn.github.io/farmhand/?enable_MINING=true.
+
 ## License
 
 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).

--- a/src/Farmhand.js
+++ b/src/Farmhand.js
@@ -1045,6 +1045,7 @@ export default class Farmhand extends Component {
 
   render() {
     const {
+      props: { features },
       state: { redirect },
       fieldToolInventory,
       handlers,
@@ -1063,6 +1064,7 @@ export default class Farmhand extends Component {
     // passed down through the component tree.
     const gameState = {
       ...this.state,
+      features,
       fieldToolInventory,
       levelEntitlements,
       plantableCropInventory,

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import window from 'global/window'
+
 export const endpoints = {
   getMarketData: `${process.env.REACT_APP_API_ROOT}api/get-market-data`,
   postDayResults: `${process.env.REACT_APP_API_ROOT}api/post-day-results`,
@@ -11,6 +13,12 @@ export const endpoints = {
 // environment.
 //
 // See: https://create-react-app.dev/docs/adding-custom-environment-variables/
+//
+// In addition to enabling features via envars, end users can manually enable
+// them via URL query parameters. This can be done by constructing a query
+// parameter that looks like:
+//
+//   ?enable_MINING=true
 export const features = Object.keys(process.env).reduce((acc, key) => {
   const matches = key.match(/REACT_APP_ENABLE_(.*)/)
 
@@ -20,3 +28,13 @@ export const features = Object.keys(process.env).reduce((acc, key) => {
 
   return acc
 }, {})
+
+const searchParams = new URLSearchParams(window.location.search)
+
+for (const key of searchParams.keys()) {
+  const matches = key.match(/enable_(.*)/)
+
+  if (matches) {
+    features[matches[1]] = true
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -163,8 +163,11 @@ import { HashRouter as Router, Route } from 'react-router-dom'
 import * as serviceWorkerRegistration from './serviceWorkerRegistration'
 import './index.sass'
 import Farmhand from './Farmhand'
+import { features } from './config'
 import 'typeface-francois-one'
 import 'typeface-public-sans'
+
+const FarmhandRoute = props => <Farmhand {...{ ...props, features }} />
 
 ReactDOM.render(
   <Router
@@ -173,7 +176,10 @@ ReactDOM.render(
     }}
   >
     <Route
-      {...{ path: ['/online/:room', '/online', '/'], component: Farmhand }}
+      {...{
+        path: ['/online/:room', '/online', '/'],
+        component: FarmhandRoute,
+      }}
     />
   </Router>,
   document.getElementById('root')


### PR DESCRIPTION
### What this PR does

It extends #136 (for #133) by allowing players to enable feature flags through URL query params.

### How this change can be validated

Manually add query params as described by the new documentation to the Preview environment's URL and see that they are provided as `props` to the `Farmhand` component in the React DevTools.

### Additional information

<img width="775" alt="Screen Shot 2021-06-29 at 8 39 22 AM" src="https://user-images.githubusercontent.com/366330/123807516-88c19400-d8b5-11eb-8b77-ec8325c873de.png">
