### PR TITLE
Decouple static ranges from slider

### DIFF
--- a/src/components/Field/Field.test.js
+++ b/src/components/Field/Field.test.js
@@ -22,6 +22,7 @@ beforeEach(() => {
         hoveredPlotRangeSize: 0,
         handleCombineEnabledChange: () => {},
         handleFieldActionRangeChange: () => {},
+        itemsSold: {},
         rows: 0,
         field: [
           [null, null],
@@ -53,7 +54,9 @@ describe('field rendering', () => {
           ],
           hoveredPlot: {},
           hoveredPlotRangeSize: 0,
+          fieldMode: fieldMode.OBSERVE,
           isCombineEnabled: false,
+          itemsSold: {},
           purchasedCombine: 0,
           rows: 0,
           setHoveredPlot: () => {},
@@ -159,6 +162,7 @@ describe('isInHoverRange', () => {
         isInHoverRange({
           hoveredPlotRangeSize: 2,
           hoveredPlot: { x: 1, y: 1 },
+          itemsSold: {},
           x: 4,
           y: 4,
         })
@@ -172,6 +176,7 @@ describe('isInHoverRange', () => {
         isInHoverRange({
           hoveredPlotRangeSize: 2,
           hoveredPlot: { x: 1, y: 1 },
+          itemsSold: {},
           x: 0,
           y: 0,
         })

--- a/src/components/Field/Field.test.js
+++ b/src/components/Field/Field.test.js
@@ -156,29 +156,107 @@ describe('water-mode class', () => {
 })
 
 describe('isInHoverRange', () => {
-  describe('plot is not in hover range', () => {
-    test('returns false', () => {
+  test('indicated plot is not in hover range', () => {
+    expect(
+      isInHoverRange({
+        hoveredPlotRangeSize: 2,
+        hoveredPlot: { x: 1, y: 1 },
+        itemsSold: {},
+        x: 4,
+        y: 4,
+      })
+    ).toBe(false)
+  })
+
+  test('indicated plot is in hover range', () => {
+    expect(
+      isInHoverRange({
+        hoveredPlotRangeSize: 2,
+        hoveredPlot: { x: 1, y: 1 },
+        itemsSold: {},
+        x: 0,
+        y: 0,
+      })
+    ).toBe(true)
+  })
+
+  describe('fieldMode === OBSERVE', () => {
+    test('indicated plot is not in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,
           hoveredPlot: { x: 1, y: 1 },
+          fieldMode: fieldMode.OBSERVE,
           itemsSold: {},
           x: 4,
           y: 4,
         })
       ).toBe(false)
     })
-  })
 
-  describe('plot is in hover range', () => {
-    test('returns true', () => {
+    test('indicated plot is in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,
           hoveredPlot: { x: 1, y: 1 },
+          fieldMode: fieldMode.OBSERVE,
           itemsSold: {},
           x: 0,
           y: 0,
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('fieldMode === SET_SPRINKLER', () => {
+    test('indicated plot is not in hover range', () => {
+      expect(
+        isInHoverRange({
+          hoveredPlotRangeSize: 2,
+          hoveredPlot: { x: 1, y: 1 },
+          fieldMode: fieldMode.SET_SPRINKLER,
+          itemsSold: {},
+          x: 4,
+          y: 4,
+        })
+      ).toBe(false)
+    })
+
+    test('indicated plot is in hover range', () => {
+      expect(
+        isInHoverRange({
+          hoveredPlotRangeSize: 2,
+          hoveredPlot: { x: 1, y: 1 },
+          fieldMode: fieldMode.SET_SPRINKLER,
+          itemsSold: {},
+          x: 0,
+          y: 0,
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('fieldMode === SET_SCARECROW', () => {
+    test('all plots are in hover range', () => {
+      expect(
+        isInHoverRange({
+          hoveredPlotRangeSize: 2,
+          hoveredPlot: { x: 1, y: 1 },
+          fieldMode: fieldMode.SET_SCARECROW,
+          itemsSold: {},
+          x: 2,
+          y: 2,
+        })
+      ).toBe(true)
+
+      expect(
+        isInHoverRange({
+          hoveredPlotRangeSize: 2,
+          hoveredPlot: { x: 1, y: 1 },
+          fieldMode: fieldMode.SET_SCARECROW,
+          itemsSold: {},
+          x: 100,
+          y: 100,
         })
       ).toBe(true)
     })

--- a/src/components/Field/Field.test.js
+++ b/src/components/Field/Field.test.js
@@ -156,7 +156,7 @@ describe('water-mode class', () => {
 })
 
 describe('isInHoverRange', () => {
-  test('indicated plot is not in hover range', () => {
+  test('indicates when plot is not in hover range', () => {
     expect(
       isInHoverRange({
         hoveredPlotRangeSize: 2,
@@ -168,7 +168,7 @@ describe('isInHoverRange', () => {
     ).toBe(false)
   })
 
-  test('indicated plot is in hover range', () => {
+  test('indicates when plot is in hover range', () => {
     expect(
       isInHoverRange({
         hoveredPlotRangeSize: 2,
@@ -180,8 +180,8 @@ describe('isInHoverRange', () => {
     ).toBe(true)
   })
 
-  describe('fieldMode === OBSERVE', () => {
-    test('indicated plot is not in hover range', () => {
+  describe('when observing the field', () => {
+    test('indicates when plot is not in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,
@@ -194,7 +194,7 @@ describe('isInHoverRange', () => {
       ).toBe(false)
     })
 
-    test('indicated plot is in hover range', () => {
+    test('indicates when plot is in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,
@@ -208,8 +208,8 @@ describe('isInHoverRange', () => {
     })
   })
 
-  describe('fieldMode === SET_SPRINKLER', () => {
-    test('indicated plot is not in hover range', () => {
+  describe('when placing a sprinkler', () => {
+    test('indicates when plot is not in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,
@@ -222,7 +222,7 @@ describe('isInHoverRange', () => {
       ).toBe(false)
     })
 
-    test('indicated plot is in hover range', () => {
+    test('indicates when plot is in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,
@@ -236,8 +236,8 @@ describe('isInHoverRange', () => {
     })
   })
 
-  describe('fieldMode === SET_SCARECROW', () => {
-    test('all plots are in hover range', () => {
+  describe('when placing a scarecrow', () => {
+    test('indicates that all plots are in hover range', () => {
       expect(
         isInHoverRange({
           hoveredPlotRangeSize: 2,

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -1,11 +1,10 @@
-$not-allowed-color: rgba(255, 0, 0, 0.5)
-
 .Plot
+  --color-generic-highlight: rgba(255, 255, 255, 0.8)
   --color-red-danger: rgba(255, 0, 0, 0.5)
   --color-blue-water: rgba(125, 245, 255, 0.75)
   --color-brown-fertilize: rgba(125, 56, 0, .75)
   --color-green-ok: rgba(0, 255, 0, 0.5)
-  --color-yellow: #ff0
+  --color-yellow: rgba(255, 255, 0, 0.75)
 
   background-repeat: no-repeat
   background-size: cover
@@ -13,9 +12,19 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
   flex-grow: 1
   image-rendering: pixelated
 
+  &:hover
+    background-color: var(--color-generic-highlight)
+    cursor: pointer
+
+  &.is-in-hover-range
+    border-color: var(--color-generic-highlight)
+
   .water-mode &.crop:hover
     background-color: var(--color-blue-water)
     cursor: pointer
+
+  .water-mode &.is-in-hover-range
+    border-color: var(--color-blue-water)
 
   .fertilize-mode &.can-be-fertilized
     background-color: var(--color-brown-fertilize)
@@ -36,8 +45,11 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
       cursor: pointer
       border-color: var(--color-yellow)
 
+    &.is-in-hover-range
+      border-color: var(--color-yellow)
+
   .cleanup-mode &.crop,
-    background-color: rgba(255, 255, 0, 0.5)
+    background-color: var(--color-yellow)
     cursor: pointer
 
   .harvest-mode.is-inventory-full &.crop.is-ripe,
@@ -52,13 +64,6 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
   .cleanup-mode &.is-ripe
     background-color: var(--color-green-ok)
     cursor: auto
-
-  &.is-in-hover-range
-    border-color: #fff
-
-  &:hover
-    background-color: rgba(255, 255, 255, 0.8)
-    cursor: pointer
 
   .set-sprinkler-mode:hover &:hover,
   .set-scarecrow-mode:hover &:hover
@@ -95,5 +100,3 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
       opacity: 0
       visibility: hidden
       transform: translate3d(0, -100%, 0) scale(0.75)
-
-

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -13,56 +13,56 @@
   image-rendering: pixelated
 
   &:hover
-    background-color: #{$colorGenericHighlight}
+    background-color: $colorGenericHighlight
     cursor: pointer
 
   &.is-in-hover-range
-    border-color: #{$colorGenericHighlight}
+    border-color: $colorGenericHighlight
 
   .water-mode &.crop:hover
-    background-color: #{$colorBlueWater}
+    background-color: $colorBlueWater
     cursor: pointer
 
   .water-mode &.is-in-hover-range
-    border-color: #{$colorBlueWater}
+    border-color: $colorBlueWater
 
   .fertilize-mode &.can-be-fertilized
-    background-color: #{$colorBrownFertilize}
+    background-color: $colorBrownFertilize
 
     &:hover
       cursor: pointer
 
   .harvest-mode &.is-ripe
-    background-color: #{$colorGreenOk}
+    background-color: $colorGreenOk
 
     &:hover
       cursor: pointer
 
   .mine-mode &.can-be-mined
-    background-color: #{$colorGreenOk}
+    background-color: $colorGreenOk
 
     &:hover
       cursor: pointer
-      border-color: #{$colorYellow}
+      border-color: $colorYellow
 
     &.is-in-hover-range
-      border-color: #{$colorYellow}
+      border-color: $colorYellow
 
   .cleanup-mode &.crop,
-    background-color: #{$colorYellow}
+    background-color: $colorYellow
     cursor: pointer
 
   .harvest-mode.is-inventory-full &.crop.is-ripe,
   .cleanup-mode.is-inventory-full &.is-replantable
-    background-color: #{$colorRedDanger}
+    background-color: $colorRedDanger
     cursor: not-allowed
 
   .cleanup-mode &.is-replantable
-    background-color: #{$colorGreenOk}
+    background-color: $colorGreenOk
     cursor: pointer
 
   .cleanup-mode &.is-ripe
-    background-color: #{$colorGreenOk}
+    background-color: $colorGreenOk
     cursor: auto
 
   .set-sprinkler-mode:hover &:hover,
@@ -73,7 +73,7 @@
       opacity: 0.5
 
     &:not(.is-empty)
-      background-color: #{$colorRedDanger}
+      background-color: $colorRedDanger
       background-image: none
       cursor: not-allowed
 

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -1,10 +1,10 @@
 .Plot
-  --color-generic-highlight: rgba(255, 255, 255, 0.8)
-  --color-red-danger: rgba(255, 0, 0, 0.5)
-  --color-blue-water: rgba(125, 245, 255, 0.75)
-  --color-brown-fertilize: rgba(125, 56, 0, .75)
-  --color-green-ok: rgba(0, 255, 0, 0.5)
-  --color-yellow: rgba(255, 255, 0, 0.75)
+  $colorGenericHighlight: rgba(255, 255, 255, 0.8)
+  $colorRedDanger: rgba(255, 0, 0, 0.5)
+  $colorBlueWater: rgba(125, 245, 255, 0.75)
+  $colorBrownFertilize: rgba(125, 56, 0, .75)
+  $colorGreenOk: rgba(0, 255, 0, 0.5)
+  $colorYellow: rgba(255, 255, 0, 0.75)
 
   background-repeat: no-repeat
   background-size: cover
@@ -13,56 +13,56 @@
   image-rendering: pixelated
 
   &:hover
-    background-color: var(--color-generic-highlight)
+    background-color: #{$colorGenericHighlight}
     cursor: pointer
 
   &.is-in-hover-range
-    border-color: var(--color-generic-highlight)
+    border-color: #{$colorGenericHighlight}
 
   .water-mode &.crop:hover
-    background-color: var(--color-blue-water)
+    background-color: #{$colorBlueWater}
     cursor: pointer
 
   .water-mode &.is-in-hover-range
-    border-color: var(--color-blue-water)
+    border-color: #{$colorBlueWater}
 
   .fertilize-mode &.can-be-fertilized
-    background-color: var(--color-brown-fertilize)
+    background-color: #{$colorBrownFertilize}
 
     &:hover
       cursor: pointer
 
   .harvest-mode &.is-ripe
-    background-color: var(--color-green-ok)
+    background-color: #{$colorGreenOk}
 
     &:hover
       cursor: pointer
 
   .mine-mode &.can-be-mined
-    background-color: var(--color-green-ok)
+    background-color: #{$colorGreenOk}
 
     &:hover
       cursor: pointer
-      border-color: var(--color-yellow)
+      border-color: #{$colorYellow}
 
     &.is-in-hover-range
-      border-color: var(--color-yellow)
+      border-color: #{$colorYellow}
 
   .cleanup-mode &.crop,
-    background-color: var(--color-yellow)
+    background-color: #{$colorYellow}
     cursor: pointer
 
   .harvest-mode.is-inventory-full &.crop.is-ripe,
   .cleanup-mode.is-inventory-full &.is-replantable
-    background-color: var(--color-red-danger)
+    background-color: #{$colorRedDanger}
     cursor: not-allowed
 
   .cleanup-mode &.is-replantable
-    background-color: var(--color-green-ok)
+    background-color: #{$colorGreenOk}
     cursor: pointer
 
   .cleanup-mode &.is-ripe
-    background-color: var(--color-green-ok)
+    background-color: #{$colorGreenOk}
     cursor: auto
 
   .set-sprinkler-mode:hover &:hover,
@@ -73,7 +73,7 @@
       opacity: 0.5
 
     &:not(.is-empty)
-      background-color: var(--color-red-danger)
+      background-color: #{$colorRedDanger}
       background-image: none
       cursor: not-allowed
 

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -14,7 +14,7 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
   image-rendering: pixelated
 
   .water-mode &.crop:hover
-    background-color: var(--color-blue-hover)
+    background-color: var(--color-blue-water)
     cursor: pointer
 
   .fertilize-mode &.can-be-fertilized
@@ -54,7 +54,7 @@ $not-allowed-color: rgba(255, 0, 0, 0.5)
     cursor: auto
 
   &.is-in-hover-range
-    background-color: rgba(255, 255, 255, 0.4)
+    border-color: #fff
 
   &:hover
     background-color: rgba(255, 255, 255, 0.8)

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -9,16 +9,12 @@ import {
   waterPlot,
 } from './reducers'
 import {
-  farmProductsSold,
-  getLevelEntitlements,
-  levelAchieved,
   moneyTotal,
   reduceByPersistedKeys,
   transformStateDataForImport,
 } from './utils'
 import {
   DEFAULT_ROOM,
-  SPRINKLER_ITEM_ID,
   TOOLBELT_FIELD_MODES,
 } from './constants'
 import { dialogView, fieldMode } from './enums'
@@ -151,24 +147,9 @@ export default {
     enablesFieldMode,
     hoveredPlotRangeSize: newHoveredPlotRangeSize,
   }) {
-    this.setState(({ hoveredPlotRangeSize, itemsSold }) => {
-      if (id === SPRINKLER_ITEM_ID) {
-        hoveredPlotRangeSize = getLevelEntitlements(
-          levelAchieved(farmProductsSold(itemsSold))
-        ).sprinklerRange
-      } else {
-        // newHoveredPlotRangeSize is either a number or undefined.
-        hoveredPlotRangeSize =
-          typeof newHoveredPlotRangeSize === 'number'
-            ? newHoveredPlotRangeSize
-            : hoveredPlotRangeSize
-      }
-
-      return {
-        fieldMode: enablesFieldMode,
-        hoveredPlotRangeSize,
-        selectedItemId: id,
-      }
+    this.setState({
+      fieldMode: enablesFieldMode,
+      selectedItemId: id,
     })
   },
 


### PR DESCRIPTION
### What this PR does

This PR implements #236. It's a UX improvement that prevents the player's field range settings from being changed by selecting the Scarecrow or the Sprinkler. It also improves how field ranges are displayed.

### How this change can be validated

Use different items and tools at different ranges, go back and forth between selecting the Scarecrow and Sprinkler items, and see if the interaction feels intuitive.

### Questions or concerns about this change

  - How well do the range colors work? Anything else that should change with the display of the ranges?
  - Does this new UX of the different items having different ranges feel good?

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->

#### Planting a seed
![Planting a seed](https://user-images.githubusercontent.com/366330/148156684-6198101a-116a-4bee-88a1-50572116542a.png)

#### Watering Can selected
![Watering Can selected](https://user-images.githubusercontent.com/366330/148156690-b70256a8-95c1-4963-8a83-a31f6d61ca52.png)

#### Hoe selected
![Hoe selected](https://user-images.githubusercontent.com/366330/148156682-b6ef6579-5246-434c-8fbf-2a4f4501f2ea.png)

#### Scythe selected
![Scythe selected](https://user-images.githubusercontent.com/366330/148156688-7901d5b5-6144-4156-b7e5-db9c937257d0.png)

#### Shovel selected
![Shovel selected](https://user-images.githubusercontent.com/366330/148156689-652dad6c-657e-4c22-bade-a56e177da4b7.png)

#### Scarecrow selected
![Scarecrow selected](https://user-images.githubusercontent.com/366330/148156686-09d3cc52-ddad-49ee-a973-3d7068f86b50.png)

#### Sprinkler selected

![Sprinkler selected](https://user-images.githubusercontent.com/366330/148156969-9e74d53f-119b-4fb1-bd3e-767d4397b9bc.png)