### PR TITLE
fix: Do not overlap End Day button with QuickSelect

### DIFF
--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -45,7 +45,7 @@ $appBarOffset: 135px
 
       @media (orientation: landscape)
         flex-direction: row
-        margin-right: 4.5em
+        margin-right: $field-space-for-right-side-controls
 
   &[data-purchased-field="1"]
     .react-transform-element

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -25,6 +25,7 @@
     bottom: auto
     top: 5em
     max-width: calc(100% - 12em)
+    left: calc(50% - (#{$field-space-for-right-side-controls} / 2))
 
     .menu-open &
       display: none

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -24,6 +24,7 @@
   @media (orientation: landscape) and (max-height: #{$break-large-phone})
     bottom: auto
     top: 5em
+    max-width: calc(100% - 12em)
 
     .menu-open &
       display: none

--- a/src/styles/variables.sass
+++ b/src/styles/variables.sass
@@ -41,3 +41,5 @@ $cow-color-orange: #ff7031
 $cow-color-purple: #d884f2
 $cow-color-white: #ffffff
 $cow-color-yellow: #fff931
+
+$field-space-for-right-side-controls: 4.5em


### PR DESCRIPTION
### What this PR does

It reveals my hubris. 🙃

It also fixes a minor big introduced by #302 wherein the QuickSelect overlapped the End Day button on smaller screens in landscape orientation.

### How this change can be validated

Play the game on a smaller screen like an iPhone SE (emulated is fine) and observe that a full tool bar does not overlap the End Day button.

### Questions or concerns about this change

I'm going to stop merging PRs without review...

### Additional information

Before this change:
![Screen Shot 2022-07-10 at 18 27 20](https://user-images.githubusercontent.com/366330/178166113-40b5f567-389f-4f97-b4ff-0c3f823d4277.png)

After this change:
![Screen Shot 2022-07-10 at 18 27 45](https://user-images.githubusercontent.com/366330/178166127-5aa2e7fd-fdf8-4dda-8e67-da73a6f3ed5f.png)

