### PR TITLE
Text updates

### DIFF
--- a/src/components/KeybindingsView/KeybindingsView.js
+++ b/src/components/KeybindingsView/KeybindingsView.js
@@ -18,7 +18,7 @@ const KeybindingsView = () => (
       <Table aria-label="Keyboard Shortcuts">
         <TableBody>
           {[
-            { label: 'Show Keyboard Shortcuts (this screen)', keybinding: '?' },
+            { label: 'Show Keyboard Shortcuts (this screen)', keybinding: 'Shift + ?' },
             { label: 'Toggle menu', keybinding: 'M' },
             { label: 'End the day', keybinding: 'Shift + C' },
             { label: 'Go to screen by <1-9> order', keybinding: '<1-9>' },

--- a/src/components/Shop/Shop.js
+++ b/src/components/Shop/Shop.js
@@ -76,7 +76,7 @@ export const Shop = ({
           aria-label="Shop tabs"
         >
           <Tab {...{ label: 'Seeds', ...a11yProps(0) }} />
-          <Tab {...{ label: 'Field Tools', ...a11yProps(1) }} />
+          <Tab {...{ label: 'Supplies', ...a11yProps(1) }} />
           <Tab {...{ label: 'Upgrades', ...a11yProps(2) }} />
         </Tabs>
       </AppBar>


### PR DESCRIPTION
### What this PR does

For #189 and a bug report on Discord, this renames the "Field Tools" tab in the shop to "Supplies" and also fixes a keyboard shortcut label.