### PR TITLE
Modal accessibility enhancements

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -23,6 +23,7 @@ import SettingsIcon from '@material-ui/icons/Settings'
 import Switch from '@material-ui/core/Switch'
 import TextField from '@material-ui/core/TextField'
 import Tooltip from '@material-ui/core/Tooltip'
+import Typography from '@material-ui/core/Typography'
 import { array, bool, func, number, object, string } from 'prop-types'
 
 import FarmhandContext from '../../Farmhand.context'
@@ -231,6 +232,9 @@ export const Navigation = ({
     0,
     100
   ),
+  currentDialogViewLowerCase = currentDialogView.toLowerCase(),
+  modalTitleId = `${currentDialogViewLowerCase}-modal-title`,
+  modalContentId = `${currentDialogViewLowerCase}-modal-content`,
 }) => (
   <header className="Navigation">
     <h1>Farmhand</h1>
@@ -342,9 +346,17 @@ export const Navigation = ({
         open: isDialogViewOpen,
         onExited: handleDialogViewExited,
       }}
+      aria-describedby={modalTitleId}
+      aria-labelledby={modalContentId}
     >
-      <DialogTitle>{dialogTitleMap[currentDialogView]}</DialogTitle>
-      <DialogContent>{dialogContentMap[currentDialogView]}</DialogContent>
+      <DialogTitle {...{ disableTypography: true }}>
+        <Typography {...{ id: modalTitleId, component: 'h2', variant: 'h6' }}>
+          {dialogTitleMap[currentDialogView]}
+        </Typography>
+      </DialogTitle>
+      <DialogContent {...{ id: modalContentId }}>
+        {dialogContentMap[currentDialogView]}
+      </DialogContent>
       <DialogActions>
         <Button onClick={handleCloseDialogView} color="primary" autoFocus>
           Close


### PR DESCRIPTION
### What this PR does

For #175, this PR adds `aria-describedby` and `aria-labelledby` attributes to the Keyboard Shortcuts modal. Since Farmhand's modals are implemented generically, this also enhances all of the other modals as well!

References for implementation: 
  - https://github.com/jeremyckahn/farmhand/issues/175#issuecomment-899082811
  - https://material-ui.com/components/modal/#accessibility

### How this change can be validated

I'm actually not sure how this can be validated and would appreciate some help with determining this. So far I've just made our DOM look like the suggested solutions, but I don't know how to verify that it's providing the intended experience to relevant users.

### Questions or concerns about this change

### Additional information

Here's how the DOM for this looks:

<img width="734" alt="Screen Shot 2021-08-15 at 5 15 48 PM" src="https://user-images.githubusercontent.com/366330/129494303-1094bf60-61f4-4649-b750-a920613980cf.png">