### PR TITLE
fix: handle null peer data in cow trades

### DIFF
--- a/src/Farmhand.js
+++ b/src/Farmhand.js
@@ -782,9 +782,11 @@ export default class Farmhand extends Component {
         if (!sendCowTradeRequest) return null
 
         const { ownerId } = peerPlayerCow
-        const [peerId] = Object.entries(peers).find(
-          ([peerId, { id }]) => id === ownerId
-        )
+
+        const [peerId] =
+          Object.entries(peers).find(
+            ([peerId, peer]) => peer?.id === ownerId
+          ) ?? []
 
         if (!peerId) {
           console.error(

--- a/src/trystero-handlers.js
+++ b/src/trystero-handlers.js
@@ -83,9 +83,15 @@ export const handleCowTradeRequest = async (
             : cowOffered.timesTraded + 1,
       }
 
-      const [, peerMetadata] = Object.entries(peers).find(
-        ([, { id }]) => id === updatedCowOffered.ownerId
-      )
+      const [, peerMetadata] =
+        Object.entries(peers).find(
+          ([, peer]) => peer?.id === updatedCowOffered.ownerId
+        ) ?? []
+
+      if (!peerMetadata) {
+        console.error(`No data for peer ${updatedCowOffered.ownerId}`)
+        return
+      }
 
       state = changeCowAutomaticHugState(state, cowToTradeAway, false)
       state = removeCowFromInventory(state, cowToTradeAway)


### PR DESCRIPTION
### What this PR does

This PR fixes a crash I noticed in Production where a peer had `null` data. Somehow a peer was connecting to the room, but the my client never received  their metadata before I initiated a trade.

For reference, peers start off with `null` data: https://github.com/jeremyckahn/farmhand/blob/015d288700eba456294cf5daf7db579b8abd9e71/src/reducers.js#L2111-L2116

Shortly thereafter (asynchronously), this data gets populated as the peers in the room broadcast their state:

https://github.com/jeremyckahn/farmhand/blob/015d288700eba456294cf5daf7db579b8abd9e71/src/Farmhand.js#L703-L706
https://github.com/jeremyckahn/farmhand/blob/015d288700eba456294cf5daf7db579b8abd9e71/src/trystero-handlers.js#L21-L23
https://github.com/jeremyckahn/farmhand/blob/015d288700eba456294cf5daf7db579b8abd9e71/src/reducers.js#L2136-L2152

In the scenario I experienced, a peer must have fallen into some invalid state and stayed `null`. This caused my game to crash upon an attempt to destructure `null`.

### How this change can be validated

I don't know how to reproduce the scenario that triggered this bug, unfortunately. I tweaked the code to synthetically trigger the error handling logic and it seems to work as expected.

### Questions or concerns about this change

I don't like coding blind like this, but I don't know of a better way deal with this issue! :grimacing: 

### Additional information

This is the stack trace for the error I experienced:

```
Uncaught TypeError: t[1] is null
    A Farmhand.js:786
    value Farmhand.js:785
    React 8
    unstable_runWithPriority scheduler.production.min.js:18
    React 16
    unstable_runWithPriority scheduler.production.min.js:18
    React 5
    i useControlled.js:38
    we Tooltip.js:273
    current Tooltip.js:306
    setTimeout handler*R</_e/< Tooltip.js:305
    React 11
    unstable_runWithPriority scheduler.production.min.js:18
    React 9
    497 index.js:202
    a (index):1
    t (index):1
    r (index):1
    <anonymous> main.d8d1ab51.chunk.js:2
```

And here's the `peers` data the triggered it:

![image](https://user-images.githubusercontent.com/366330/160744675-1a282445-e230-4a5e-ac5c-7393c6a6528c.png)

