### PR TITLE
Make analytics work on all production domains

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,18 +53,40 @@
         image-rendering: pixelated;
       }
     </style>
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-SH37EG4NP9"
-    ></script>
     <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag('js', new Date())
+      ;(function() {
+        let analyticsID
 
-      gtag('config', 'G-SH37EG4NP9')
+        switch (window.location.host) {
+          case 'jeremyckahn.github.io':
+            gtag('js', new Date())
+            analyticsId = 'G-SH37EG4NP9'
+            break
+          case 'www.farmhand.life':
+            analyticsId = 'G-3KRQX38CYH'
+            break
+          default:
+            console.warn('Unrecognized domain. No analytics will be recorded.')
+            return
+        }
+
+        const script = document.createElement('script')
+        script.setAttribute('async', '')
+        script.setAttribute(
+          'src',
+          `https://www.googletagmanager.com/gtag/js?id=${analyticsID}`
+        )
+
+        document.head.appendChild(script)
+        window.dataLayer = window.dataLayer || []
+
+        function gtag() {
+          dataLayer.push(arguments)
+        }
+
+        gtag('js', new Date())
+        gtag('config', analyticsID)
+      })()
     </script>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -55,19 +55,14 @@
     </style>
     <script>
       ;(function() {
-        let analyticsID
+        const analyticsID = {
+          'jeremyckahn.github.io': 'G-SH37EG4NP9',
+          'www.farmhand.life': 'G-3KRQX38CYH',
+        }[window.location.host]
 
-        switch (window.location.host) {
-          case 'jeremyckahn.github.io':
-            gtag('js', new Date())
-            analyticsId = 'G-SH37EG4NP9'
-            break
-          case 'www.farmhand.life':
-            analyticsId = 'G-3KRQX38CYH'
-            break
-          default:
-            console.warn('Unrecognized domain. No analytics will be recorded.')
-            return
+        if (!analyticsID) {
+          console.warn('Unrecognized domain. No analytics will be recorded.')
+          return
         }
 
         const script = document.createElement('script')


### PR DESCRIPTION
### What this PR does

This is another attempt at #216: Making Google Analytics work on www.farmhand.life.

### How this change can be validated

I was actually able to test it this time! As of this writing, this is running at https://www.farmhand.life/ via manual promotion to Prod in Vercel. After loading the page, I was able to see my session appear in Google Analytics: 
![image](https://user-images.githubusercontent.com/366330/146660662-b7ad5132-f4fc-4ea3-ac80-2221457487b5.png)

To validate, take a look at the Analytics dashboard for farmhand.life and see your session show up.
<!-- 
### Questions or concerns about this change

### Additional information

Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
