### PR TITLE
feat: Universal MacOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,18 @@ jobs:
         with:
           name: build-output
           path: build
+
+  # FIXME: Remove this. It is just for testing.
+  publish_native_build:
+    needs: test_and_build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm ci --no-optional
+      - name: 'Build Electron App'
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: npm run build:native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,3 @@ jobs:
         with:
           name: build-output
           path: build
-
-  # FIXME: Remove this. It is just for testing.
-  publish_native_build:
-    needs: test_and_build
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - run: npm ci --no-optional
-      - name: 'Build Electron App'
-        env:
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        run: npm run build:native

--- a/package.json
+++ b/package.json
@@ -145,7 +145,11 @@
       "output": "build/native"
     },
     "mac": {
-      "target": "dmg",
+      "target": {
+        "target": "dmg",
+        "arch": "universal"
+      },
+      "mergeASARs": false,
       "icon": "./public/app-icons/Icon-512x512.png"
     },
     "win": {


### PR DESCRIPTION
### What this PR does

This PR makes the Farmhand app for MacOS perform better for Apple Silicon users by distributing a [universal binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary).

### How this change can be validated

Run `npm run build:native` and verify that the build artifact at ` build/native/mac-universal/Farmhand.app` works on a Mac. You will likely see harmless errors in the build output related to missing GitHub tokens, but that is expected.

### Questions or concerns about this change

The generated app is excessively large (like 1.75GB) and I have no idea why that is. I think it's normal, just... wow.

### Additional information

I've run this in the CI job and it seems to work: https://github.com/jeremyckahn/farmhand/runs/7342659160?check_suite_focus=true