### PR TITLE
Lstebner/rtl tests take two

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -36,15 +36,21 @@ const getRemainingOnboardingAchievements = memoize(completedAchievements =>
   )
 )
 
+const environmentAllowsInstall = ['production', 'development'].includes(
+  process.env.NODE_ENV
+)
+
+const VALID_ORIGINS = [
+  'https://jeremyckahn.github.io',
+  'https://www.farmhand.life',
+  'http://localhost:3000',
+]
+
 // https://stackoverflow.com/questions/41742390/javascript-to-check-if-pwa-or-mobile-web/41749865#41749865
 const isInstallable =
-  // process.env checks are needed to make tests not fail
-  (process.env.NODE_ENV === 'production' ||
-    process.env.NODE_ENV === 'development') &&
+  environmentAllowsInstall &&
   !window.matchMedia('(display-mode: standalone)').matches &&
-  (window.location.origin === 'https://jeremyckahn.github.io' ||
-    window.location.origin === 'https://www.farmhand.life' ||
-    window.location.origin === 'http://localhost:3000') // For debugging
+  VALID_ORIGINS.includes(window.location.origin)
 
 const Home = ({
   completedAchievements,

--- a/src/components/Home/Home.test.js
+++ b/src/components/Home/Home.test.js
@@ -1,28 +1,45 @@
 import React from 'react'
 
 import { screen, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import FarmhandContext from '../Farmhand/Farmhand.context'
 
 import Home from './Home'
 
-beforeEach(() => {
-  const gameState = {
-    completedAchievements: {},
-  }
+describe('<Home />', () => {
+  let handleViewChangeButtonClick
 
-  render(
-    <FarmhandContext.Provider value={{ gameState, handlers: {} }}>
-      <Home
-        {...{
-          completedAchievements: {},
-          handleViewChangeButtonClick: () => {},
-        }}
-      />
-    </FarmhandContext.Provider>
-  )
-})
+  beforeEach(() => {
+    const gameState = {
+      completedAchievements: {},
+    }
 
-test('renders', () => {
-  expect(screen.getByText('Welcome!')).toBeInTheDocument()
+    handleViewChangeButtonClick = jest.fn()
+
+    render(
+      <FarmhandContext.Provider value={{ gameState, handlers: {} }}>
+        <Home handleViewChangeButtonClick={handleViewChangeButtonClick} />
+      </FarmhandContext.Provider>
+    )
+  })
+
+  test('rendered welcome message', () => {
+    expect(screen.getByText('Welcome!')).toBeInTheDocument()
+  })
+
+  describe('go to shop', () => {
+    const shopButton = () =>
+      screen.getByRole('button', { name: 'Go to the shop' })
+
+    test('contains an action to go to the shop', () => {
+      expect(shopButton()).toBeInTheDocument()
+    })
+
+    test('calls to change view when shop button is clicked', () => {
+      userEvent.click(shopButton())
+
+      expect(handleViewChangeButtonClick).toHaveBeenCalledWith('SHOP')
+    })
+  })
 })

--- a/src/components/Home/Home.test.js
+++ b/src/components/Home/Home.test.js
@@ -1,21 +1,28 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+
+import { screen, render } from '@testing-library/react'
+
+import FarmhandContext from '../Farmhand/Farmhand.context'
 
 import Home from './Home'
 
-let component
-
 beforeEach(() => {
-  component = shallow(
-    <Home
-      {...{
-        completedAchievements: {},
-        handleViewChangeButtonClick: () => {},
-      }}
-    />
+  const gameState = {
+    completedAchievements: {},
+  }
+
+  render(
+    <FarmhandContext.Provider value={{ gameState, handlers: {} }}>
+      <Home
+        {...{
+          completedAchievements: {},
+          handleViewChangeButtonClick: () => {},
+        }}
+      />
+    </FarmhandContext.Provider>
   )
 })
 
 test('renders', () => {
-  expect(component).toHaveLength(1)
+  expect(screen.getByText('Welcome!')).toBeInTheDocument()
 })

--- a/src/components/Workshop/ForgeTabPanel.js
+++ b/src/components/Workshop/ForgeTabPanel.js
@@ -19,6 +19,7 @@ import { getUpgradesAvailable } from './getUpgradesAvailable'
 
 export function ForgeTabPanel({
   currentTab,
+  index,
   learnedForgeRecipes,
   setCurrentTab,
   toolLevels,
@@ -29,7 +30,7 @@ export function ForgeTabPanel({
   })
 
   return (
-    <TabPanel value={currentTab} index={1}>
+    <TabPanel value={currentTab} index={index}>
       <RecipeList
         learnedRecipes={learnedForgeRecipes}
         allRecipes={recipeCategories[recipeType.FORGE]}
@@ -71,6 +72,7 @@ export function ForgeTabPanel({
 
 ForgeTabPanel.propTypes = {
   currentTab: PropTypes.number.isRequired,
+  index: PropTypes.number.isRequired,
   learnedForgeRecipes: PropTypes.array.isRequired,
   setCurrentTab: PropTypes.func.isRequired,
   toolLevels: PropTypes.object.isRequired,

--- a/src/components/Workshop/ForgeTabPanel.js
+++ b/src/components/Workshop/ForgeTabPanel.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Card from '@material-ui/core/Card'
+import CardContent from '@material-ui/core/CardContent'
+import Divider from '@material-ui/core/Divider'
+import ReactMarkdown from 'react-markdown'
+
+import { recipeType } from '../../enums'
+
+import { recipeCategories } from '../../data/maps'
+
+import UpgradePurchase from '../UpgradePurchase'
+
+import { TabPanel } from './TabPanel'
+import { RecipeList } from './RecipeList'
+
+import { getUpgradesAvailable } from './getUpgradesAvailable'
+
+export function ForgeTabPanel({
+  currentTab,
+  learnedForgeRecipes,
+  setCurrentTab,
+  toolLevels,
+}) {
+  const upgradesAvailable = getUpgradesAvailable({
+    toolLevels,
+    learnedForgeRecipes,
+  })
+
+  return (
+    <TabPanel value={currentTab} index={1}>
+      <RecipeList
+        learnedRecipes={learnedForgeRecipes}
+        allRecipes={recipeCategories[recipeType.FORGE]}
+      />
+      {upgradesAvailable.length ? (
+        <>
+          <Divider />
+          <ul className="card-list">
+            <li>
+              <h4>Tool Upgrades</h4>
+            </li>
+            {upgradesAvailable.map(upgrade => (
+              <li key={upgrade.id}>
+                <UpgradePurchase upgrade={upgrade} />
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+      <Divider />
+      <ul className="card-list">
+        <li>
+          <Card>
+            <CardContent>
+              <ReactMarkdown
+                {...{
+                  linkTarget: '_blank',
+                  className: 'markdown',
+                  source: `Forge Recipes are learned by selling resources mined from the field.`,
+                }}
+              />
+            </CardContent>
+          </Card>
+        </li>
+      </ul>
+    </TabPanel>
+  )
+}
+
+ForgeTabPanel.propTypes = {
+  currentTab: PropTypes.number.isRequired,
+  learnedForgeRecipes: PropTypes.array.isRequired,
+  setCurrentTab: PropTypes.func.isRequired,
+  toolLevels: PropTypes.object.isRequired,
+}

--- a/src/components/Workshop/KitchenTabPanel.js
+++ b/src/components/Workshop/KitchenTabPanel.js
@@ -15,11 +15,12 @@ import { RecipeList } from './RecipeList'
 
 export function KitchenTabPanel({
   currentTab,
-  setCurrentTab,
+  index,
   learnedKitchenRecipes,
+  setCurrentTab,
 }) {
   return (
-    <TabPanel value={currentTab} index={0}>
+    <TabPanel value={currentTab} index={index}>
       <RecipeList
         learnedRecipes={learnedKitchenRecipes}
         allRecipes={recipeCategories[recipeType.KITCHEN]}
@@ -46,6 +47,7 @@ export function KitchenTabPanel({
 
 KitchenTabPanel.propTypes = {
   currentTab: PropTypes.number.isRequired,
-  setCurrentTab: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired,
   learnedKitchenRecipes: PropTypes.array.isRequired,
+  setCurrentTab: PropTypes.func.isRequired,
 }

--- a/src/components/Workshop/KitchenTabPanel.js
+++ b/src/components/Workshop/KitchenTabPanel.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Card from '@material-ui/core/Card'
+import CardContent from '@material-ui/core/CardContent'
+import Divider from '@material-ui/core/Divider'
+import ReactMarkdown from 'react-markdown'
+
+import { recipeType } from '../../enums'
+
+import { recipeCategories } from '../../data/maps'
+
+import { TabPanel } from './TabPanel'
+import { RecipeList } from './RecipeList'
+
+export function KitchenTabPanel({
+  currentTab,
+  setCurrentTab,
+  learnedKitchenRecipes,
+}) {
+  return (
+    <TabPanel value={currentTab} index={0}>
+      <RecipeList
+        learnedRecipes={learnedKitchenRecipes}
+        allRecipes={recipeCategories[recipeType.KITCHEN]}
+      />
+      <Divider />
+      <ul className="card-list">
+        <li>
+          <Card>
+            <CardContent>
+              <ReactMarkdown
+                {...{
+                  linkTarget: '_blank',
+                  className: 'markdown',
+                  source: `Kitchen recipes are learned by selling crops and animal products. Sell as much as you can of a wide variety of items!`,
+                }}
+              />
+            </CardContent>
+          </Card>
+        </li>
+      </ul>
+    </TabPanel>
+  )
+}
+
+KitchenTabPanel.propTypes = {
+  currentTab: PropTypes.number.isRequired,
+  setCurrentTab: PropTypes.func.isRequired,
+  learnedKitchenRecipes: PropTypes.array.isRequired,
+}

--- a/src/components/Workshop/RecipeList.js
+++ b/src/components/Workshop/RecipeList.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Recipe from '../Recipe'
+
+export function RecipeList({ allRecipes, learnedRecipes }) {
+  const numLearnedRecipes = learnedRecipes.length
+  const totalRecipes = Object.keys(allRecipes).length
+
+  return (
+    <>
+      <h3>
+        Learned Recipes ({numLearnedRecipes} / {totalRecipes})
+      </h3>
+      <ul className="card-list">
+        {learnedRecipes.map(recipeId => (
+          <li key={recipeId}>
+            <Recipe
+              {...{
+                recipe: allRecipes[recipeId],
+              }}
+            />
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+RecipeList.propTypes = {
+  allRecipes: PropTypes.object.isRequired,
+  learnedRecipes: PropTypes.array.isRequired,
+}

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { bool, object } from 'prop-types'
+import { number, object } from 'prop-types'
 import AppBar from '@material-ui/core/AppBar'
 import Tab from '@material-ui/core/Tab'
 import Tabs from '@material-ui/core/Tabs'
@@ -45,12 +45,14 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
       </AppBar>
       <KitchenTabPanel
         currentTab={currentTab}
-        setCurrentTab={setCurrentTab}
+        index={0}
         learnedKitchenRecipes={learnedKitchenRecipes}
+        setCurrentTab={setCurrentTab}
       />
       {showForge ? (
         <ForgeTabPanel
           currentTab={currentTab}
+          index={1}
           learnedForgeRecipes={learnedForgeRecipes}
           setCurrentTab={setCurrentTab}
           toolLevels={toolLevels}
@@ -62,7 +64,7 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
 
 Workshop.propTypes = {
   learnedRecipes: object.isRequired,
-  purchasedSmelter: bool,
+  purchasedSmelter: number,
   toolLevels: object.isRequired,
 }
 

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -12,7 +12,6 @@ import { features } from '../../config'
 import { recipeType } from '../../enums'
 
 import { recipeCategories, recipesMap } from '../../data/maps'
-import toolUpgrades from '../../data/upgrades'
 
 import Recipe from '../Recipe'
 import UpgradePurchase from '../UpgradePurchase'
@@ -62,8 +61,6 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
   const upgradesAvailable = getUpgradesAvailable({
     toolLevels,
     learnedForgeRecipes,
-    toolUpgrades,
-    recipesMap,
   })
 
   const showForge = features.MINING && purchasedSmelter

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { object } from 'prop-types'
+import { bool, object } from 'prop-types'
 import Card from '@material-ui/core/Card'
 import CardContent from '@material-ui/core/CardContent'
 import Divider from '@material-ui/core/Divider'
@@ -201,6 +201,8 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
 
 Workshop.propTypes = {
   learnedRecipes: object.isRequired,
+  purchasedSmelter: bool,
+  toolLevels: object.isRequired,
 }
 
 export default function Consumer(props) {

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -21,6 +21,8 @@ import FarmhandContext from '../Farmhand/Farmhand.context'
 
 import { TabPanel, a11yProps } from './TabPanel'
 
+import { getUpgradesAvailable } from './getUpgradesAvailable'
+
 import './Workshop.sass'
 
 /**
@@ -49,38 +51,6 @@ const getLearnedRecipeCategories = learnedRecipes => {
   return { learnedKitchenRecipes, learnedForgeRecipes }
 }
 
-/**
- * Get available upgrades based on current tool levels and unlocked recipes
- * @param {object} toolLevels - the current level of each tool
- * @param {array} learnedRecipes - list of learned recipes from farmhand state
- * @returns {array} a list of all applicable upgrades
- */
-const getUpgradesAvailable = (toolLevels, learnedRecipes) => {
-  let upgradesAvailable = []
-  const learnedRecipeIds = learnedRecipes.map(r => r.id)
-
-  for (let type of Object.keys(toolUpgrades)) {
-    let upgrade = toolUpgrades[type][toolLevels[type]]
-
-    if (upgrade && !upgrade.isMaxLevel && upgrade.nextLevel) {
-      const nextLevelUpgrade = toolUpgrades[type][upgrade.nextLevel]
-      let allIngredientsUnlocked = true
-
-      for (let ingredient of Object.keys(nextLevelUpgrade.ingredients)) {
-        allIngredientsUnlocked =
-          allIngredientsUnlocked &&
-          !!(!recipesMap[ingredient] || learnedRecipeIds.includes(ingredient))
-      }
-
-      if (allIngredientsUnlocked) {
-        upgradesAvailable.push(nextLevelUpgrade)
-      }
-    }
-  }
-
-  return upgradesAvailable
-}
-
 const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
   const [currentTab, setCurrentTab] = useState(0)
 
@@ -89,10 +59,12 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
     learnedForgeRecipes,
   } = getLearnedRecipeCategories(learnedRecipes)
 
-  const upgradesAvailable = getUpgradesAvailable(
+  const upgradesAvailable = getUpgradesAvailable({
     toolLevels,
-    learnedForgeRecipes
-  )
+    learnedForgeRecipes,
+    toolUpgrades,
+    recipesMap,
+  })
 
   const showForge = features.MINING && purchasedSmelter
 

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -1,9 +1,5 @@
 import React, { useState } from 'react'
 import { bool, object } from 'prop-types'
-import Card from '@material-ui/core/Card'
-import CardContent from '@material-ui/core/CardContent'
-import Divider from '@material-ui/core/Divider'
-import ReactMarkdown from 'react-markdown'
 import AppBar from '@material-ui/core/AppBar'
 import Tab from '@material-ui/core/Tab'
 import Tabs from '@material-ui/core/Tabs'
@@ -11,57 +7,27 @@ import Tabs from '@material-ui/core/Tabs'
 import { features } from '../../config'
 import { recipeType } from '../../enums'
 
-import { recipeCategories, recipesMap } from '../../data/maps'
-
-import Recipe from '../Recipe'
-import UpgradePurchase from '../UpgradePurchase'
+import { recipesMap } from '../../data/maps'
 
 import FarmhandContext from '../Farmhand/Farmhand.context'
 
-import { TabPanel, a11yProps } from './TabPanel'
+import { a11yProps } from './TabPanel'
 
-import { getUpgradesAvailable } from './getUpgradesAvailable'
+import { ForgeTabPanel } from './ForgeTabPanel'
+import { KitchenTabPanel } from './KitchenTabPanel'
 
 import './Workshop.sass'
-
-/**
- * @param {Array.<Object.<string, true>>} learnedRecipes
- * @returns {{ learnedKitchenRecipes: Array.<farmhand.recipe>, learnedForgeRecipes: Array.<farmhand.recipe>}}
- */
-const getLearnedRecipeCategories = learnedRecipes => {
-  const learnedKitchenRecipes = []
-  const learnedForgeRecipes = []
-
-  for (const learnedRecipeId of Object.keys(learnedRecipes)) {
-    const learnedRecipe = recipesMap[learnedRecipeId]
-
-    switch (learnedRecipe.recipeType) {
-      case recipeType.KITCHEN:
-        learnedKitchenRecipes.push(learnedRecipe)
-        break
-      case recipeType.FORGE:
-        learnedForgeRecipes.push(learnedRecipe)
-        break
-      default:
-        throw new Error(`Received invalid recipe ID: ${learnedRecipeId}`)
-    }
-  }
-
-  return { learnedKitchenRecipes, learnedForgeRecipes }
-}
 
 const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
   const [currentTab, setCurrentTab] = useState(0)
 
-  const {
-    learnedKitchenRecipes,
-    learnedForgeRecipes,
-  } = getLearnedRecipeCategories(learnedRecipes)
+  const learnedKitchenRecipes = Object.keys(learnedRecipes).filter(
+    recipeId => recipesMap[recipeId].recipeType === recipeType.KITCHEN
+  )
 
-  const upgradesAvailable = getUpgradesAvailable({
-    toolLevels,
-    learnedForgeRecipes,
-  })
+  const learnedForgeRecipes = Object.keys(learnedRecipes).filter(
+    recipeId => recipesMap[recipeId].recipeType === recipeType.FORGE
+  )
 
   const showForge = features.MINING && purchasedSmelter
 
@@ -77,88 +43,18 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
           {showForge ? <Tab {...{ label: 'Forge', ...a11yProps(1) }} /> : null}
         </Tabs>
       </AppBar>
-      <TabPanel value={currentTab} index={0}>
-        <h3>
-          Learned Recipes ({learnedKitchenRecipes.length} /{' '}
-          {Object.keys(recipeCategories[recipeType.KITCHEN]).length})
-        </h3>
-        <ul className="card-list">
-          {learnedKitchenRecipes.map(({ id: recipeId }) => (
-            <li key={recipeId}>
-              <Recipe
-                {...{
-                  recipe: recipeCategories[recipeType.KITCHEN][recipeId],
-                }}
-              />
-            </li>
-          ))}
-        </ul>
-        <Divider />
-        <ul className="card-list">
-          <li>
-            <Card>
-              <CardContent>
-                <ReactMarkdown
-                  {...{
-                    linkTarget: '_blank',
-                    className: 'markdown',
-                    source: `Kitchen recipes are learned by selling crops and animal products. Sell as much as you can of a wide variety of items!`,
-                  }}
-                />
-              </CardContent>
-            </Card>
-          </li>
-        </ul>
-      </TabPanel>
+      <KitchenTabPanel
+        currentTab={currentTab}
+        setCurrentTab={setCurrentTab}
+        learnedKitchenRecipes={learnedKitchenRecipes}
+      />
       {showForge ? (
-        <TabPanel value={currentTab} index={1}>
-          <h3>
-            Learned Recipes ({learnedForgeRecipes.length} /{' '}
-            {Object.keys(recipeCategories[recipeType.FORGE]).length})
-          </h3>
-          <ul className="card-list">
-            {learnedForgeRecipes.map(({ id: recipeId }) => (
-              <li key={recipeId}>
-                <Recipe
-                  {...{
-                    recipe: recipeCategories[recipeType.FORGE][recipeId],
-                  }}
-                />
-              </li>
-            ))}
-          </ul>
-          {upgradesAvailable.length ? (
-            <>
-              <Divider />
-              <ul className="card-list">
-                <li>
-                  <h4>Tool Upgrades</h4>
-                </li>
-                {upgradesAvailable.map(upgrade => (
-                  <li key={upgrade.id}>
-                    <UpgradePurchase upgrade={upgrade} />
-                  </li>
-                ))}
-              </ul>
-            </>
-          ) : null}
-          <Divider />
-          <ul className="card-list">
-            <li>
-              <Card>
-                <CardContent>
-                  <ReactMarkdown
-                    {...{
-                      linkTarget: '_blank',
-                      className: 'markdown',
-                      source: `Forge Recipes are learned by selling resources mined from the field.`,
-                    }}
-                  />
-                </CardContent>
-              </Card>
-            </li>
-          </ul>
-        </TabPanel>
+        <ForgeTabPanel
+          currentTab={currentTab}
+          learnedForgeRecipes={learnedForgeRecipes}
+          setCurrentTab={setCurrentTab}
+          toolLevels={toolLevels}
+        />
       ) : null}
     </div>
   )

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -98,10 +98,6 @@ const Workshop = ({ learnedRecipes, purchasedSmelter, toolLevels }) => {
         </ul>
         <Divider />
         <ul className="card-list">
-          {/*
-          This really isn't a list, but it makes it easy to keep the UI
-          consistent.
-        */}
           <li>
             <Card>
               <CardContent>

--- a/src/components/Workshop/Workshop.test.js
+++ b/src/components/Workshop/Workshop.test.js
@@ -93,7 +93,7 @@ describe('<Workshop />', () => {
   })
 
   describe('forge', () => {
-    describe('has not purchased smelter', () => {
+    describe('player has not purchased the smelter', () => {
       test('is not rendered', () => {
         renderWorkshop(gameState)
 
@@ -101,7 +101,7 @@ describe('<Workshop />', () => {
       })
     })
 
-    describe('has purchased smelter', () => {
+    describe('player has purchased the smelter', () => {
       beforeEach(() => {
         getUpgradesAvailable.mockReturnValue([])
 

--- a/src/components/Workshop/Workshop.test.js
+++ b/src/components/Workshop/Workshop.test.js
@@ -4,7 +4,11 @@ import userEvent from '@testing-library/user-event'
 
 import FarmhandContext from '../Farmhand/Farmhand.context'
 
+import { getUpgradesAvailable } from './getUpgradesAvailable'
+
 import Workshop from './Workshop'
+
+jest.mock('./getUpgradesAvailable')
 
 jest.mock('../../data/maps', () => ({
   ...jest.requireActual('../../data/maps'),
@@ -37,7 +41,10 @@ jest.mock('../../data/maps', () => ({
   },
 }))
 
-jest.mock('../Recipe', () => props => <div data-testid="Recipe">Recipe</div>)
+jest.mock('../Recipe', () => () => <div data-testid="Recipe">Recipe</div>)
+jest.mock('../UpgradePurchase', () => () => (
+  <div data-testid="UpgradePurchase">UpgradePurchase</div>
+))
 
 describe('<Workshop />', () => {
   let gameState = {
@@ -96,6 +103,8 @@ describe('<Workshop />', () => {
 
     describe('has purchased smelter', () => {
       beforeEach(() => {
+        getUpgradesAvailable.mockReturnValue([])
+
         gameState.purchasedSmelter = true
         gameState.learnedRecipes = {
           'forge-recipe-1': true,
@@ -113,6 +122,27 @@ describe('<Workshop />', () => {
 
       test('renders a Recipe card for each learned recipe', () => {
         expect(screen.getAllByTestId('Recipe')).toHaveLength(2)
+      })
+    })
+
+    describe('has upgrades available', () => {
+      beforeEach(() => {
+        const availableUpgrades = [{ id: 'upgrade-1' }, { id: 'upgrade-2' }]
+
+        getUpgradesAvailable.mockReturnValue(availableUpgrades)
+        gameState.purchasedSmelter = true
+
+        renderWorkshop(gameState)
+
+        userEvent.click(screen.getByText('Forge'))
+      })
+
+      test('renders upgrades heading', () => {
+        expect(screen.getByText('Tool Upgrades')).toBeInTheDocument()
+      })
+
+      it('renders an UpgradePurchase card for each upgrade available', () => {
+        expect(screen.getAllByTestId('UpgradePurchase')).toHaveLength(2)
       })
     })
   })

--- a/src/components/Workshop/Workshop.test.js
+++ b/src/components/Workshop/Workshop.test.js
@@ -49,7 +49,7 @@ jest.mock('../UpgradePurchase', () => () => (
 describe('<Workshop />', () => {
   let gameState = {
     learnedRecipes: {},
-    purchasedSmelter: false,
+    purchasedSmelter: 0,
     toolLevels: {},
   }
 
@@ -64,13 +64,13 @@ describe('<Workshop />', () => {
   describe('kitchen', () => {
     let numLearnedRecipes = 0
     beforeEach(() => {
-      numLearnedRecipes = Object.keys(gameState.learnedRecipes).length
-
       gameState.learnedRecipes = {
         'kitchen-recipe-1': true,
         'kitchen-recipe-2': true,
         'kitchen-recipe-3': true,
       }
+
+      numLearnedRecipes = Object.keys(gameState.learnedRecipes).length
 
       renderWorkshop(gameState)
     })
@@ -105,7 +105,7 @@ describe('<Workshop />', () => {
       beforeEach(() => {
         getUpgradesAvailable.mockReturnValue([])
 
-        gameState.purchasedSmelter = true
+        gameState.purchasedSmelter = 1
         gameState.learnedRecipes = {
           'forge-recipe-1': true,
           'forge-recipe-2': true,
@@ -130,7 +130,7 @@ describe('<Workshop />', () => {
         const availableUpgrades = [{ id: 'upgrade-1' }, { id: 'upgrade-2' }]
 
         getUpgradesAvailable.mockReturnValue(availableUpgrades)
-        gameState.purchasedSmelter = true
+        gameState.purchasedSmelter = 1
 
         renderWorkshop(gameState)
 

--- a/src/components/Workshop/Workshop.test.js
+++ b/src/components/Workshop/Workshop.test.js
@@ -14,15 +14,30 @@ jest.mock('../../data/maps', () => ({
       name: 'kitchen recipe 1',
       recipeType: 'KITCHEN',
     },
+    'kitchen-recipe-2': {
+      id: 'kitchen-recipe-2',
+      name: 'kitchen recipe 2',
+      recipeType: 'KITCHEN',
+    },
+    'kitchen-recipe-3': {
+      id: 'kitchen-recipe-3',
+      name: 'kitchen recipe 3',
+      recipeType: 'KITCHEN',
+    },
     'forge-recipe-1': {
       id: 'forge-recipe-1',
       name: 'forge recipe 1',
       recipeType: 'FORGE',
     },
+    'forge-recipe-2': {
+      id: 'forge-recipe-2',
+      name: 'forge recipe 2',
+      recipeType: 'FORGE',
+    },
   },
 }))
 
-jest.mock('../Recipe', () => () => 'Recipe')
+jest.mock('../Recipe', () => props => <div data-testid="Recipe">Recipe</div>)
 
 describe('<Workshop />', () => {
   let gameState = {
@@ -46,6 +61,8 @@ describe('<Workshop />', () => {
 
       gameState.learnedRecipes = {
         'kitchen-recipe-1': true,
+        'kitchen-recipe-2': true,
+        'kitchen-recipe-3': true,
       }
 
       renderWorkshop(gameState)
@@ -64,10 +81,7 @@ describe('<Workshop />', () => {
     })
 
     test('renders a Recipe card for each learned recipe', () => {
-      const recipesList = screen.getByText('Learned Recipes', { exact: false })
-        .nextElementSibling
-
-      expect(recipesList.querySelectorAll('li')).toHaveLength(numLearnedRecipes)
+      expect(screen.getAllByTestId('Recipe')).toHaveLength(numLearnedRecipes)
     })
   })
 
@@ -85,6 +99,7 @@ describe('<Workshop />', () => {
         gameState.purchasedSmelter = true
         gameState.learnedRecipes = {
           'forge-recipe-1': true,
+          'forge-recipe-2': true,
         }
 
         renderWorkshop(gameState)
@@ -97,11 +112,7 @@ describe('<Workshop />', () => {
       })
 
       test('renders a Recipe card for each learned recipe', () => {
-        const recipesList = screen.getByText('Learned Recipes', {
-          exact: false,
-        }).nextElementSibling
-
-        expect(recipesList.querySelectorAll('li')).toHaveLength(1)
+        expect(screen.getAllByTestId('Recipe')).toHaveLength(2)
       })
     })
   })

--- a/src/components/Workshop/Workshop.test.js
+++ b/src/components/Workshop/Workshop.test.js
@@ -1,20 +1,72 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { screen, render } from '@testing-library/react'
+
+import FarmhandContext from '../Farmhand/Farmhand.context'
 
 import Workshop from './Workshop'
 
-let component
+jest.mock('../../data/maps', () => ({
+  ...jest.requireActual('../../data/maps'),
+  recipesMap: {
+    'kitchen-recipe-1': {
+      id: 'kitchen-recipe-1',
+      name: 'kitchen recipe 1',
+      recipeType: 'KITCHEN',
+    },
+  },
+}))
 
-beforeEach(() => {
-  component = shallow(
-    <Workshop
-      {...{
-        learnedRecipes: {},
-      }}
-    />
-  )
-})
+jest.mock('../Recipe', () => () => 'Recipe')
 
-test('renders', () => {
-  expect(component).toHaveLength(1)
+describe('<Workshop />', () => {
+  let gameState = {
+    learnedRecipes: {},
+    purchasedSmelter: false,
+    toolLevels: {},
+  }
+
+  const renderWorkshop = gameState => {
+    render(
+      <FarmhandContext.Provider value={{ gameState, handlers: {} }}>
+        <Workshop />
+      </FarmhandContext.Provider>
+    )
+  }
+
+  describe('kitchen', () => {
+    test('is available', () => {
+      renderWorkshop(gameState)
+
+      expect(screen.getByText('Kitchen')).toBeInTheDocument()
+    })
+
+    test('renders learned recipes', () => {
+      gameState.learnedRecipes = {
+        'kitchen-recipe-1': true,
+      }
+      renderWorkshop(gameState)
+
+      expect(
+        screen.getByText('Learned Recipes (1', { exact: false })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('forge', () => {
+    test('is rendered if smelter is purchased', () => {
+      gameState.purchasedSmelter = true
+
+      renderWorkshop(gameState)
+
+      expect(screen.getByText('Forge')).toBeInTheDocument()
+    })
+
+    test('is not rendered if smelter is not purchased', () => {
+      gameState.purchasedSmelter = false
+
+      renderWorkshop(gameState)
+
+      expect(screen.queryByText('Forge')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/Workshop/getUpgradesAvailable.js
+++ b/src/components/Workshop/getUpgradesAvailable.js
@@ -1,0 +1,36 @@
+/**
+ * Get available upgrades based on current tool levels and unlocked recipes
+ * @param {object} toolLevels - the current level of each tool
+ * @param {array} learnedForgeRecipes - list of learned forge recipes from farmhand state
+ * @returns {array} a list of all applicable upgrades
+ */
+export function getUpgradesAvailable({
+  toolLevels,
+  learnedForgeRecipes,
+  toolUpgrades,
+  recipesMap,
+}) {
+  let upgradesAvailable = []
+  const learnedRecipeIds = learnedForgeRecipes.map(r => r.id)
+
+  for (let type of Object.keys(toolUpgrades)) {
+    let upgrade = toolUpgrades[type][toolLevels[type]]
+
+    if (upgrade && !upgrade.isMaxLevel && upgrade.nextLevel) {
+      const nextLevelUpgrade = toolUpgrades[type][upgrade.nextLevel]
+      let allIngredientsUnlocked = true
+
+      for (let ingredient of Object.keys(nextLevelUpgrade.ingredients)) {
+        allIngredientsUnlocked =
+          allIngredientsUnlocked &&
+          !!(!recipesMap[ingredient] || learnedRecipeIds.includes(ingredient))
+      }
+
+      if (allIngredientsUnlocked) {
+        upgradesAvailable.push(nextLevelUpgrade)
+      }
+    }
+  }
+
+  return upgradesAvailable
+}

--- a/src/components/Workshop/getUpgradesAvailable.js
+++ b/src/components/Workshop/getUpgradesAvailable.js
@@ -1,15 +1,13 @@
+import toolUpgrades from '../../data/upgrades'
+import { recipesMap } from '../../data/maps'
+
 /**
  * Get available upgrades based on current tool levels and unlocked recipes
- * @param {object} toolLevels - the current level of each tool
  * @param {array} learnedForgeRecipes - list of learned forge recipes from farmhand state
+ * @param {object} toolLevels - the current level of each tool
  * @returns {array} a list of all applicable upgrades
  */
-export function getUpgradesAvailable({
-  toolLevels,
-  learnedForgeRecipes,
-  toolUpgrades,
-  recipesMap,
-}) {
+export function getUpgradesAvailable({ learnedForgeRecipes, toolLevels }) {
   let upgradesAvailable = []
   const learnedRecipeIds = learnedForgeRecipes.map(r => r.id)
 

--- a/src/components/Workshop/getUpgradesAvailable.js
+++ b/src/components/Workshop/getUpgradesAvailable.js
@@ -12,7 +12,7 @@ export function getUpgradesAvailable({ learnedForgeRecipes, toolLevels }) {
   const learnedRecipeIds = learnedForgeRecipes.map(r => r.id)
 
   for (let type of Object.keys(toolUpgrades)) {
-    let upgrade = toolUpgrades[type][toolLevels[type]]
+    const upgrade = toolUpgrades[type][toolLevels[type]]
 
     if (upgrade && !upgrade.isMaxLevel && upgrade.nextLevel) {
       const nextLevelUpgrade = toolUpgrades[type][upgrade.nextLevel]

--- a/src/components/Workshop/getUpgradesAvailable.test.js
+++ b/src/components/Workshop/getUpgradesAvailable.test.js
@@ -1,0 +1,32 @@
+import { toolLevel, toolType } from '../../enums'
+
+import { getUpgradesAvailable } from './getUpgradesAvailable'
+
+describe('getUpgradesAvailable', () => {
+  const toolLevels = {
+    [toolType.HOE]: toolLevel.DEFAULT,
+    [toolType.SCYTHE]: toolLevel.DEFAULT,
+    [toolType.SHOVEL]: toolLevel.UNAVAILABLE,
+    [toolType.WATERING_CAN]: toolLevel.DEFAULT,
+  }
+
+  test('it returns an empty list if no upgrades are available', () => {
+    const availableUpgrades = getUpgradesAvailable({
+      toolLevels,
+      learnedForgeRecipes: [],
+    })
+
+    expect(availableUpgrades).toEqual([])
+  })
+
+  test('it returns a list of available upgrades when required recipes have been learned', () => {
+    const learnedForgeRecipes = [{ id: 'bronze-ingot' }]
+
+    const availableUpgrades = getUpgradesAvailable({
+      toolLevels,
+      learnedForgeRecipes,
+    }).map(item => item.id)
+
+    expect(availableUpgrades).toEqual(['hoe-bronze', 'scythe-bronze'])
+  })
+})


### PR DESCRIPTION
this is a recreation of PR #295 because I messed up the branch there beyond repair. it was much simpler to just whip up a new PR. my bad 😓 

### What this PR does

updates some enzyme based tests to use testing-library

- update tests for Home component
- update tests for Workshop component
- broke out helper for `getAvailableUpgrades` from workshop and added test for it too

once I had all these new tests in place I decided to refactor the Workshop component a bit. I broke it apart into some separate smaller components and simplified some of the logic, but I'm open to suggestions/feedback on this if it doesn't seem improved, or there's further improvement that comes to mind.

### How this change can be validated

- tests pass
- it's worth also taking a look at the Workshop to make sure the kitchen and forge recipes seem to still be arranged as expected

### Questions or concerns about this change

happy to refactor anything additional that stands out here