### PR TITLE
fix: [#308] limit field size on wider screens

### DIFF
--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -9,6 +9,7 @@ $appBarOffset: 135px
     margin-bottom: 10.5em
   @media (orientation: landscape)
     margin-bottom: 5em
+    max-width: 120vh
 
   @media (min-width: #{$break-medium-phone})
     margin-top: 5em

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -2,7 +2,7 @@
 
 $appBarOffset: 135px
 $bottomControlsOffset: 260px
-$horizontalQuickSelectOffest: 80px;
+$horizontalQuickSelectOffest: 80px
 $obscuringPortraitUiVerticalOffset: $appBarOffset + $horizontalQuickSelectOffest
 $obscuringLandscapeUiVerticalOffset: $appBarOffset + $bottomControlsOffset
 

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -2,27 +2,43 @@
 
 $appBarOffset: 135px
 $bottomControlsOffset: 260px
-$obscuringUiVerticalOffset: $appBarOffset + $bottomControlsOffset
+$horizontalQuickSelectOffest: 80px;
+$obscuringPortraitUiVerticalOffset: $appBarOffset + $horizontalQuickSelectOffest
+$obscuringLandscapeUiVerticalOffset: $appBarOffset + $bottomControlsOffset
 
 .Field
   margin: 0 auto
 
   @media (orientation: portrait)
     margin-bottom: 10.5em
+
+    @media (min-width: #{$break-sm})
+      &[data-purchased-field="0"]
+        max-width: calc(100vh * (6/10) - #{$obscuringPortraitUiVerticalOffset})
+
+      &[data-purchased-field="1"]
+        max-width: calc(100vh * (8/12) - #{$obscuringPortraitUiVerticalOffset})
+
+      &[data-purchased-field="2"]
+        max-width: calc(100vh * (10/16) - #{$obscuringPortraitUiVerticalOffset})
+
+      &[data-purchased-field="3"]
+        max-width: calc(100vh * (12/18) - #{$obscuringPortraitUiVerticalOffset})
+
   @media (orientation: landscape)
     margin-bottom: 5em
 
     &[data-purchased-field="0"]
-      max-width: calc(100vh * (10/6) - #{$obscuringUiVerticalOffset})
+      max-width: calc(100vh * (10/6) - #{$obscuringLandscapeUiVerticalOffset})
 
     &[data-purchased-field="1"]
-      max-width: calc(100vh * (12/8) - #{$obscuringUiVerticalOffset})
+      max-width: calc(100vh * (12/8) - #{$obscuringLandscapeUiVerticalOffset})
 
     &[data-purchased-field="2"]
-      max-width: calc(100vh * (16/10) - #{$obscuringUiVerticalOffset})
+      max-width: calc(100vh * (16/10) - #{$obscuringLandscapeUiVerticalOffset})
 
     &[data-purchased-field="3"]
-      max-width: calc(100vh * (18/12) - #{$obscuringUiVerticalOffset})
+      max-width: calc(100vh * (18/12) - #{$obscuringLandscapeUiVerticalOffset})
 
     @media (max-height: #{$break-large-phone})
       margin-top: 5em

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -1,6 +1,8 @@
 @import ../../styles/variables.sass
 
 $appBarOffset: 135px
+$bottomControlsOffset: 260px
+$obscuringUiVerticalOffset: $appBarOffset + $bottomControlsOffset
 
 .Field
   margin: 0 auto
@@ -9,10 +11,21 @@ $appBarOffset: 135px
     margin-bottom: 10.5em
   @media (orientation: landscape)
     margin-bottom: 5em
-    max-width: 120vh
 
-  @media (min-width: #{$break-medium-phone})
-    margin-top: 5em
+    &[data-purchased-field="0"]
+      max-width: calc(100vh * (10/6) - #{$obscuringUiVerticalOffset})
+
+    &[data-purchased-field="1"]
+      max-width: calc(100vh * (12/8) - #{$obscuringUiVerticalOffset})
+
+    &[data-purchased-field="2"]
+      max-width: calc(100vh * (16/10) - #{$obscuringUiVerticalOffset})
+
+    &[data-purchased-field="3"]
+      max-width: calc(100vh * (18/12) - #{$obscuringUiVerticalOffset})
+
+    @media (max-height: #{$break-large-phone})
+      margin-top: 5em
 
   .row
     display: flex


### PR DESCRIPTION
### What this PR does

This PR addressed the need described in #308 by limiting the field size for wider screens.

### How this change can be validated

Open the field in a variety of screen sizes and ensure that the field is generally fully visible and accessible. It won't always be perfect, but it should at least fit on the screen reasonably well.

### Questions or concerns about this change

Enabling greater zoom-out was much harder than I anticipated due to issues similar to https://github.com/prc5/react-zoom-pan-pinch/issues/84. We have a workaround in place to deal with this here: https://github.com/jeremyckahn/farmhand/blob/4f8970728c3958ccc1a1f4406b035d74a9608c53/src/components/Field/Field.js#L376-L382

Ideally we could simply remove the `if (scale >= 1)` check, but that crashes the game. 🙁

### Additional information

Before this PR:

![image](https://user-images.githubusercontent.com/366330/179137526-a4cf61a8-cf10-4bc9-898d-ef3e0ba7d2e9.png)


After this PR:

![image](https://user-images.githubusercontent.com/366330/179137468-94ebfab5-256a-410b-82ab-4fab0bead50a.png)