### PR TITLE
feat: Field landscape dislay

### DIFF
--- a/src/components/Farmhand/Farmhand.sass
+++ b/src/components/Farmhand/Farmhand.sass
@@ -150,7 +150,7 @@ body
         @media (max-width: 320px)
           margin: 0.25em 0.1em
 
-  @media (min-width: #{$break-md})
+  @media (orientation: landscape)
     &.menu-open .bottom-controls
       left: calc(50vw + #{$sidebar-width / 2})
 

--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -168,7 +168,7 @@ export const FieldContentWrapper = ({
         }}
       />
       <TransformComponent>{fieldContent}</TransformComponent>
-      <div className="fab-buttons zoom-controls right">
+      <div className="fab-buttons zoom-controls zoom-in-wrapper">
         <Tooltip
           {...{
             placement: 'top',
@@ -186,7 +186,7 @@ export const FieldContentWrapper = ({
           </Fab>
         </Tooltip>
       </div>
-      <div className="fab-buttons zoom-controls left">
+      <div className="fab-buttons zoom-controls zoom-out-wrapper">
         <Tooltip
           {...{
             placement: 'top',

--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -418,7 +418,6 @@ export const Field = props => {
           </div>
         )}
         <QuickSelect />
-        <div {...{ className: 'spacer' }} />
       </div>
     </>
   )

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -85,7 +85,7 @@ $appBarOffset: 135px
     flex-direction: column
     bottom: 1em
 
-    &.right
+    &.zoom-in-wrapper
       right: 0.5em
 
       @media (orientation: portrait)
@@ -94,7 +94,7 @@ $appBarOffset: 135px
       @media (orientation: landscape)
         bottom: 5.5em
 
-    &.left
+    &.zoom-out-wrapper
       @media (orientation: portrait)
         left: 0.5em
 

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -5,22 +5,8 @@ $appBarOffset: 135px
 .Field
   margin: 0 auto
 
-  @media (orientation: portrait)
-    @media (min-width: #{$break-sm})
-      padding-right: 5em
-
-    @media (min-width: #{$break-md})
-      &[data-purchased-field="0"]
-        max-width: calc(100vh * (6/10) - #{$appBarOffset})
-
-      &[data-purchased-field="1"]
-        max-width: calc(100vh * (8/12) - #{$appBarOffset})
-
-      &[data-purchased-field="2"]
-        max-width: calc(100vh * (10/16) - #{$appBarOffset})
-
-      &[data-purchased-field="3"]
-        max-width: calc(100vh * (12/18) - #{$appBarOffset})
+  @media (min-width: #{$break-medium-phone})
+    margin-top: 5em
 
   .spacer
     @media (orientation: portrait)
@@ -53,8 +39,8 @@ $appBarOffset: 135px
 
       @media (orientation: landscape)
         border-width: 2px
-        margin-bottom: -98%;
-        transform: translateY(-32.5%) scale(0.5) rotate(-90deg)
+        margin-bottom: -94%
+        transform: translateY(-32.5%) translateX(-4.5%) scale(0.6) rotate(-90deg)
 
   &[data-purchased-field="1"]
     .react-transform-element

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -54,8 +54,9 @@ $appBarOffset: 135px
       image-rendering: pixelated
 
       @media (orientation: landscape)
-        transform: translateY(-32.5%) scale(0.5) rotate(-90deg)
+        border-width: 2px
         margin-bottom: -98%;
+        transform: translateY(-32.5%) scale(0.5) rotate(-90deg)
 
   &[data-purchased-field="1"]
     .react-transform-element

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -85,6 +85,10 @@ $appBarOffset: 135px
     flex-direction: column
     bottom: 1em
 
+    @media (orientation: portrait)
+      .menu-open &
+        display: none
+
     &.zoom-in-wrapper
       right: 0.5em
 

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -23,10 +23,8 @@ $appBarOffset: 135px
         max-width: calc(100vh * (12/18) - #{$appBarOffset})
 
   .spacer
-    min-height: 12em
-
     @media (orientation: portrait)
-      min-height: 5em
+      min-height: 10em
 
   .row
     display: flex
@@ -73,7 +71,7 @@ $appBarOffset: 135px
   .slider-wrapper
     background: rgba(128, 128, 128, 0.75)
     border-radius: 2em
-    bottom: 13.5em
+    bottom: 7.5em
     left: 50%
     padding: 0 1em
     position: fixed
@@ -81,15 +79,11 @@ $appBarOffset: 135px
     transition: left $duration-entering-screen $easing-ease-out
     width: 250px
 
-    @media (min-width: #{$break-sm})
-      bottom: 7.5em
+    @media (orientation: portrait)
+      bottom: 13.5em
 
-    @media (min-width: #{$break-md})
-      .menu-open &
-        left: calc(50vw + #{$sidebar-width / 2})
-
-    @media (max-width: #{$break-medium-phone})
-      bottom: 11em
+    .menu-open &
+      left: calc(50vw + #{$sidebar-width / 2})
 
   .zoom-controls
     position: fixed
@@ -100,20 +94,17 @@ $appBarOffset: 135px
     &.right
       right: 0.5em
 
-      @media (max-width: #{$break-medium-phone})
+      @media (orientation: portrait)
         right: 0.25em
 
-      @media (min-width: #{$break-sm})
+      @media (orientation: landscape)
         bottom: 5.5em
 
     &.left
-      left: 0.5em
+      @media (orientation: portrait)
+        left: 0.5em
 
-      @media (max-width: #{$break-medium-phone})
-        left: 0.25em
-
-      @media (min-width: #{$break-sm})
-        left: auto
+      @media (orientation: landscape)
         right: 0.5em
 
     @media (max-width: #{$break-medium-phone})
@@ -128,4 +119,4 @@ $appBarOffset: 135px
     padding: 1em 0 0
 
     @media (orientation: landscape)
-      margin-bottom: 7.5em
+      margin-bottom: 10.5em

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -5,27 +5,28 @@ $appBarOffset: 135px
 .Field
   margin: 0 auto
 
-  @media (min-width: #{$break-sm})
-    padding-right: 5em
+  @media (orientation: portrait)
+    @media (min-width: #{$break-sm})
+      padding-right: 5em
 
-  @media (min-width: #{$break-md})
-    &[data-purchased-field="0"]
-      max-width: calc(100vh * (6/10) - #{$appBarOffset})
+    @media (min-width: #{$break-md})
+      &[data-purchased-field="0"]
+        max-width: calc(100vh * (6/10) - #{$appBarOffset})
 
-    &[data-purchased-field="1"]
-      max-width: calc(100vh * (8/12) - #{$appBarOffset})
+      &[data-purchased-field="1"]
+        max-width: calc(100vh * (8/12) - #{$appBarOffset})
 
-    &[data-purchased-field="2"]
-      max-width: calc(100vh * (10/16) - #{$appBarOffset})
+      &[data-purchased-field="2"]
+        max-width: calc(100vh * (10/16) - #{$appBarOffset})
 
-    &[data-purchased-field="3"]
-      max-width: calc(100vh * (12/18) - #{$appBarOffset})
+      &[data-purchased-field="3"]
+        max-width: calc(100vh * (12/18) - #{$appBarOffset})
 
   .spacer
-    min-height: 8em
+    min-height: 12em
 
-    @media (min-width: #{$break-sm})
-      min-height: 7.5em
+    @media (orientation: portrait)
+      min-height: 5em
 
   .row
     display: flex
@@ -42,12 +43,19 @@ $appBarOffset: 135px
     height: auto
     width: auto
 
+    @media (orientation: landscape)
+      height: 50vh
+
     .row-wrapper
       background-image: url('../../img/ui/dirt.png')
       border: solid 1px #000
       background-repeat: repeat
       background-size: calc(100% * (1 / 6) * 1.5)
       image-rendering: pixelated
+
+      @media (orientation: landscape)
+        transform: translateY(-32.5%) scale(0.5) rotate(-90deg)
+        margin-bottom: -98%;
 
   &[data-purchased-field="1"]
     .react-transform-element
@@ -117,3 +125,6 @@ $appBarOffset: 135px
     align-items: center
     display: flex
     padding: 1em 0 0
+
+    @media (orientation: landscape)
+      margin-bottom: 7.5em

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -68,6 +68,9 @@ $appBarOffset: 135px
     @media (orientation: portrait)
       bottom: 13.5em
 
+      .menu-open &
+        display: none
+
     .menu-open &
       left: calc(50vw + #{$sidebar-width / 2})
 

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -5,15 +5,21 @@ $appBarOffset: 135px
 .Field
   margin: 0 auto
 
+  @media (orientation: portrait)
+    margin-bottom: 10.5em
+  @media (orientation: landscape)
+    margin-bottom: 5em
+
   @media (min-width: #{$break-medium-phone})
     margin-top: 5em
 
-  .spacer
-    @media (orientation: portrait)
-      min-height: 10em
-
   .row
     display: flex
+    flex-direction: row
+    width: 100%
+
+    @media (orientation: landscape)
+      flex-direction: column-reverse
 
   .react-transform-component
     overflow: visible
@@ -27,9 +33,6 @@ $appBarOffset: 135px
     height: auto
     width: auto
 
-    @media (orientation: landscape)
-      height: 50vh
-
     .row-wrapper
       background-image: url('../../img/ui/dirt.png')
       border: solid 1px #000
@@ -37,10 +40,12 @@ $appBarOffset: 135px
       background-size: calc(100% * (1 / 6) * 1.5)
       image-rendering: pixelated
 
+      display: flex
+      flex-direction: column
+
       @media (orientation: landscape)
-        border-width: 2px
-        margin-bottom: -94%
-        transform: translateY(-32.5%) translateX(-4.5%) scale(0.6) rotate(-90deg)
+        flex-direction: row
+        margin-right: 4.5em
 
   &[data-purchased-field="1"]
     .react-transform-element
@@ -106,6 +111,3 @@ $appBarOffset: 135px
     align-items: center
     display: flex
     padding: 1em 0 0
-
-    @media (orientation: landscape)
-      margin-bottom: 10.5em

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -12,10 +12,6 @@
   flex-grow: 1
   image-rendering: pixelated
 
-  @media (orientation: landscape)
-    border-width: 2px
-    transform: rotate(90deg)
-
   &:hover
     background-color: $colorGenericHighlight
     cursor: pointer

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -13,6 +13,7 @@
   image-rendering: pixelated
 
   @media (orientation: landscape)
+    border-width: 2px
     transform: rotate(90deg)
 
   &:hover

--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -12,6 +12,9 @@
   flex-grow: 1
   image-rendering: pixelated
 
+  @media (orientation: landscape)
+    transform: rotate(90deg)
+
   &:hover
     background-color: $colorGenericHighlight
     cursor: pointer

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -8,7 +8,7 @@
   position: fixed
   transform: translateX(-50%)
 
-  @media (min-width: #{$break-sm})
+  @media (orientation: landscape)
     &.MuiPaper-root // Specificity is needed for card-style overrides
       @include card-style
       bottom: auto
@@ -31,13 +31,13 @@
     display: flex
     flex-flow: row
 
-    @media (min-width: #{$break-sm})
+    @media (orientation: landscape)
       flex-flow: column
 
-  @media (max-width: #{$break-medium-phone})
-    bottom: 6em
+  @media (orientation: portrait)
+    bottom: 7.5em
 
-  @media (max-width: #{$break-sm})
+  @media (orientation: portrait)
     .menu-open &
       display: none
 
@@ -48,18 +48,18 @@
     padding: .5em
     position: relative
 
-    @media (min-width: #{$break-sm})
+    @media (orientation: landscape)
       overflow-x: hidden
 
     > *
-      @media (min-width: #{$break-sm})
+      @media (orientation: landscape)
         align-items: center
         width: 3em
 
-    @media (max-width: #{$break-sm})
+    @media (orientation: portrait)
       @include card-style
 
-    @media (min-width: #{$break-sm})
+    @media (orientation: landscape)
       flex-direction: column
 
   .Toolbelt
@@ -78,7 +78,7 @@
   .MuiDivider-root
     margin: 0 0.5em
 
-    @media (min-width: #{$break-sm})
+    @media (orientation: landscape)
       margin: 0 0 1em 0
       height: 1px
       width: 100%

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -2,40 +2,41 @@
 @import ../../styles/utils.sass
 
 .QuickSelect
-  bottom: 8em
+  bottom: 7.5em
   left: 50%
-  max-width: calc(100% - 1em)
+  max-width: calc(100% - 12em)
   position: fixed
   transform: translateX(-50%)
 
-  @media (orientation: landscape)
-    &.MuiPaper-root // Specificity is needed for card-style overrides
-      @include card-style
-      bottom: auto
-      left: auto
-      max-height: calc(100vh - 20em)
-      min-width: 4em
-      overflow: auto
-      right: 0.75em
-      top: 9em
-      transform: none
+  &.MuiPaper-root // Specificity is needed for card-style overrides
+    @include card-style
 
-  // This specificity is needed to overwrite MUI Paper transition styles.
-  &.MuiPaper-root
-    transition: max-width $duration-entering-screen $easing-ease-out
+  @media (orientation: landscape) and (min-height: #{$break-large-phone})
+    bottom: auto
+    left: auto
+    max-height: calc(100vh - 20em)
+    min-width: 4em
+    overflow: auto
+    right: 0.75em
+    top: 9em
+    transform: none
 
-  .menu-open &
-    max-width: calc(100% - 1em - #{2 * $sidebar-width})
+  @media (orientation: landscape) and (max-height: #{$break-large-phone})
+    bottom: auto
+    top: 5em
+
+    .menu-open &
+      display: none
 
   .button-array
     display: flex
     flex-flow: row
 
-    @media (orientation: landscape)
+    @media (orientation: landscape) and (min-height: #{$break-large-phone})
       flex-flow: column
 
-  @media (orientation: portrait)
-    bottom: 7.5em
+  @media (orientation: landscape) and (min-height: #{$break-large-phone})
+    bottom: 8em
 
   @media (orientation: portrait)
     .menu-open &
@@ -48,18 +49,15 @@
     padding: .5em
     position: relative
 
-    @media (orientation: landscape)
+    @media (orientation: landscape) and (min-height: #{$break-large-phone})
       overflow-x: hidden
 
     > *
-      @media (orientation: landscape)
+      @media (orientation: landscape) and (min-height: #{$break-large-phone})
         align-items: center
         width: 3em
 
-    @media (orientation: portrait)
-      @include card-style
-
-    @media (orientation: landscape)
+    @media (orientation: landscape) and (min-height: #{$break-large-phone})
       flex-direction: column
 
   .Toolbelt
@@ -78,7 +76,7 @@
   .MuiDivider-root
     margin: 0 0.5em
 
-    @media (orientation: landscape)
+    @media (orientation: landscape) and (min-height: #{$break-large-phone})
       margin: 0 0 1em 0
       height: 1px
       width: 100%


### PR DESCRIPTION
### What this PR does

This PR changes the Field to make a better use of screen space on wider screens. It simplifies the overall responsive design of the UI to leverage `orientation` media queries rather than specific pixel breakpoints. 

### How this change can be validated

View the Field in a variety of scenarios (portrait, landscape, menu open/closed) on a variety of devices (desktop/laptop, mobile, tablet) and make sure everything is accessible.

### Questions or concerns about this change

There are areas where this could still be improved, but I think it's a net positive so far!

### Additional information

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/366330/177214082-e0947060-1e30-4ea3-9ab1-1e535d4ee7b7.png)

![image](https://user-images.githubusercontent.com/366330/177214130-e289878c-27f8-4ca4-a230-16f4463ad0a4.png)

![image](https://user-images.githubusercontent.com/366330/177214147-09a01b8b-7b6a-48bc-b306-bb952b4bc08a.png)

![image](https://user-images.githubusercontent.com/366330/177214207-884a3afb-2601-4d00-a385-09cbe737c46f.png)

![image](https://user-images.githubusercontent.com/366330/177214239-16126b5a-68ec-494a-818c-0acda1968601.png)

![image](https://user-images.githubusercontent.com/366330/177214269-6b206d0b-9a2d-4b72-b678-ee2c598f00ee.png)

![image](https://user-images.githubusercontent.com/366330/177214337-7beff67a-dd45-4cc8-a05e-16047fe75193.png)

![image](https://user-images.githubusercontent.com/366330/177214372-aa2c241a-41c6-4ab7-a0b5-63c84a52ed86.png)

![image](https://user-images.githubusercontent.com/366330/177214385-99a76976-e2f9-4919-9447-1dd0062ff718.png)

![image](https://user-images.githubusercontent.com/366330/177214423-50bf020c-7f28-4aa4-81b9-4aae38a4a93d.png)

![image](https://user-images.githubusercontent.com/366330/177214471-0aa1ce47-4312-48c7-909c-616257a68bc9.png)

![image](https://user-images.githubusercontent.com/366330/177214454-cf0d7328-8498-44e7-a735-7c233f637c7b.png)

</details>