### PR TITLE
feat:[closes #234] Hide Home Screen option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ npm start
 
 In this case, the local app will be using the Production API and database. However you boot, Farmhand will be accessible from http://localhost:3000/.
 
+### Multiplayer system architecture
+
+The system design for Farmhand's multiplayer functionality has been [detailed in this blog post](https://dev.to/jeremyckahn/how-i-designed-an-abuse-resistant-fault-tolerant-zero-cost-multiplayer-online-game-140g).
+
 ### CI/CD
 
 Automation is done with [GitHub Actions](.github/workflows). All changes are tested and built upon Git push. Merges to `main` automatically deploy to Production (the `gh-pages` branch) upon a successful test run and build.

--- a/src/Farmhand.js
+++ b/src/Farmhand.js
@@ -236,6 +236,7 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * their respective quantities.
  * @property {boolean} useAlternateEndDayButtonPosition Option to display the
  * Bed button on the left side of the screen.
+ * @property {boolean} hideHomeScreen Option to hide the Home Screen
  * @property {Object.<number>} valueAdjustments
  * @property {string} version Comes from the `version` property in
  * package.json.
@@ -299,7 +300,11 @@ export default class Farmhand extends Component {
 
   get viewList() {
     const { COW_PEN, FIELD, HOME, WORKSHOP, SHOP } = stageFocusType
-    const viewList = [HOME, SHOP, FIELD]
+    const viewList = [SHOP, FIELD]
+
+    if (!this.state.hideHomeScreen) {
+      viewList.unshift(HOME)
+    }
 
     if (this.state.purchasedCowPen) {
       viewList.push(COW_PEN)
@@ -403,6 +408,7 @@ export default class Farmhand extends Component {
         [toolType.WATERING_CAN]: toolLevel.DEFAULT,
       },
       useAlternateEndDayButtonPosition: false,
+      hideHomeScreen: false,
       valueAdjustments: {},
       version: process.env.REACT_APP_VERSION,
     }

--- a/src/Farmhand.js
+++ b/src/Farmhand.js
@@ -225,6 +225,7 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {number} revenue The amount of money the player has generated in
  * @property {string} redirect Transient value used to drive router redirection.
  * @property {string} room What online room the player is in.
+ * @property {boolean} showHomeScreen Option to show the Home Screen
  * @property {boolean} showNotifications
  * @property {farmhand.module:enums.stageFocusType} stageFocus
  * @property {Array.<farmhand.notification>} todaysNotifications
@@ -236,7 +237,6 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * their respective quantities.
  * @property {boolean} useAlternateEndDayButtonPosition Option to display the
  * Bed button on the left side of the screen.
- * @property {boolean} hideHomeScreen Option to hide the Home Screen
  * @property {Object.<number>} valueAdjustments
  * @property {string} version Comes from the `version` property in
  * package.json.
@@ -302,7 +302,7 @@ export default class Farmhand extends Component {
     const { COW_PEN, FIELD, HOME, WORKSHOP, SHOP } = stageFocusType
     const viewList = [SHOP, FIELD]
 
-    if (!this.state.hideHomeScreen) {
+    if (this.state.showHomeScreen) {
       viewList.unshift(HOME)
     }
 
@@ -394,6 +394,7 @@ export default class Farmhand extends Component {
       purchasedCowPen: 0,
       purchasedField: 0,
       purchasedSmelter: 0,
+      showHomeScreen: true,
       showNotifications: true,
       stageFocus: stageFocusType.HOME,
       todaysNotifications: [],
@@ -408,7 +409,6 @@ export default class Farmhand extends Component {
         [toolType.WATERING_CAN]: toolLevel.DEFAULT,
       },
       useAlternateEndDayButtonPosition: false,
-      hideHomeScreen: false,
       valueAdjustments: {},
       version: process.env.REACT_APP_VERSION,
     }

--- a/src/Farmhand.js
+++ b/src/Farmhand.js
@@ -555,6 +555,13 @@ export default class Farmhand extends Component {
           }
         })
       })
+
+      if (
+        !this.state.showHomeScreen &&
+        this.state.stageFocus === stageFocusType.HOME
+      ) {
+        this.focusNextView()
+      }
     } else {
       // Initialize new game
       this.incrementDay(true)

--- a/src/Farmhand.js
+++ b/src/Farmhand.js
@@ -555,13 +555,6 @@ export default class Farmhand extends Component {
           }
         })
       })
