### PR TITLE
[#214] Fix Google Analytics for www.farmhand.life

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,13 +58,29 @@
       src="https://www.googletagmanager.com/gtag/js?id=G-SH37EG4NP9"
     ></script>
     <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag('js', new Date())
+      ;(function() {
+        let analyticsId
 
-      gtag('config', 'G-SH37EG4NP9')
+        switch (window.location.host) {
+          case 'jeremyckahn.github.io':
+            analyticsId = 'G-SH37EG4NP9'
+            break
+          case 'www.farmhand.life':
+            analyticsId = 'G-3KRQX38CYH'
+            break
+          default:
+            console.warn('Unrecognized domain. No analytics will be recorded.')
+            return
+        }
+
+        window.dataLayer = window.dataLayer || []
+        function gtag() {
+          dataLayer.push(arguments)
+        }
+        gtag('js', new Date())
+
+        gtag('config', analyticsId)
+      })()
     </script>
   </head>
   <body>


### PR DESCRIPTION
### What this PR does

This PR fixes analytics tracking for https://www.farmhand.life/. Presently only analytics for https://jeremyckahn.github.io/farmhand/ are being recorded.

### How this change can be validated

Ship it and see if the data shows up in the Google Analytics dashboard. :man_shrugging: 