### PR TITLE
fix: [closes #140] avoid increasing value of items sold from the shop

### DIFF
--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -14,7 +14,7 @@ import classNames from 'classnames'
 import FarmhandContext from '../../Farmhand.context'
 import { items } from '../../img'
 import { itemsMap } from '../../data/maps'
-import { shopItemIds } from '../../data/shop-inventory'
+import { itemIds as shopItemIds } from '../../data/shop-inventory'
 import {
   inventorySpaceRemaining,
   isItemSoldInShop,

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -33,7 +33,7 @@ import './Item.sass'
 
 const noop = () => {}
 
-const shopItemIds = shopInventory.map(item => item.id)
+const shopItemIds = new Set(shopInventory.map(item => item.id))
 
 const ValueIndicator = ({ poorValue }) => (
   <Tooltip
@@ -153,7 +153,7 @@ export const Item = ({
 
   // #140 - never increase the value of items the shop sells otherwise they
   // can be bought and instantly resold for a profit to game the.. game
-  if (!shopItemIds.includes(id)) {
+  if (!shopItemIds.has(id)) {
     sellPrice *= getSalePriceMultiplier(completedAchievements)
   }
 

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -14,6 +14,7 @@ import classNames from 'classnames'
 import FarmhandContext from '../../Farmhand.context'
 import { items } from '../../img'
 import { itemsMap } from '../../data/maps'
+import shopInventory from '../../data/shop-inventory'
 import {
   inventorySpaceRemaining,
   isItemSoldInShop,
@@ -31,6 +32,8 @@ import AnimatedNumber from '../AnimatedNumber'
 import './Item.sass'
 
 const noop = () => {}
+
+const shopItemIds = shopInventory.map(item => item.id)
 
 const ValueIndicator = ({ poorValue }) => (
   <Tooltip
@@ -146,8 +149,13 @@ export const Item = ({
 
   const avatar = <img {...{ src: items[id] }} alt={name} />
 
-  const sellPrice =
-    adjustedValue * getSalePriceMultiplier(completedAchievements)
+  let sellPrice = adjustedValue
+
+  // #140 - never increase the value of items the shop sells otherwise they
+  // can be bought and instantly resold for a profit to game the.. game
+  if (!shopItemIds.includes(id)) {
+    sellPrice *= getSalePriceMultiplier(completedAchievements)
+  }
 
   return (
     <Card

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -14,7 +14,7 @@ import classNames from 'classnames'
 import FarmhandContext from '../../Farmhand.context'
 import { items } from '../../img'
 import { itemsMap } from '../../data/maps'
-import shopInventory from '../../data/shop-inventory'
+import { shopItemIds } from '../../data/shop-inventory'
 import {
   inventorySpaceRemaining,
   isItemSoldInShop,
@@ -32,8 +32,6 @@ import AnimatedNumber from '../AnimatedNumber'
 import './Item.sass'
 
 const noop = () => {}
-
-const shopItemIds = new Set(shopInventory.map(item => item.id))
 
 const ValueIndicator = ({ poorValue }) => (
   <Tooltip

--- a/src/components/Item/Item.test.js
+++ b/src/components/Item/Item.test.js
@@ -7,7 +7,6 @@ import { testItem } from '../../test-utils'
 import { Item } from './Item'
 
 jest.mock('../../data/maps')
-jest.mock('../../data/shop-inventory')
 
 let component
 

--- a/src/data/shop-inventory.js
+++ b/src/data/shop-inventory.js
@@ -18,7 +18,7 @@ import {
   sprinkler,
 } from './items'
 
-export default [
+const shopInventory = [
   // Plantable crops
   asparagusSeed,
   carrotSeed,
@@ -37,3 +37,7 @@ export default [
   scarecrow,
   sprinkler,
 ]
+
+export default shopInventory
+
+export const shopItemIds = new Set(shopInventory.map(item => item.id))

--- a/src/data/shop-inventory.js
+++ b/src/data/shop-inventory.js
@@ -18,7 +18,7 @@ import {
   sprinkler,
 } from './items'
 
-const shopInventory = [
+const inventory = [
   // Plantable crops
   asparagusSeed,
   carrotSeed,
@@ -38,6 +38,6 @@ const shopInventory = [
   sprinkler,
 ]
 
-export default shopInventory
+export default inventory
 
-export const shopItemIds = new Set(shopInventory.map(item => item.id))
+export const itemIds = new Set(inventory.map(item => item.id))


### PR DESCRIPTION
### What this PR does

  the "I am Rich" achievement PR introduced an exploitable bug by
  affecting the price of seeds, and other items sold from the shop.
  players could buy these and instantly resell them for a steady profit.

  this PR patches that hole by checking to see if an item is sold in the
  shop before applying the adjustment to the value. this should help
  prevent this bug from popping back up in the future.

### How this change can be validated

To test this change you need to achieve one of the "i am rich" achievements; so sell at least $500,000 worth of goods. Then check the resale price of seeds, fertilizer, and the scarecrow. These should all stay consistent as to what they were before, even though crops and workshop items start to get boosted.

### Questions or concerns about this change

This logic being wrapped up in this component makes it very cumbersome to test. We should probably try to make the component purely presentational and get some good unit tests written around this logic.

### Additional information

![image](https://user-images.githubusercontent.com/628757/124062654-ed7c0c00-d9e5-11eb-868a-5971947d6674.png)
