### PR TITLE
feat: Give QuickSelect more space

### DIFF
--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -4,7 +4,7 @@
 .QuickSelect
   bottom: 7.5em
   left: 50%
-  max-width: calc(100% - 12em)
+  max-width: calc(100% - 2em)
   position: fixed
   transform: translateX(-50%)
 


### PR DESCRIPTION
### What this PR does

This PR follows up #300 to give the QuickSelect bar more space. This is helpful for smaller screens where the bar was really narrow.

### How this change can be validated

Ensure the QuickSelect bar has enough space in all scenarios where it shows.

### Questions or concerns about this change

### Additional information

Before this change:
![Screen Shot 2022-07-10 at 17 55 54](https://user-images.githubusercontent.com/366330/178165197-a99df815-edb3-49d5-a658-349d2892acfc.png)

After this change:
![Screen Shot 2022-07-10 at 17 56 22](https://user-images.githubusercontent.com/366330/178165209-419be163-3692-4ca7-9344-7bc9f692f640.png)