### PR TITLE
Add sprite shadows

### DIFF
--- a/src/Farmhand.sass
+++ b/src/Farmhand.sass
@@ -81,6 +81,10 @@ body
     .MuiCard-root
       background: darken($card-background, 10%)
 
+  .MuiCardHeader-avatar
+    img
+      @include sprite-shadow
+
   .MuiTableCell-root
     border-color: #e9c777
 

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -1,3 +1,5 @@
+@import ../../styles/utils.sass
+
 $not-allowed-color: rgba(255, 0, 0, 0.5)
 
 .Plot
@@ -12,6 +14,9 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
   border: solid 1px #000
   flex-grow: 1
   image-rendering: pixelated
+
+  img
+    @include sprite-shadow
 
   .water-mode &.crop:hover
     background-color: var(--color-blue-hover)

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -1,5 +1,3 @@
-@import ../../styles/utils.sass
-
 $not-allowed-color: rgba(255, 0, 0, 0.5)
 
 .Plot
@@ -14,9 +12,6 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
   border: solid 1px #000
   flex-grow: 1
   image-rendering: pixelated
-
-  img
-    @include sprite-shadow
 
   .water-mode &.crop:hover
     background-color: var(--color-blue-hover)

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -72,6 +72,9 @@
     min-width: 3.5em
     margin: 0 0.25em
 
+    img
+      @include sprite-shadow
+
   .MuiDivider-root
     margin: 0 0.5em
 

--- a/src/styles/utils.sass
+++ b/src/styles/utils.sass
@@ -24,4 +24,4 @@ img
     justify-content: center
 
 @mixin sprite-shadow
-  filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));
+  filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4))

--- a/src/styles/utils.sass
+++ b/src/styles/utils.sass
@@ -22,3 +22,6 @@ img
 
   .MuiTabs-flexContainer
     justify-content: center
+
+@mixin sprite-shadow
+  filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4));

--- a/src/styles/utils.sass
+++ b/src/styles/utils.sass
@@ -24,4 +24,4 @@ img
     justify-content: center
 
 @mixin sprite-shadow
-  filter: drop-shadow(2px 2px 2px rgba(0, 0, 0, 0.4))
+  filter: drop-shadow(2px 2px 2px rgba(100, 100, 100, .4))


### PR DESCRIPTION
### What this PR does

For #114, this PR gives sprites throughout the game a slight drop shadow.

### How this change can be validated

Open the preview URL (https://farmhand-git-jeremyckahn-114sprite-shadows-jeremyckahn.vercel.app/), navigate around the various screens, and observe the new drop shadow styles.

### Questions or concerns about this change

How do folks feel about this aesthetic change? Is the shadow too strong? Is it even better than the flat style it replaces?

### Additional information
<img width="438" alt="Screen Shot 2021-08-31 at 8 44 23 AM" src="https://user-images.githubusercontent.com/366330/131513872-c5ce535f-7c2f-417f-82d7-ba9e22408ee3.png">
<img width="334" alt="Screen Shot 2021-08-31 at 8 44 35 AM" src="https://user-images.githubusercontent.com/366330/131513877-8cfd8fca-c8c6-4094-88d4-9fc130335c4b.png">
<img width="191" alt="Screen Shot 2021-08-31 at 8 43 53 AM" src="https://user-images.githubusercontent.com/366330/131513880-bf87c24e-8401-4442-b3f8-9a89063a36ef.png">
<img width="333" alt="Screen Shot 2021-08-31 at 8 45 13 AM" src="https://user-images.githubusercontent.com/366330/131513882-bb01666e-e3aa-471e-987f-62a6320ed1e0.png">
<img width="489" alt="Screen Shot 2021-08-31 at 8 44 48 AM" src="https://user-images.githubusercontent.com/366330/131513883-d0cb476f-5764-49a7-b984-27b016c9a96a.png">
