### PR TITLE
Lstebner/271 disable upgrade buttons

### DIFF
--- a/src/components/UpgradePurchase/UpgradePurchase.js
+++ b/src/components/UpgradePurchase/UpgradePurchase.js
@@ -65,7 +65,12 @@ export function UpgradePurchase({
       />
 
       <CardActions>
-        <Button color="primary" onClick={handleUpgrade} variant="contained">
+        <Button
+          color="primary"
+          onClick={handleUpgrade}
+          variant="contained"
+          disabled={!canBeMade}
+        >
           Upgrade Tool
         </Button>
       </CardActions>

--- a/src/components/UpgradePurchase/UpgradePurchase.test.js
+++ b/src/components/UpgradePurchase/UpgradePurchase.test.js
@@ -26,12 +26,18 @@ describe('<UpgradePurchase />', () => {
 
     props = {
       handleUpgradeTool: jest.fn(),
-      inventory: [],
-      inventoryLimit: 99,
+      inventory: [
+        {
+          id: 'bronze-ore',
+          quantity: 100,
+        },
+        { id: 'coal', quantity: 100 },
+      ],
       playerInventoryQuantities: {
         'bronze-ore': 100,
         coal: 100,
       },
+      inventoryLimit: 999,
       toolLevels,
       upgrade,
     }
@@ -62,6 +68,14 @@ describe('<UpgradePurchase />', () => {
   })
 
   describe('handle upgrade', () => {
+    test('it does not call handle upgrade if the player does not have the ingredients available', () => {
+      render(<UpgradePurchase {...props} inventory={[]} />)
+
+      screen.getByRole('button').click()
+
+      expect(props.handleUpgradeTool).not.toHaveBeenCalledWith(upgrade)
+    })
+
     test('it calls the provided callback to handle the upgrade action', () => {
       render(<UpgradePurchase {...props} />)
 

--- a/src/components/UpgradePurchase/UpgradePurchase.test.js
+++ b/src/components/UpgradePurchase/UpgradePurchase.test.js
@@ -73,7 +73,7 @@ describe('<UpgradePurchase />', () => {
 
       screen.getByRole('button').click()
 
-      expect(props.handleUpgradeTool).not.toHaveBeenCalledWith(upgrade)
+      expect(props.handleUpgradeTool).not.toHaveBeenCalled()
     })
 
     test('it calls the provided callback to handle the upgrade action', () => {


### PR DESCRIPTION
### What this PR does

fixes #271 by adding a 'disabled' attribute to the button in the `UpgradePurchase` component similar to how the others work

### How this change can be validated

Unlock the recipes for the tool upgrades but then try purchasing them when you don't actually have enough materials. on the current main branch it will happily let you purchase! with this change the buttons will be disabled and will not allow the purchase to be made. the logic for if the player has the available resources was already there, it just wasn't being used to disable the button.

here's a save that has the shovel unlocked and a few recipes: 
[farmhand-save-early-access-to-upgrades.json.zip](https://github.com/jeremyckahn/farmhand/files/8453806/farmhand-save-early-access-to-upgrades.json.zip)


### Questions or concerns about this change

Disabling buttons in this type of way isn't actually accessible. It ends up "removing" them from the DOM tree and then screen readers don't know they're there. Long term, disabling buttons should be visual only, and we have to add logic to the click handlers to prevent the action when it's not allowed. i went with the disabled route for this PR to match how the other areas of the UI are currently working and patch the hole for the majority to start. accessibility can be a separate effort since we know there are other issues here and there.

### Additional information

video of the bug: https://www.dropbox.com/s/14ebdad8ssvqadw/early%20access%20to%20upgrades.mov?dl=0

and the fix with disabled buttons:

<img width="593" alt="image" src="https://user-images.githubusercontent.com/628757/162481638-a8a67836-1769-4ef8-bb2e-6d12f69e1f2f.png">