-
-      if (
-        !this.state.showHomeScreen &&
-        this.state.stageFocus === stageFocusType.HOME
-      ) {
-        this.focusNextView()
-      }
     } else {
       // Initialize new game
       this.incrementDay(true)

--- a/src/components/SettingsView/SettingsView.js
+++ b/src/components/SettingsView/SettingsView.js
@@ -25,8 +25,10 @@ const SettingsView = ({
   handleSaveButtonClick,
   handleShowNotificationsChange,
   handleUseAlternateEndDayButtonPositionChange,
+  handleHideHomeScreenChange,
   showNotifications,
   useAlternateEndDayButtonPosition,
+  hideHomeScreen
 }) => {
   const [isClearDataDialogOpen, setIsClearDataDialogOpen] = useState(false)
 
@@ -69,6 +71,17 @@ const SettingsView = ({
               />
             }
             label="Show new notifications"
+          />
+          <FormControlLabel
+              control={
+                <Switch
+                    color="primary"
+                    checked={hideHomeScreen}
+                    onChange={handleHideHomeScreenChange}
+                    name="hide-home-screen"
+                />
+              }
+              label="Hide Home Screen"
           />
         </FormGroup>
       </FormControl>
@@ -175,8 +188,10 @@ SettingsView.propTypes = {
   handleSaveButtonClick: func.isRequired,
   handleShowNotificationsChange: func.isRequired,
   handleUseAlternateEndDayButtonPositionChange: func.isRequired,
+  handleHideHomeScreenChange: func.isRequired,
   showNotifications: bool.isRequired,
   useAlternateEndDayButtonPosition: bool.isRequired,
+  hideHomeScreen: bool.isRequired
 }
 
 export default function Consumer(props) {

--- a/src/components/SettingsView/SettingsView.js
+++ b/src/components/SettingsView/SettingsView.js
@@ -25,10 +25,10 @@ const SettingsView = ({
   handleSaveButtonClick,
   handleShowNotificationsChange,
   handleUseAlternateEndDayButtonPositionChange,
-  handleHideHomeScreenChange,
+  handleShowHomeScreenChange,
   showNotifications,
   useAlternateEndDayButtonPosition,
-  hideHomeScreen
+  showHomeScreen,
 }) => {
   const [isClearDataDialogOpen, setIsClearDataDialogOpen] = useState(false)
 
@@ -73,15 +73,15 @@ const SettingsView = ({
             label="Show new notifications"
           />
           <FormControlLabel
-              control={
-                <Switch
-                    color="primary"
-                    checked={hideHomeScreen}
-                    onChange={handleHideHomeScreenChange}
-                    name="hide-home-screen"
-                />
-              }
-              label="Hide Home Screen"
+            control={
+              <Switch
+                color="primary"
+                checked={showHomeScreen}
+                onChange={handleShowHomeScreenChange}
+                name="show-home-screen"
+              />
+            }
+            label="Show the Home Screen"
           />
         </FormGroup>
       </FormControl>
@@ -188,10 +188,10 @@ SettingsView.propTypes = {
   handleSaveButtonClick: func.isRequired,
   handleShowNotificationsChange: func.isRequired,
   handleUseAlternateEndDayButtonPositionChange: func.isRequired,
-  handleHideHomeScreenChange: func.isRequired,
+  handleShowHomeScreenChange: func.isRequired,
   showNotifications: bool.isRequired,
   useAlternateEndDayButtonPosition: bool.isRequired,
-  hideHomeScreen: bool.isRequired
+  showHomeScreen: bool.isRequired,
 }
 
 export default function Consumer(props) {

--- a/src/components/SettingsView/SettingsView.test.js
+++ b/src/components/SettingsView/SettingsView.test.js
@@ -15,10 +15,10 @@ beforeEach(() => {
         handleSaveButtonClick: () => {},
         handleShowNotificationsChange: () => {},
         handleUseAlternateEndDayButtonPositionChange: () => {},
-        handleHideHomeScreenChange: () => {},
+        handleShowHomeScreenChange: () => {},
         showNotifications: true,
         useAlternateEndDayButtonPosition: false,
-        hideHomeScreen: false
+        showHomeScreen: false
       }}
     />
   )

--- a/src/components/SettingsView/SettingsView.test.js
+++ b/src/components/SettingsView/SettingsView.test.js
@@ -15,8 +15,10 @@ beforeEach(() => {
         handleSaveButtonClick: () => {},
         handleShowNotificationsChange: () => {},
         handleUseAlternateEndDayButtonPositionChange: () => {},
+        handleHideHomeScreenChange: () => {},
         showNotifications: true,
         useAlternateEndDayButtonPosition: false,
+        hideHomeScreen: false
       }}
     />
   )

--- a/src/constants.js
+++ b/src/constants.js
@@ -160,6 +160,7 @@ export const PERSISTED_STATE_KEYS = [
   'todaysStartingInventory',
   'toolLevels',
   'useAlternateEndDayButtonPosition',
+  'hideHomeScreen',
   'valueAdjustments',
   'version',
 ]

--- a/src/constants.js
+++ b/src/constants.js
@@ -153,6 +153,7 @@ export const PERSISTED_STATE_KEYS = [
   'recordProfitabilityStreak',
   'recordSingleDayProfit',
   'revenue',
+  'showHomeScreen',
   'showNotifications',
   'todaysLosses',
   'todaysPurchases',
@@ -160,7 +161,6 @@ export const PERSISTED_STATE_KEYS = [
   'todaysStartingInventory',
   'toolLevels',
   'useAlternateEndDayButtonPosition',
-  'hideHomeScreen',
   'valueAdjustments',
   'version',
 ]

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -399,6 +399,17 @@ export default {
     this.setState({ useAlternateEndDayButtonPosition })
   },
 
+  handleHideHomeScreenChange(
+      _e,
+      hideHomeScreen
+  ) {
+    if (this.state.stageFocus === 'HOME') {
+      this.focusNextView()
+    }
+
+    this.setState({ hideHomeScreen })
+  },
+
   handleShowNotificationsChange({ target: { checked } }) {
     this.setState({ showNotifications: checked })
   },

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -21,7 +21,7 @@ import {
   SPRINKLER_ITEM_ID,
   TOOLBELT_FIELD_MODES,
 } from './constants'
-import {dialogView, fieldMode, stageFocusType} from './enums'
+import { dialogView, fieldMode, stageFocusType } from './enums'
 import {
   DISCONNECTING_FROM_SERVER,
   INVALID_DATA_PROVIDED,

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -403,7 +403,7 @@ export default {
       _e,
       showHomeScreen
   ) {
-    if (this.state.stageFocus === stageFocusType.HOME) {
+    if (this.state.stageFocus === stageFocusType.HOME && !(showHomeScreen)) {
       this.focusNextView()
     }
 

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -21,7 +21,7 @@ import {
   SPRINKLER_ITEM_ID,
   TOOLBELT_FIELD_MODES,
 } from './constants'
-import { dialogView, fieldMode } from './enums'
+import {dialogView, fieldMode, stageFocusType} from './enums'
 import {
   DISCONNECTING_FROM_SERVER,
   INVALID_DATA_PROVIDED,
@@ -399,15 +399,15 @@ export default {
     this.setState({ useAlternateEndDayButtonPosition })
   },
 
-  handleHideHomeScreenChange(
+  handleShowHomeScreenChange(
       _e,
-      hideHomeScreen
+      showHomeScreen
   ) {
-    if (this.state.stageFocus === 'HOME') {
+    if (this.state.stageFocus === stageFocusType.HOME) {
       this.focusNextView()
     }
 
-    this.setState({ hideHomeScreen })
+    this.setState({ showHomeScreen })
   },
 
   handleShowNotificationsChange({ target: { checked } }) {

--- a/src/event-handlers.test.js
+++ b/src/event-handlers.test.js
@@ -168,3 +168,48 @@ describe('handleCowSelect', () => {
     expect(component.instance().selectCow).toHaveBeenCalledWith({ id: 'abc' })
   })
 })
+
+describe('handleShowHomeScreenChange', () => {
+
+  beforeEach(() => {
+    jest.spyOn(component.instance(), 'setState').mockImplementation()
+    jest.spyOn(component.instance(), 'focusNextView').mockImplementation()
+  })
+
+  test('change show home screen setting to False and navigate to the next view', () => {
+    component.state().stageFocus = stageFocusType.HOME
+    component.state().showHomeScreen = true
+
+    handlers().handleShowHomeScreenChange(null, false)
+    expect(component.instance().setState).toHaveBeenCalled()
+    // expect(component.showHomeScreen).toBeFalse()
+    expect(component.instance().focusNextView).toHaveBeenCalled()
+  })
+
+  test('change show home screen setting to False and do not navigate', () => {
+    component.state().stageFocus = stageFocusType.SHOP
+    component.state().showHomeScreen = true
+
+    handlers().handleShowHomeScreenChange(null, false)
+    expect(component.instance().setState).toHaveBeenCalled()
+    expect(component.instance().focusNextView).not.toHaveBeenCalled()
+  })
+
+  test('change show home screen setting to True and does not navigate', () => {
+    component.state().stageFocus = stageFocusType.HOME
+    component.state().showHomeScreen = false
+
+    handlers().handleShowHomeScreenChange(null, true)
+    expect(component.instance().setState).toHaveBeenCalled()
+    expect(component.instance().focusNextView).not.toHaveBeenCalled()
+  })
+
+  test('change show home screen setting to True and does not navigate', () => {
+    component.state().stageFocus = stageFocusType.SHOP
+    component.state().showHomeScreen = false
+
+    handlers().handleShowHomeScreenChange(null, true)
+    expect(component.instance().setState).toHaveBeenCalled()
+    expect(component.instance().focusNextView).not.toHaveBeenCalled()
+  })
+})

--- a/src/event-handlers.test.js
+++ b/src/event-handlers.test.js
@@ -170,46 +170,51 @@ describe('handleCowSelect', () => {
 })
 
 describe('handleShowHomeScreenChange', () => {
-
   beforeEach(() => {
-    jest.spyOn(component.instance(), 'setState').mockImplementation()
     jest.spyOn(component.instance(), 'focusNextView').mockImplementation()
   })
 
-  test('change show home screen setting to False and navigate to the next view', () => {
-    component.state().stageFocus = stageFocusType.HOME
-    component.state().showHomeScreen = true
+  test('change show home screen setting to False while on Home and navigate to the next view', () => {
+    component.setState({
+      stageFocus: stageFocusType.HOME,
+      showHomeScreen: true,
+    })
 
     handlers().handleShowHomeScreenChange(null, false)
-    expect(component.instance().setState).toHaveBeenCalled()
-    // expect(component.showHomeScreen).toBeFalse()
+    expect(component.state().showHomeScreen).toBeFalse()
     expect(component.instance().focusNextView).toHaveBeenCalled()
   })
 
-  test('change show home screen setting to False and do not navigate', () => {
-    component.state().stageFocus = stageFocusType.SHOP
-    component.state().showHomeScreen = true
+  test('change show home screen setting to False while not on Home and do not navigate', () => {
+    component.setState({
+      stageFocus: stageFocusType.SHOP,
+      showHomeScreen: true,
+    })
 
     handlers().handleShowHomeScreenChange(null, false)
-    expect(component.instance().setState).toHaveBeenCalled()
+    expect(component.state().showHomeScreen).toBeFalse()
     expect(component.instance().focusNextView).not.toHaveBeenCalled()
   })
 
-  test('change show home screen setting to True and does not navigate', () => {
-    component.state().stageFocus = stageFocusType.HOME
-    component.state().showHomeScreen = false
+  test('change show home screen setting to True while on Home and do not navigate', () => {
+    component.setState({
+      stageFocus: stageFocusType.HOME,
+      showHomeScreen: false,
+    })
 
     handlers().handleShowHomeScreenChange(null, true)
-    expect(component.instance().setState).toHaveBeenCalled()
+    expect(component.state().showHomeScreen).toBeTrue()
     expect(component.instance().focusNextView).not.toHaveBeenCalled()
   })
 
-  test('change show home screen setting to True and does not navigate', () => {
-    component.state().stageFocus = stageFocusType.SHOP
-    component.state().showHomeScreen = false
+  test('change show home screen setting to True while not on Home and do not navigate', () => {
+    component.setState({
+      stageFocus: stageFocusType.SHOP,
+      showHomeScreen: false,
+    })
 
     handlers().handleShowHomeScreenChange(null, true)
-    expect(component.instance().setState).toHaveBeenCalled()
+    expect(component.state().showHomeScreen).toBeTrue()
     expect(component.instance().focusNextView).not.toHaveBeenCalled()
   })
 })

--- a/src/event-handlers.test.js
+++ b/src/event-handlers.test.js
@@ -170,10 +170,6 @@ describe('handleCowSelect', () => {
 })
 
 describe('handleShowHomeScreenChange', () => {
-  beforeEach(() => {
-    jest.spyOn(component.instance(), 'focusNextView').mockImplementation()
-  })
-
   test('change show home screen setting to False while on Home and navigate to the next view', () => {
     component.setState({
       stageFocus: stageFocusType.HOME,
@@ -182,7 +178,7 @@ describe('handleShowHomeScreenChange', () => {
 
     handlers().handleShowHomeScreenChange(null, false)
     expect(component.state().showHomeScreen).toBeFalse()
-    expect(component.instance().focusNextView).toHaveBeenCalled()
+    expect(component.state().stageFocus).not.toEqual(stageFocusType.HOME)
   })
 
   test('change show home screen setting to False while not on Home and do not navigate', () => {
@@ -193,7 +189,7 @@ describe('handleShowHomeScreenChange', () => {
 
     handlers().handleShowHomeScreenChange(null, false)
     expect(component.state().showHomeScreen).toBeFalse()
-    expect(component.instance().focusNextView).not.toHaveBeenCalled()
+    expect(component.state().stageFocus).toEqual(stageFocusType.SHOP)
   })
 
   test('change show home screen setting to True while on Home and do not navigate', () => {
@@ -204,7 +200,7 @@ describe('handleShowHomeScreenChange', () => {
 
     handlers().handleShowHomeScreenChange(null, true)
     expect(component.state().showHomeScreen).toBeTrue()
-    expect(component.instance().focusNextView).not.toHaveBeenCalled()
+    expect(component.state().stageFocus).toEqual(stageFocusType.HOME)
   })
 
   test('change show home screen setting to True while not on Home and do not navigate', () => {
@@ -215,6 +211,6 @@ describe('handleShowHomeScreenChange', () => {
 
     handlers().handleShowHomeScreenChange(null, true)
     expect(component.state().showHomeScreen).toBeTrue()
-    expect(component.instance().focusNextView).not.toHaveBeenCalled()
+    expect(component.state().stageFocus).toEqual(stageFocusType.SHOP)
   })
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -998,7 +998,10 @@ export const transformStateDataForImport = state => {
     sanitizedState.toolLevels = unlockTool(sanitizedState.toolLevels, tool)
   }
 
-  if (!sanitizedState.showHomeScreen) {
+  if (
+    !sanitizedState.showHomeScreen &&
+    sanitizedState.stageFocus === stageFocusType.HOME
+  ) {
     sanitizedState.stageFocus = stageFocusType.SHOP
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,7 @@ import {
   fertilizerType,
   genders,
   itemType,
+  stageFocusType,
   standardCowColors,
   toolLevel,
 } from './enums'
@@ -995,6 +996,10 @@ export const transformStateDataForImport = state => {
 
   for (const tool of Object.keys(unlockedTools)) {
     sanitizedState.toolLevels = unlockTool(sanitizedState.toolLevels, tool)
+  }
+
+  if (!sanitizedState.showHomeScreen) {
+    sanitizedState.stageFocus = stageFocusType.SHOP
   }
 
   return sanitizedState


### PR DESCRIPTION
### What this PR does

This adds an option to the Settings page to hide the Home screen. It is off by default and changes persist into the saved game state.

When the option is toggled on, HOME is removed as a navigation option and if the user is on the Home page it will move them to the next view (which is currently the SHOP).

When the page is first loaded or reloaded with the Home view hidden, the program will move to the next view in the list as above (is not hardcoded to SHOP).

### How this change can be validated

Manual testing by opening settings and toggling the option.

### Questions or concerns about this change

If you toggle it off and are shifted over to the SHOP, it will not shift you back to HOME if you toggle it off again. Not sure if users will care?

### Additional information

![234 Settings Screenshot with new option](https://user-images.githubusercontent.com/35631425/147894767-c19bc760-4bc4-4781-b38c-b14fb7414f34.jpg)