### PR TITLE
convert Achievement test from enzyme to rtl

### DIFF
--- a/src/components/Achievement/Achievement.js
+++ b/src/components/Achievement/Achievement.js
@@ -36,10 +36,10 @@ const Achievement = ({
 
 Achievement.propTypes = {
   achievement: shape({
-    description: string,
-    id: string,
-    name: string,
-    rewardDescription: string,
+    description: string.isRequired,
+    id: string.isRequired,
+    name: string.isRequired,
+    rewardDescription: string.isRequired,
   }).isRequired,
   completedAchievements: object.isRequired,
   isComplete: bool,

--- a/src/components/Achievement/Achievement.js
+++ b/src/components/Achievement/Achievement.js
@@ -6,7 +6,7 @@ import Card from '@material-ui/core/Card'
 import CardHeader from '@material-ui/core/CardHeader'
 import CardContent from '@material-ui/core/CardContent'
 import BeenhereIcon from '@material-ui/icons/Beenhere'
-import { bool, object } from 'prop-types'
+import { bool, object, shape, string } from 'prop-types'
 
 import FarmhandContext from '../../Farmhand.context'
 
@@ -35,7 +35,12 @@ const Achievement = ({
 )
 
 Achievement.propTypes = {
-  achievement: object.isRequired,
+  achievement: shape({
+    description: string,
+    id: string,
+    name: string,
+    rewardDescription: string,
+  }).isRequired,
   completedAchievements: object.isRequired,
   isComplete: bool,
 }

--- a/src/components/Achievement/Achievement.test.js
+++ b/src/components/Achievement/Achievement.test.js
@@ -1,16 +1,47 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+
+import FarmhandContext from '../../Farmhand.context'
 
 import Achievement from './Achievement'
 
-let component
+describe('<Achievement />', () => {
+  let achievementObject
 
-beforeEach(() => {
-  component = shallow(
-    <Achievement {...{ achievement: {}, completedAchievements: {} }} />
-  )
-})
+  beforeEach(() => {
+    achievementObject = {
+      description: 'the best achievement',
+      id: 'achievement-1',
+      name: 'achievement one',
+      rewardDescription: 'the greatest reward',
+    }
 
-test('renders', () => {
-  expect(component).toHaveLength(1)
+    const farmhandContextValue = {
+      gameState: {},
+      handlers: {},
+    }
+
+    render(
+      <FarmhandContext.Provider value={farmhandContextValue}>
+        <Achievement
+          achievement={achievementObject}
+          completedAchievements={{}}
+        />
+      </FarmhandContext.Provider>
+    )
+  })
+
+  test('renders the name of the achievement', () => {
+    expect(screen.getByText(achievementObject.name)).toBeInTheDocument()
+  })
+
+  test('renders the achievement description', () => {
+    expect(screen.getByText(achievementObject.description)).toBeInTheDocument()
+  })
+
+  test('renders the reward description', () => {
+    expect(
+      screen.getByText(new RegExp(achievementObject.rewardDescription))
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
### What this PR does

converts the Achievement test to use react testing library as part of the #269 effort. i also converted a proptype from an object to a shape because when i went to write the test i wasn't sure what achievement should look like without digging into the use.

### How this change can be validated

tests need to pass

### Questions or concerns about this change

n/a

### Additional information

n/a
