### PR TITLE
fix: put gold-digger achievement behind feature flag

### DIFF
--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -12,6 +12,7 @@ import {
 import { cropLifeStage, standardCowColors } from '../enums'
 import { COW_FEED_ITEM_ID, I_AM_RICH_BONUSES } from '../constants'
 import { addItemToInventory } from '../reducers'
+import { features } from '../config'
 
 import { itemsMap } from './maps'
 
@@ -275,19 +276,26 @@ const achievements = [
     condition: state => state.revenue >= goal,
     reward: state => state,
   }))(),
-
-  (() => ({
-    id: 'gold-digger',
-    name: 'Gold Digger',
-    description: `Pay off your loan from the bank.`,
-    rewardDescription: `The Shovel`,
-    condition: state => state.loanBalance === 0,
-    reward: state => ({
-      ...state,
-      shovelUnlocked: true,
-    }),
-  }))(),
 ]
+
+if (features.MINING) {
+  achievements.push(
+    Object.assign(
+      {},
+      {
+        id: 'gold-digger',
+        name: 'Gold Digger',
+        description: `Pay off your loan from the bank.`,
+        rewardDescription: `The Shovel`,
+        condition: state => state.loanBalance === 0,
+        reward: state => ({
+          ...state,
+          shovelUnlocked: true,
+        }),
+      }
+    )
+  )
+}
 
 export default achievements
 

--- a/src/data/achievements.test.js
+++ b/src/data/achievements.test.js
@@ -7,6 +7,12 @@ jest.mock('./items')
 jest.mock('./levels', () => ({ levels: [] }))
 jest.mock('./recipes')
 jest.mock('./shop-inventory')
+jest.mock('../config', () => ({
+  ...jest.requireActual('../config'),
+  features: {
+    MINING: true,
+  },
+}))
 
 describe('harvest-crop', () => {
   describe('condition', () => {


### PR DESCRIPTION
### What this PR does

the gold-digger achievement was not behind the MINING feature flag and was unlockable in production, even though the shovel didn't unlock. this fixes that bug and only adds the achievement when the feature is actually enabled.

### How this change can be validated

- go to production farmhand game
- open the achievements list
- find "gold digger" at the bottom
- next, go to vercel preview URL
- open the achievement list
- notice the 'gold digger' achievement is no longer there!

