### PR TITLE
[#171] [DRAFT] Upgrade to dinero.js@2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@jeremyckahn/farmhand",
-      "version": "1.10.19",
+      "version": "1.10.20",
       "license": "CC BY-NC-SA 4.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.27",
@@ -20,7 +20,7 @@
         "axios": "^0.21.1",
         "classnames": "^2.2.6",
         "compass-mixins": "^0.12.10",
-        "dinero.js": "^1.7.0",
+        "dinero.js": "2.0.0-alpha.8",
         "fast-memoize": "^2.5.2",
         "file-saver": "^2.0.2",
         "global": "^4.4.0",
@@ -1709,6 +1709,27 @@
       "version": "10.1.0",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==",
       "dev": true
+    },
+    "node_modules/@dinero.js/calculator-number": {
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dinero.js/calculator-number/-/calculator-number-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-/L+N7g5DjcS6wlMb2hcOXWBKW2TGiG+vZDZr9ow0nsHUTdwtMarL1bmBH9fGldHhH2XsxcrjN9H+036yeNzh3Q==",
+      "dependencies": {
+        "@dinero.js/core": "2.0.0-alpha.8"
+      }
+    },
+    "node_modules/@dinero.js/core": {
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dinero.js/core/-/core-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-3jaw2j6J/SshlCZz5KhHkh8zP47HRmt9RpnjR0BJs2awpweVuZIyyX9qzGVUEVpml9IwzQ1U+YdXevhOxtcDgg==",
+      "dependencies": {
+        "@dinero.js/currencies": "2.0.0-alpha.8"
+      }
+    },
+    "node_modules/@dinero.js/currencies": {
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dinero.js/currencies/-/currencies-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-zApiqtuuPwjiM9LJA5/kNcT48VSHRiz2/mktkXjIpfxrJKzthXybUAgEenExIH6dYhLDgVmsLQZtZFOsdYl0Ag=="
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
@@ -10106,10 +10127,13 @@
       }
     },
     "node_modules/dinero.js": {
-      "version": "1.8.1",
-      "integrity": "sha512-AQ09MDKonkGUrhBZZFx4tPTVcVJuHJ0VEA73LvcBoBB2eQSi1DbapeXj4wnUUpx1hVnPdyev1xPNnNMGy/Au0g==",
-      "engines": {
-        "node": "*"
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/dinero.js/-/dinero.js-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-6bl+g6oh6iQ6vPR5Pd4qr7D+P5e51GYRUT3jl8HYqYeejYC5sd9OVTTbXC3WU7L25mAIbOm+diiTVz1rL4QLwg==",
+      "dependencies": {
+        "@dinero.js/calculator-number": "2.0.0-alpha.8",
+        "@dinero.js/core": "2.0.0-alpha.8",
+        "@dinero.js/currencies": "2.0.0-alpha.8"
       }
     },
     "node_modules/dir-glob": {
@@ -36615,6 +36639,27 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==",
       "dev": true
     },
+    "@dinero.js/calculator-number": {
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dinero.js/calculator-number/-/calculator-number-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-/L+N7g5DjcS6wlMb2hcOXWBKW2TGiG+vZDZr9ow0nsHUTdwtMarL1bmBH9fGldHhH2XsxcrjN9H+036yeNzh3Q==",
+      "requires": {
+        "@dinero.js/core": "2.0.0-alpha.8"
+      }
+    },
+    "@dinero.js/core": {
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dinero.js/core/-/core-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-3jaw2j6J/SshlCZz5KhHkh8zP47HRmt9RpnjR0BJs2awpweVuZIyyX9qzGVUEVpml9IwzQ1U+YdXevhOxtcDgg==",
+      "requires": {
+        "@dinero.js/currencies": "2.0.0-alpha.8"
+      }
+    },
+    "@dinero.js/currencies": {
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dinero.js/currencies/-/currencies-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-zApiqtuuPwjiM9LJA5/kNcT48VSHRiz2/mktkXjIpfxrJKzthXybUAgEenExIH6dYhLDgVmsLQZtZFOsdYl0Ag=="
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
@@ -43186,8 +43231,14 @@
       }
     },
     "dinero.js": {
-      "version": "1.8.1",
-      "integrity": "sha512-AQ09MDKonkGUrhBZZFx4tPTVcVJuHJ0VEA73LvcBoBB2eQSi1DbapeXj4wnUUpx1hVnPdyev1xPNnNMGy/Au0g=="
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/dinero.js/-/dinero.js-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-6bl+g6oh6iQ6vPR5Pd4qr7D+P5e51GYRUT3jl8HYqYeejYC5sd9OVTTbXC3WU7L25mAIbOm+diiTVz1rL4QLwg==",
+      "requires": {
+        "@dinero.js/calculator-number": "2.0.0-alpha.8",
+        "@dinero.js/core": "2.0.0-alpha.8",
+        "@dinero.js/currencies": "2.0.0-alpha.8"
+      }
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "axios": "^0.21.1",
     "classnames": "^2.2.6",
     "compass-mixins": "^0.12.10",
-    "dinero.js": "^1.7.0",
+    "dinero.js": "2.0.0-alpha.8",
     "fast-memoize": "^2.5.2",
     "file-saver": "^2.0.2",
     "global": "^4.4.0",


### PR DESCRIPTION
### What this PR does

It upgrades Dinero.js to 2.0.0. Currently the discussion for this change is happening in #171. This PR and description will be updated once https://github.com/dinerojs/dinero.js/pull/309 is merged.

This PR should be considered a work in progress and does not yet need a formal review.

### How this change can be validated

### Questions or concerns about this change

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
