### PR TITLE
Make all cow sales count towards revenue

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1369,21 +1369,12 @@ export const addCowToInventory = (state, cow) => {
  * @returns {farmhand.state}
  */
 export const sellCow = (state, cow) => {
-  const { cowsSold, money } = state
+  const { cowsSold } = state
+  const cowColorId = getCowColorId(cow)
   const cowValue = getCowValue(cow, true)
 
   state = removeCowFromInventory(state, cow)
-
-  const cowColorId = getCowColorId(cow)
-
-  if (cow.isBred) {
-    state = addRevenue(state, cowValue)
-  } else {
-    state = {
-      ...state,
-      money: moneyTotal(money, cowValue),
-    }
-  }
+  state = addRevenue(state, cowValue)
 
   const newCowsSold = {
     ...cowsSold,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1115,6 +1115,7 @@ export const getCostOfNextStorageExpansion = currentInventoryLimit => {
  */
 export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
+// TODO: This needs to be used for rendering the values of items.
 /**
  * @param {object} completedAchievements from game state
  * @returns {number} multiplier to be used for sales price adjustments based on completedAchievements

--- a/src/utils.js
+++ b/src/utils.js
@@ -1115,7 +1115,9 @@ export const getCostOfNextStorageExpansion = currentInventoryLimit => {
  */
 export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-// TODO: This needs to be used for rendering the values of items.
+// TODO: This needs to be used for rendering the values of items:
+// https://github.com/jeremyckahn/farmhand/issues/264
+//
 /**
  * @param {object} completedAchievements from game state
  * @returns {number} multiplier to be used for sales price adjustments based on completedAchievements


### PR DESCRIPTION
### What this PR does

For #255, this PR changes cow sales such that they all count towards revenue figures. Per what was originally reported, a poor design choice on my part resulted in a broken-feeling experience. After some debugging and experimentation, I discovered that simply removing the undesirable logic resulted in cow sales working in an intuitive and appropriate manner, as cows are worth $0 the day they are purchased. They gain value with age: https://github.com/jeremyckahn/farmhand/blob/9e9997d81291311ffb86b90daf6fe32f9426cee5/src/utils.js#L607-L621

### How this change can be validated

Sell any cow and see that its value is reflected accurately in "Today's Revenue" in the Farm Stats dialogue.
