### PR TITLE
chore: updating deprecated method name reference

### DIFF
--- a/src/mui-theme.js
+++ b/src/mui-theme.js
@@ -1,6 +1,6 @@
-import { createMuiTheme } from '@material-ui/core'
+import { createTheme } from '@material-ui/core'
 
-export default createMuiTheme({
+export default createTheme({
   typography: {
     // Needed to silence this warning:
     // https://material-ui.com/style/typography/#migration-to-typography-v2


### PR DESCRIPTION
### What this PR does 

 a warning was being output in the console that this method name
  changed from createMuiTheme to createTheme so this updates that import
  and call

### How this change can be validated

run the branch and see that the warning no longer shows up in the console. it was also being output from the test runner and can be validated by no longer seeing it there as well.

### Additional information

<img width="416" alt="Screen Shot 2021-07-12 at 10 23 56 PM" src="https://user-images.githubusercontent.com/628757/125395448-109ca900-e360-11eb-8050-1d491e911a1f.png">
