### PR TITLE
Make piskel-cli optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
-      - run: npm ci
+      - run: npm ci --no-optional
       - run: npm test
       - run: npm run build

--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
+      - run: npm ci --no-optional
 
       - name: Tag release
         run: npm version ${{ github.event.inputs.releaseType }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ nvm i
 npm ci
 ```
 
-If `npm ci` errors out due to PhantomJS installation errors (this has been seen in some WSL/Linux environments), try `npm_config_tmp=/tmp npm ci` instead. [See this related comment](https://github.com/yarnpkg/yarn/issues/1016#issuecomment-283067214).
+If `npm ci` errors out due to PhantomJS installation errors (this has been seen in some WSL/Linux environments), try `npm_config_tmp=/tmp npm ci` instead. [See this related comment](https://github.com/yarnpkg/yarn/issues/1016#issuecomment-283067214). Alternatively, try `npm ci --no-optional`.
 
 To run the game locally with the API and Redis database, run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@jeremyckahn/farmhand",
-      "version": "1.10.28",
+      "version": "1.10.30",
       "license": "CC BY-NC-SA 4.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.27",
@@ -29,6 +29,7 @@
         "lodash.sortby": "^4.7.0",
         "lodash.throttle": "^4.1.1",
         "notistack": "^1.0.5",
+        "piskel-cli": "*",
         "prop-types": "^15.6.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -85,7 +86,6 @@
         "node-sass": "^4.14.1",
         "nodemon": "^2.0.2",
         "npm-run-all": "^4.1.3",
-        "piskel-cli": "^1.0.38",
         "prettier": "^1.13.7",
         "pretty-quick": "^2.0.1",
         "react-scripts": "^4.0.3",
@@ -95,6 +95,9 @@
       "engines": {
         "node": "14.x",
         "npm": "7.x"
+      },
+      "optionalDependencies": {
+        "piskel-cli": "^1.0.41"
       }
     },
     "node_modules/@achingbrain/electron-fetch": {
@@ -7202,9 +7205,10 @@
     },
     "node_modules/boom": {
       "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "hoek": "2.x.x"
       },
@@ -8682,7 +8686,7 @@
     "node_modules/concat-stream": {
       "version": "1.5.0",
       "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-      "dev": true,
+      "devOptional": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -8695,17 +8699,17 @@
     "node_modules/concat-stream/node_modules/isarray": {
       "version": "1.0.0",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concat-stream/node_modules/process-nextick-args": {
       "version": "1.0.7",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.0.6",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -8718,7 +8722,7 @@
     "node_modules/concat-stream/node_modules/string_decoder": {
       "version": "0.10.31",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concurrently": {
       "version": "6.1.0",
@@ -9030,9 +9034,10 @@
     },
     "node_modules/cryptiles": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "boom": "2.x.x"
       },
@@ -12122,8 +12127,9 @@
     },
     "node_modules/extract-zip": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "concat-stream": "1.5.0",
         "debug": "0.7.4",
@@ -12136,22 +12142,25 @@
     },
     "node_modules/extract-zip/node_modules/debug": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
       "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/extract-zip/node_modules/minimist": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "optional": true
     },
     "node_modules/extract-zip/node_modules/mkdirp": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -12296,8 +12305,9 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -12947,16 +12957,18 @@
     },
     "node_modules/generate-function": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
     },
     "node_modules/generate-object-property": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -13345,7 +13357,7 @@
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -13356,7 +13368,7 @@
     "node_modules/has-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13509,8 +13521,9 @@
     },
     "node_modules/hasha": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-stream": "^1.0.1",
         "pinkie-promise": "^2.0.0"
@@ -13525,9 +13538,10 @@
     },
     "node_modules/hawk": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "deprecated": "This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "boom": "2.x.x",
         "cryptiles": "2.x.x",
@@ -13578,9 +13592,10 @@
     },
     "node_modules/hoek": {
       "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.40"
       }
@@ -15872,18 +15887,20 @@
     },
     "node_modules/is-my-ip-valid": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
+      "optional": true
     },
     "node_modules/is-my-json-valid": {
-      "version": "2.20.5",
-      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
-      "dev": true,
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "optional": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
         "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
+        "jsonpointer": "^5.0.0",
         "xtend": "^4.0.0"
       }
     },
@@ -16013,8 +16030,9 @@
     },
     "node_modules/is-property": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "optional": true
     },
     "node_modules/is-regex": {
       "version": "1.1.3",
@@ -16054,7 +16072,7 @@
     "node_modules/is-stream": {
       "version": "1.1.0",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20555,9 +20573,10 @@
       }
     },
     "node_modules/jsonpointer": {
-      "version": "4.1.0",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20667,9 +20686,10 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.6.0",
-      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
-      "dev": true,
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "optional": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -20679,8 +20699,9 @@
     },
     "node_modules/jszip/node_modules/lie": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -20710,8 +20731,9 @@
     },
     "node_modules/kew": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
+      "optional": true
     },
     "node_modules/keypair": {
       "version": "1.0.3",
@@ -23330,9 +23352,10 @@
     },
     "node_modules/node-uuid": {
       "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
       "deprecated": "Use uuid module instead",
-      "dev": true,
+      "optional": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -24442,7 +24465,7 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/parallel-transform": {
       "version": "1.2.0",
@@ -24678,8 +24701,9 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "optional": true
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -24687,10 +24711,11 @@
     },
     "node_modules/phantomjs": {
       "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-2.1.7.tgz",
       "integrity": "sha1-xpEPZ5NcNyhbYRQyn8LyfV8+MTQ=",
       "deprecated": "Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'",
-      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "extract-zip": "~1.5.0",
         "fs-extra": "~0.26.4",
@@ -24707,53 +24732,60 @@
     },
     "node_modules/phantomjs/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/phantomjs/node_modules/ansi-styles": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/phantomjs/node_modules/assert-plus": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/phantomjs/node_modules/aws-sign2": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/phantomjs/node_modules/bl": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "readable-stream": "~2.0.5"
       }
     },
     "node_modules/phantomjs/node_modules/caseless": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
+      "optional": true
     },
     "node_modules/phantomjs/node_modules/chalk": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -24767,16 +24799,18 @@
     },
     "node_modules/phantomjs/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/phantomjs/node_modules/form-data": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
       "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "async": "^2.0.1",
         "combined-stream": "^1.0.5",
@@ -24788,8 +24822,9 @@
     },
     "node_modules/phantomjs/node_modules/fs-extra": {
       "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^2.1.0",
@@ -24800,9 +24835,10 @@
     },
     "node_modules/phantomjs/node_modules/har-validator": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "deprecated": "this library is no longer supported",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "chalk": "^1.1.1",
         "commander": "^2.9.0",
@@ -24818,8 +24854,9 @@
     },
     "node_modules/phantomjs/node_modules/http-signature": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^0.2.0",
         "jsprim": "^1.2.2",
@@ -24832,56 +24869,64 @@
     },
     "node_modules/phantomjs/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "optional": true
     },
     "node_modules/phantomjs/node_modules/jsonfile": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
+      "optional": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/phantomjs/node_modules/klaw": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
+      "optional": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/phantomjs/node_modules/oauth-sign": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/phantomjs/node_modules/process-nextick-args": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "optional": true
     },
     "node_modules/phantomjs/node_modules/progress": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/phantomjs/node_modules/qs": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
       "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw=",
-      "dev": true,
-      "engines": ">=0.10.40"
+      "engines": ">=0.10.40",
+      "optional": true
     },
     "node_modules/phantomjs/node_modules/readable-stream": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -24893,9 +24938,10 @@
     },
     "node_modules/phantomjs/node_modules/request": {
       "version": "2.67.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "aws-sign2": "~0.6.0",
         "bl": "~1.0.0",
@@ -24924,8 +24970,9 @@
     },
     "node_modules/phantomjs/node_modules/rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -24935,13 +24982,15 @@
     },
     "node_modules/phantomjs/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "optional": true
     },
     "node_modules/phantomjs/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -24951,33 +25000,37 @@
     },
     "node_modules/phantomjs/node_modules/supports-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/phantomjs/node_modules/tough-cookie": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
       "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
       "deprecated": "ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/phantomjs/node_modules/tunnel-agent": {
       "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/phantomjs/node_modules/which": {
       "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -25018,7 +25071,7 @@
     "node_modules/pinkie": {
       "version": "2.0.4",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25026,7 +25079,7 @@
     "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -25047,8 +25100,9 @@
     },
     "node_modules/piskel-cli": {
       "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/piskel-cli/-/piskel-cli-1.0.41.tgz",
       "integrity": "sha512-XU3pB4pl1opN2vt+VOQseW+NHbKLT7Fe271KQXevZ2/lCrP0wb3wE+wbcrNHwrdv4mL0PakPJgFjoZ24W+UEVw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "jszip": "^3.1.5",
         "minimist": "^1.2.0",
@@ -26712,7 +26766,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -28040,7 +28094,7 @@
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -28054,7 +28108,7 @@
     "node_modules/readable-stream/node_modules/isarray": {
       "version": "1.0.0",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/readdirp": {
       "version": "3.5.0",
@@ -28503,8 +28557,9 @@
     },
     "node_modules/request-progress": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "throttleit": "^1.0.0"
       }
@@ -30316,9 +30371,10 @@
     },
     "node_modules/sntp": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "deprecated": "This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "hoek": "2.x.x"
       },
@@ -31143,8 +31199,9 @@
     },
     "node_modules/stringstream": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
+      "optional": true
     },
     "node_modules/strip-ansi": {
       "version": "6.0.0",
@@ -32014,8 +32071,9 @@
     },
     "node_modules/throttleit": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-      "dev": true
+      "optional": true
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -32460,7 +32518,7 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -35285,8 +35343,9 @@
     },
     "node_modules/yauzl": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "fd-slicer": "~1.0.1"
       }
@@ -40924,8 +40983,9 @@
     },
     "boom": {
       "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -42091,7 +42151,7 @@
     "concat-stream": {
       "version": "1.5.0",
       "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "~2.0.0",
@@ -42101,17 +42161,17 @@
         "isarray": {
           "version": "1.0.0",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "devOptional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
+          "devOptional": true
         },
         "readable-stream": {
           "version": "2.0.6",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -42124,7 +42184,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -42367,8 +42427,9 @@
     },
     "cryptiles": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "boom": "2.x.x"
       }
@@ -44748,8 +44809,9 @@
     },
     "extract-zip": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "concat-stream": "1.5.0",
         "debug": "0.7.4",
@@ -44759,18 +44821,21 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
+          "optional": true
         },
         "minimist": {
           "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -44892,8 +44957,9 @@
     },
     "fd-slicer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -45389,16 +45455,18 @@
     },
     "generate-function": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-property": "^1.0.2"
       }
     },
     "generate-object-property": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-property": "^1.0.0"
       }
@@ -45689,7 +45757,7 @@
     "has-ansi": {
       "version": "2.0.0",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -45697,7 +45765,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -45811,8 +45879,9 @@
     },
     "hasha": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-stream": "^1.0.1",
         "pinkie-promise": "^2.0.0"
@@ -45824,8 +45893,9 @@
     },
     "hawk": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "boom": "2.x.x",
         "cryptiles": "2.x.x",
@@ -45870,8 +45940,9 @@
     },
     "hoek": {
       "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -47613,18 +47684,20 @@
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
+      "optional": true
     },
     "is-my-json-valid": {
-      "version": "2.20.5",
-      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
-      "dev": true,
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "optional": true,
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
         "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
+        "jsonpointer": "^5.0.0",
         "xtend": "^4.0.0"
       }
     },
@@ -47716,8 +47789,9 @@
     },
     "is-property": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "optional": true
     },
     "is-regex": {
       "version": "1.1.3",
@@ -47745,7 +47819,7 @@
     "is-stream": {
       "version": "1.1.0",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "devOptional": true
     },
     "is-string": {
       "version": "1.0.6",
@@ -51286,9 +51360,10 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "optional": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -51387,9 +51462,10 @@
       }
     },
     "jszip": {
-      "version": "3.6.0",
-      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
-      "dev": true,
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "optional": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -51399,8 +51475,9 @@
       "dependencies": {
         "lie": {
           "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
           "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "immediate": "~3.0.5"
           }
@@ -51432,8 +51509,9 @@
     },
     "kew": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
+      "optional": true
     },
     "keypair": {
       "version": "1.0.3",
@@ -53601,8 +53679,9 @@
     },
     "node-uuid": {
       "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
+      "optional": true
     },
     "nodemon": {
       "version": "2.0.7",
@@ -54391,7 +54470,7 @@
     "pako": {
       "version": "1.0.11",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "devOptional": true
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -54582,8 +54661,9 @@
     },
     "pend": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "optional": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -54591,8 +54671,9 @@
     },
     "phantomjs": {
       "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-2.1.7.tgz",
       "integrity": "sha1-xpEPZ5NcNyhbYRQyn8LyfV8+MTQ=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "extract-zip": "~1.5.0",
         "fs-extra": "~0.26.4",
@@ -54606,41 +54687,48 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "optional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
+          "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
+          "optional": true
         },
         "bl": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "~2.0.5"
           }
         },
         "caseless": {
           "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -54651,13 +54739,15 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "optional": true
         },
         "form-data": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "async": "^2.0.1",
             "combined-stream": "^1.0.5",
@@ -54666,8 +54756,9 @@
         },
         "fs-extra": {
           "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0",
@@ -54678,8 +54769,9 @@
         },
         "har-validator": {
           "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "chalk": "^1.1.1",
             "commander": "^2.9.0",
@@ -54689,8 +54781,9 @@
         },
         "http-signature": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "assert-plus": "^0.2.0",
             "jsprim": "^1.2.2",
@@ -54699,49 +54792,57 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "optional": true
         },
         "jsonfile": {
           "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
         },
         "klaw": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
           "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.9"
           }
         },
         "oauth-sign": {
           "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
+          "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
+          "optional": true
         },
         "progress": {
           "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
+          "optional": true
         },
         "qs": {
           "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
           "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw=",
-          "dev": true
+          "optional": true
         },
         "readable-stream": {
           "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -54753,8 +54854,9 @@
         },
         "request": {
           "version": "2.67.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
           "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "aws-sign2": "~0.6.0",
             "bl": "~1.0.0",
@@ -54780,44 +54882,51 @@
         },
         "rimraf": {
           "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "string_decoder": {
           "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
           "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
-          "dev": true
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
+          "optional": true
         },
         "which": {
           "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -54842,12 +54951,12 @@
     "pinkie": {
       "version": "2.0.4",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "devOptional": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -54862,8 +54971,9 @@
     },
     "piskel-cli": {
       "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/piskel-cli/-/piskel-cli-1.0.41.tgz",
       "integrity": "sha512-XU3pB4pl1opN2vt+VOQseW+NHbKLT7Fe271KQXevZ2/lCrP0wb3wE+wbcrNHwrdv4mL0PakPJgFjoZ24W+UEVw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "jszip": "^3.1.5",
         "minimist": "^1.2.0",
@@ -56201,7 +56311,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "devOptional": true
     },
     "progress": {
       "version": "2.0.3",
@@ -57191,7 +57301,7 @@
     "readable-stream": {
       "version": "2.3.7",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -57205,7 +57315,7 @@
         "isarray": {
           "version": "1.0.0",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -57594,8 +57704,9 @@
     },
     "request-progress": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "throttleit": "^1.0.0"
       }
@@ -59028,8 +59139,9 @@
     },
     "sntp": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -59726,8 +59838,9 @@
     },
     "stringstream": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
+      "optional": true
     },
     "strip-ansi": {
       "version": "6.0.0",
@@ -60377,8 +60490,9 @@
     },
     "throttleit": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-      "dev": true
+      "optional": true
     },
     "through2": {
       "version": "2.0.5",
@@ -60725,7 +60839,7 @@
     "typedarray": {
       "version": "0.0.6",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "devOptional": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -62996,8 +63110,9 @@
     },
     "yauzl": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "fd-slicer": "~1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "node-sass": "^4.14.1",
     "nodemon": "^2.0.2",
     "npm-run-all": "^4.1.3",
-    "piskel-cli": "^1.0.38",
     "prettier": "^1.13.7",
     "pretty-quick": "^2.0.1",
     "react-scripts": "^4.0.3",
@@ -139,5 +138,8 @@
     "transformIgnorePatterns": [
       "node_modules/(?!trystero)/"
     ]
+  },
+  "optionalDependencies": {
+    "piskel-cli": "^1.0.41"
   }
 }


### PR DESCRIPTION
### What this PR does

This PR fixes breaking builds in Vercel, which we need for deploys. I'm not really sure what changed, but it seems to be something on Vercel's side. `piskel-cli` is an optional development dependency, and it sub-depends on PhantomJS. PhantomJS has long been a source of pain when installing Farmhand. It tends to not install correctly on a lot of environments, which causes the entire project installation to fail.

This PR should hopefully provide a long term fix by moving `piskel-cli` to the [`optionalDependencies` list](https://betterprogramming.pub/what-are-npms-optional-dependencies-and-when-should-we-use-them-796a6a964e73).

### How this change can be validated

I think this passing build should sufficiently validate this change: https://vercel.com/jeremyckahn/farmhand/HTdUa4tjXEvQAnT9Tq9DkKWqTNVt

You can also do `rm -rf node_modules && npm ci --no-optional && ls node_modules/piskel-cli/` to see something like:

```
ls: cannot access 'node_modules/piskel-cli/': No such file or directory
```

### Questions or concerns about this change

Maybe there's a better way to do this? I'd like to drop PhantomJS altogether, but https://github.com/jordanjwatkins/piskel-cli seems to be pretty dependent upon it and hasn't seen any updates in a few years.