### PR TITLE
chore: [#239] Format and lint all branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "if git-branch-is develop; then pretty-quick --staged && npm run lint && cross-env CI=true react-scripts test --env=jsdom; fi"
+      "pre-commit": "pretty-quick --staged && npm run lint && if git-branch-is develop; then cross-env CI=true react-scripts test --env=jsdom; fi"
     }
   },
   "files": [

--- a/src/components/CowPen/CowPen.js
+++ b/src/components/CowPen/CowPen.js
@@ -161,10 +161,7 @@ export class Cow extends Component {
   }
 
   componentWillUnmount() {
-    ;[
-      this.repositionTimeoutId,
-      this.animateHugTimeoutId,
-    ].forEach(clearTimeout)
+    ;[this.repositionTimeoutId, this.animateHugTimeoutId].forEach(clearTimeout)
 
     this.tweenable.cancel()
   }

--- a/src/components/CowPenContextMenu/CowPenContextMenu.test.js
+++ b/src/components/CowPenContextMenu/CowPenContextMenu.test.js
@@ -295,7 +295,7 @@ describe('CowCard', () => {
         .closest('label')
         .querySelector('[type=checkbox]')
       expect(button).not.toHaveAttribute('disabled')
-    });
+    })
 
     test('is disabled when pen has space and incompatible partner', () => {
       const testCow = generateCow({

--- a/src/components/KeybindingsView/KeybindingsView.js
+++ b/src/components/KeybindingsView/KeybindingsView.js
@@ -18,7 +18,10 @@ const KeybindingsView = () => (
       <Table aria-label="Keyboard Shortcuts">
         <TableBody>
           {[
-            { label: 'Show Keyboard Shortcuts (this screen)', keybinding: 'Shift + ?' },
+            {
+              label: 'Show Keyboard Shortcuts (this screen)',
+              keybinding: 'Shift + ?',
+            },
             { label: 'Toggle menu', keybinding: 'M' },
             { label: 'End the day', keybinding: 'Shift + C' },
             { label: 'Go to screen by <1-9> order', keybinding: '<1-9>' },

--- a/src/components/KeybindingsView/KeybindingsView.test.js
+++ b/src/components/KeybindingsView/KeybindingsView.test.js
@@ -1,16 +1,14 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import React from 'react'
+import { shallow } from 'enzyme'
 
-import KeybindingsView from './KeybindingsView';
+import KeybindingsView from './KeybindingsView'
 
-let component;
+let component
 
 beforeEach(() => {
-  component = shallow(
-    <KeybindingsView {...{}} />
-  );
-});
+  component = shallow(<KeybindingsView {...{}} />)
+})
 
 test('renders', () => {
-  expect(component).toHaveLength(1);
-});
+  expect(component).toHaveLength(1)
+})

--- a/src/components/KeybindingsView/index.js
+++ b/src/components/KeybindingsView/index.js
@@ -1,1 +1,1 @@
-export { default } from './KeybindingsView';
+export { default } from './KeybindingsView'

--- a/src/components/OnlinePeersView/OnlinePeersView.test.js
+++ b/src/components/OnlinePeersView/OnlinePeersView.test.js
@@ -1,21 +1,23 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import React from 'react'
+import { shallow } from 'enzyme'
 
-import OnlinePeersView from './OnlinePeersView';
+import OnlinePeersView from './OnlinePeersView'
 
-let component;
+let component
 
 beforeEach(() => {
   component = shallow(
-    <OnlinePeersView {...{
-      activePlayers: 0,
-      id: '',
-      latestPeerMessages: [],
-      peers: {},
-    }} />
-  );
-});
+    <OnlinePeersView
+      {...{
+        activePlayers: 0,
+        id: '',
+        latestPeerMessages: [],
+        peers: {},
+      }}
+    />
+  )
+})
 
 test('renders', () => {
-  expect(component).toHaveLength(1);
-});
+  expect(component).toHaveLength(1)
+})

--- a/src/components/OnlinePeersView/index.js
+++ b/src/components/OnlinePeersView/index.js
@@ -1,1 +1,1 @@
-export { default } from './OnlinePeersView';
+export { default } from './OnlinePeersView'

--- a/src/components/Plot/Plot.js
+++ b/src/components/Plot/Plot.js
@@ -91,7 +91,11 @@ export const Plot = ({
   )
 
   useEffect(() => {
-    if (!initialIsShoveledState && plotContent?.isShoveled && plotContent?.oreId) {
+    if (
+      !initialIsShoveledState &&
+      plotContent?.isShoveled &&
+      plotContent?.oreId
+    ) {
       setWasJustShoveled(true)
     }
   }, [initialIsShoveledState, plotContent])

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -18,10 +18,10 @@ export const testCrop = (item = {}) => ({
 /**
  * @param {farmhand.shoveledPlot} plotProps
  */
-export const testShoveledPlot = (plotProps) => ({
+export const testShoveledPlot = plotProps => ({
   isShoveled: true,
   daysUntilClear: 5,
-  ...plotProps
+  ...plotProps,
 })
 
 export const testItem = (item = {}) => ({

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -562,7 +562,7 @@ describe('getPlotImage', () => {
     expect(getPlotImage(getPlotContentFromItemId('sample-ore-1'))).toBe(
       itemImages['sample-ore-1']
     )
-  });
+  })
 
   test('returns item image for other content', () => {
     expect(getPlotImage(getPlotContentFromItemId('sprinkler'))).toBe(


### PR DESCRIPTION
### What this PR does

Ticket: #239

This PR is a followup to a configuration gap that surfaced in @UnquietBones' PR: https://github.com/jeremyckahn/farmhand/pull/238#discussion_r777235755

It changes the `pre-commit` hook to run ESLint and Prettier for all commits for all branches, but only run the tests on the `develop` branch. The CI system will the run the tests for all pushes regardless, so any broken tests should still be caught pretty quickly.

This PR also runs `npm run prettier` to clean up all the style violations that were not caught previously because of this gap.

### How this change can be validated

Branch off of `jeremyckahn/239_format-and-lint-all-branches`, make a change that breaks Prettier rules, attempt to commit it, and observe that it is automatically fixed before being committed.

### Questions or concerns about this change

Are there any other checks that we should run in the pre-commit hook?
<!-- 
### Additional information

Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
