### PR TITLE
Use farmhand.life as primary prod URL

### DIFF
--- a/.github/workflows/notify-discord-about-update.yml
+++ b/.github/workflows/notify-discord-about-update.yml
@@ -20,4 +20,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.0
         with:
-          args: 'A game update is available on https://jeremyckahn.github.io/farmhand/ ! Take a look at what changed: {{ EVENT_PAYLOAD.compare }}'
+          args: 'A game update is available on https://www.farmhand.life! Take a look at what changed: {{ EVENT_PAYLOAD.compare }}'

--- a/.github/workflows/notify-discord-about-update.yml
+++ b/.github/workflows/notify-discord-about-update.yml
@@ -20,4 +20,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.0
         with:
-          args: 'A game update is available on https://www.farmhand.life! Take a look at what changed: {{ EVENT_PAYLOAD.compare }}'
+          args: 'A game update is available on https://www.farmhand.life/ ! Take a look at what changed: {{ EVENT_PAYLOAD.compare }}'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### A farming game by [Jeremy Kahn](https://github.com/jeremyckahn)
 
-**[Play Farmhand in your browser!](https://www.farmhand.life)**
+**[Play Farmhand in your browser!](https://www.farmhand.life/)**
 
 - `develop`: [![CI](https://github.com/jeremyckahn/farmhand/workflows/CI/badge.svg)](https://github.com/jeremyckahn/farmhand/actions?query=workflow%3ACI) [![Release New Version](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml/badge.svg)](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml)
 - All versioned releases available at [unpkg](https://unpkg.com/browse/@jeremyckahn/farmhand/build/)
@@ -99,7 +99,7 @@ Use this GitHub Action to deploy a new version of Farmhand: [![Release New Versi
 
 As an authenticated repo owner or collaborator, click "Run workflow" and enter the argument to be passed to [`npm version`](https://docs.npmjs.com/cli/v7/commands/npm-version) and press the green "Run workflow". For updates that do not change [`farmhand.state`](https://jeremyckahn.github.io/farmhand/docs/farmhand.html#.state) (which is most of them), use the default `patch` version. This workflow will deploy Farmhand to:
 
-- https://www.farmhand.life
+- https://www.farmhand.life/
 - https://jeremyckahn.github.io/farmhand/
 - https://jeremyckahn.itch.io/farmhand
 - https://www.npmjs.com/package/@jeremyckahn/farmhand

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Farmhand](public/farmhand-logo-kairi-large.png)](https://jeremyckahn.github.io/farmhand/)
+[![Farmhand](public/farmhand-logo-kairi-large.png)](https://www.farmhand.life)
 
 <sub>_Logo art by [Kairi](https://discord.com/channels/714539345050075176/714539345637408793/859622159176302625)_</sub>
 
@@ -6,7 +6,7 @@
 
 ### A farming game by [Jeremy Kahn](https://github.com/jeremyckahn)
 
-**[Play Farmhand in your browser!](https://jeremyckahn.github.io/farmhand/)**
+**[Play Farmhand in your browser!](https://www.farmhand.life)**
 
 - `develop`: [![CI](https://github.com/jeremyckahn/farmhand/workflows/CI/badge.svg)](https://github.com/jeremyckahn/farmhand/actions?query=workflow%3ACI) [![Release New Version](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml/badge.svg)](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml)
 - All versioned releases available at [unpkg](https://unpkg.com/browse/@jeremyckahn/farmhand/build/)
@@ -99,6 +99,7 @@ Use this GitHub Action to deploy a new version of Farmhand: [![Release New Versi
 
 As an authenticated repo owner or collaborator, click "Run workflow" and enter the argument to be passed to [`npm version`](https://docs.npmjs.com/cli/v7/commands/npm-version) and press the green "Run workflow". For updates that do not change [`farmhand.state`](https://jeremyckahn.github.io/farmhand/docs/farmhand.html#.state) (which is most of them), use the default `patch` version. This workflow will deploy Farmhand to:
 
+- https://www.farmhand.life
 - https://jeremyckahn.github.io/farmhand/
 - https://jeremyckahn.itch.io/farmhand
 - https://www.npmjs.com/package/@jeremyckahn/farmhand
@@ -122,7 +123,7 @@ REACT_APP_ENABLE_MINING=true
 
 Would enable the `MINING` feature only for the local development environment. You can access the enabled feature flags at runtime by `import`ing the `features` Object from [`config.js`](https://github.com/jeremyckahn/farmhand/blob/develop/src/config.js). See [Adding Custom Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables/) for more information on how to use environment variables.
 
-In addition to enabling features via environment variables, players can manually enable them in the browser (such as for beta testing). This can be done by manually constructing a URL query parameter that looks like `?enable_[FEATURE_NAME]=true`. For example, to enable the `MINING` feature, players could use the URL https://jeremyckahn.github.io/farmhand/?enable_MINING=true.
+In addition to enabling features via environment variables, players can manually enable them in the browser (such as for beta testing). This can be done by manually constructing a URL query parameter that looks like `?enable_[FEATURE_NAME]=true`. For example, to enable the `MINING` feature, players could use the URL https://www.farmhand.life?enable_MINING=true.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "A farming game",
   "unpkg": "build/index.html",
-  "homepage": "https://www.farmhand.life",
+  "homepage": "https://www.farmhand.life/",
   "scripts": {
     "build": "react-scripts build",
     "build:analyze": "npm run build && source-map-explorer 'build/static/js/*.js'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "A farming game",
   "unpkg": "build/index.html",
-  "homepage": "http://jeremyckahn.github.io/farmhand/",
+  "homepage": "https://www.farmhand.life",
   "scripts": {
     "build": "react-scripts build",
     "build:analyze": "npm run build && source-map-explorer 'build/static/js/*.js'",

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -38,6 +38,7 @@ const isInstallable =
     process.env.NODE_ENV === 'development') &&
   !window.matchMedia('(display-mode: standalone)').matches &&
   (window.location.origin === 'https://jeremyckahn.github.io' ||
+    window.location.origin === 'https://www.farmhand.life' ||
     window.location.origin === 'http://localhost:3000') // For debugging
 
 const Home = ({


### PR DESCRIPTION
### What this PR does

This changes a number of references from https://jeremyckahn.github.io/farmhand/ to https://www.farmhand.life/. We should prefer the latter, as it is more memorable and inclusive of all who work on the game.

### How this change can be validated

I'm not sure that there's a great way to? I don't think this will break anything either way, though.

<!--### Questions or concerns about this change

### Additional information

Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
