### PR TITLE
refactor: convert AccountingView spec from enzyme to testing-library

### DIFF
--- a/src/components/AccountingView/AccountingView.test.js
+++ b/src/components/AccountingView/AccountingView.test.js
@@ -45,7 +45,7 @@ describe('<AccountView />', () => {
       expect(screen.getByText('Loan Balance')).toBeInTheDocument()
     })
 
-    test('it displays the load input', () => {
+    test('it displays the loan input', () => {
       expect(screen.getByRole('textbox')).toBeInTheDocument()
     })
 

--- a/src/components/AccountingView/AccountingView.test.js
+++ b/src/components/AccountingView/AccountingView.test.js
@@ -1,23 +1,76 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import FarmhandContext from '../../Farmhand.context'
+
+import { STANDARD_LOAN_AMOUNT } from '../../constants'
 
 import AccountingView from './AccountingView'
 
-let component
+describe('<AccountView />', () => {
+  let handleClickLoanPaydownButton, handleClickTakeOutLoanButton
 
-beforeEach(() => {
-  component = shallow(
-    <AccountingView
-      {...{
-        handleClickLoanPaydownButton: () => {},
-        handleClickTakeOutLoanButton: () => {},
-        loanBalance: 0,
-        money: 0,
-      }}
-    />
-  )
-})
+  beforeEach(() => {
+    const contextValue = {
+      gameState: {},
+      handlers: {},
+    }
 
-test('renders', () => {
-  expect(component).toHaveLength(1)
+    handleClickLoanPaydownButton = jest.fn()
+    handleClickTakeOutLoanButton = jest.fn()
+
+    render(
+      <FarmhandContext.Provider value={contextValue}>
+        <AccountingView
+          {...{
+            handleClickLoanPaydownButton,
+            handleClickTakeOutLoanButton,
+            loanBalance: 1000,
+            money: 1,
+          }}
+        />
+      </FarmhandContext.Provider>
+    )
+  })
+
+  const getPayLoanButton = () =>
+    screen.getByRole('button', { name: 'Pay into loan' })
+
+  const getTakeOutLoanButton = () =>
+    screen.getByRole('button', { name: /Take out a \$(\d)+ loan/ })
+
+  describe('render', () => {
+    test('displays the heading', () => {
+      expect(screen.getByText('Loan Balance')).toBeInTheDocument()
+    })
+
+    test('it displays the load input', () => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    test('it has a button for paying the loan', () => {
+      expect(getPayLoanButton()).toBeInTheDocument()
+    })
+
+    test('it has a button for taking out a loan', () => {
+      expect(getTakeOutLoanButton()).toBeInTheDocument()
+    })
+  })
+
+  describe('interactions', () => {
+    it('calls the pay loan callback when pay loan is clicked', () => {
+      userEvent.click(getPayLoanButton())
+
+      expect(handleClickLoanPaydownButton).toHaveBeenCalledWith(1)
+    })
+
+    it('calls the take out loan callback when take out loan is pressed', () => {
+      userEvent.click(getTakeOutLoanButton())
+
+      expect(handleClickTakeOutLoanButton).toHaveBeenCalledWith(
+        STANDARD_LOAN_AMOUNT
+      )
+    })
+  })
 })


### PR DESCRIPTION
### What this PR does

Convert spec file from enzyme to using testing-library.

### How this change can be validated

if unit tests pass, it's good to go!

### Questions or concerns about this change

This isn't quite 100% coverage, but it's pretty close. There are currently two components in the `AccountingView.js` file and I think if the other was split out the coverage would be easier to achieve.

### Additional information

<img width="1122" alt="Screen Shot 2022-05-06 at 9 34 01 AM" src="https://user-images.githubusercontent.com/628757/167175252-00ae985c-b215-4516-8fa5-fef828ea0a76.png">
<img width="1336" alt="Screen Shot 2022-05-06 at 9 34 40 AM" src="https://user-images.githubusercontent.com/628757/167175255-5e832d1f-070b-43ff-9ca9-ac66131c4242.png">

