### PR TITLE
Tabify cow menu

### DIFF
--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -78,7 +78,7 @@ export const AppBar = ({
 }) => (
   <MuiAppBar
     {...{
-      className: 'AppBar',
+      className: 'AppBar top-level',
       position: 'fixed',
     }}
   >

--- a/src/components/ContextPane/ContextPane.sass
+++ b/src/components/ContextPane/ContextPane.sass
@@ -1,6 +1,9 @@
+@import ../../styles/utils.sass
 @import ../../styles/variables.sass
 
 .ContextPane
+  @include center-tabs
+  margin: 0
 
   h2
     margin: 0.5em 0 1em

--- a/src/components/CowPenContextMenu/CowPenContextMenu.sass
+++ b/src/components/CowPenContextMenu/CowPenContextMenu.sass
@@ -10,6 +10,12 @@
   display: flex
   flex-flow: column
 
+  h3
+    text-align: center
+
+  .MuiTab-root
+    min-width: unset
+
   .fa
     font-size: 1em
 

--- a/src/components/CowPenContextMenu/TabPanel/index.js
+++ b/src/components/CowPenContextMenu/TabPanel/index.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { node, number } from 'prop-types'
+
+export const TabPanel = props => {
+  const { children, value, index, ...other } = props
+
+  return (
+    <section
+      role="tabpanel"
+      hidden={value !== index}
+      id={`cow-context-tabpanel-${index}`}
+      aria-labelledby={`cow-context-tab-${index}`}
+      {...other}
+    >
+      {value === index ? children : null}
+    </section>
+  )
+}
+
+TabPanel.propTypes = {
+  children: node,
+  index: number.isRequired,
+  value: number.isRequired,
+}
+
+export const a11yProps = index => ({
+  id: `cow-context-tab-${index}`,
+  'aria-controls': `cow-context-tabpanel-${index}`,
+})

--- a/src/components/Stage/Stage.sass
+++ b/src/components/Stage/Stage.sass
@@ -67,20 +67,8 @@
     @media (min-width: #{$break-medium-phone})
       display: none
 
-  .MuiAppBar-root
-    border-radius: .5em .5em 0 0
-    margin-top: 4em
-
   section
     padding: .5em 0
-
-    &[role=tabpanel]
-      background: rgba(255, 255, 255, 0.5)
-      border-radius: 0 0 .5em .5em
-      padding: .5em 0.5em 0.5em
-
-      .card-list > li:last-child
-        margin-bottom: 0
 
     @media (max-width: #{$break-sm})
       font-size: 1em

--- a/src/styles/utils.sass
+++ b/src/styles/utils.sass
@@ -23,5 +23,17 @@ img
   .MuiTabs-flexContainer
     justify-content: center
 
+  .MuiAppBar-root
+    border-radius: .5em .5em 0 0
+    margin-top: 4em
+
+  [role=tabpanel]
+    background: rgba(255, 255, 255, 0.5)
+    border-radius: 0 0 .5em .5em
+    padding: .5em 0.5em 0.5em
+
+    .card-list > li:last-child
+      margin-bottom: 0
+
 @mixin sprite-shadow
   filter: drop-shadow(2px 2px 2px rgba(100, 100, 100, .4))


### PR DESCRIPTION
### What this PR does

For #200, this PR redesigns the Cows menu to be tab-based for easier navigation.

This is a rather noisy diff, but there's not much logic being added that hasn't been seen already in #185 and #183. A lot got moved around to make sense with tabs, but new logic is minimal.

### How this change can be validated

Purchase a Cow Pen and do any number of your standard cow operations (buy/sell cows, feed, hugging machines).

### Additional information

<img width="351" alt="Screen Shot 2021-09-04 at 6 26 37 PM" src="https://user-images.githubusercontent.com/366330/132110312-77fff67e-57d1-4edd-9085-4fdf8f03fc9c.png">

<img width="332" alt="Screen Shot 2021-09-04 at 6 27 05 PM" src="https://user-images.githubusercontent.com/366330/132110320-4f4f856d-275d-4512-b623-e0caa892abe7.png">

<img width="329" alt="Screen Shot 2021-09-04 at 6 27 21 PM" src="https://user-images.githubusercontent.com/366330/132110323-8725c3a2-af94-4578-92b5-3ee0b9de650d.png">

