### PR TITLE
update for proper data

### DIFF
--- a/src/components/Workshop/getUpgradesAvailable.js
+++ b/src/components/Workshop/getUpgradesAvailable.js
@@ -9,7 +9,6 @@ import { recipesMap } from '../../data/maps'
  */
 export function getUpgradesAvailable({ learnedForgeRecipes, toolLevels }) {
   let upgradesAvailable = []
-  const learnedRecipeIds = learnedForgeRecipes.map(r => r.id)
 
   for (let type of Object.keys(toolUpgrades)) {
     const upgrade = toolUpgrades[type][toolLevels[type]]
@@ -21,7 +20,9 @@ export function getUpgradesAvailable({ learnedForgeRecipes, toolLevels }) {
       for (let ingredient of Object.keys(nextLevelUpgrade.ingredients)) {
         allIngredientsUnlocked =
           allIngredientsUnlocked &&
-          !!(!recipesMap[ingredient] || learnedRecipeIds.includes(ingredient))
+          !!(
+            !recipesMap[ingredient] || learnedForgeRecipes.includes(ingredient)
+          )
       }
 
       if (allIngredientsUnlocked) {

--- a/src/components/Workshop/getUpgradesAvailable.test.js
+++ b/src/components/Workshop/getUpgradesAvailable.test.js
@@ -20,7 +20,7 @@ describe('getUpgradesAvailable', () => {
   })
 
   test('it returns a list of available upgrades when required recipes have been learned', () => {
-    const learnedForgeRecipes = [{ id: 'bronze-ingot' }]
+    const learnedForgeRecipes = ['bronze-ingot']
 
     const availableUpgrades = getUpgradesAvailable({
       toolLevels,


### PR DESCRIPTION
### What this PR does

Fixes tool upgrades not showing up in the forge due to expectation of data being in a different shape than it actually was

### How this change can be validated

Get to the point of unlocking ore recipes and then verify that the tool upgrades are also available. Compare this to prod where the tool upgrades do not show up.

Here's a save that can be used 

[farmhand-2022-07-16.json.zip](https://github.com/jeremyckahn/farmhand/files/9126360/farmhand-2022-07-16.json.zip)

### Additional information

screenshot of tool upgrades showing up in local server running this branch

<img width="1437" alt="Screen Shot 2022-07-16 at 11 17 28 AM" src="https://user-images.githubusercontent.com/628757/179367372-143c6ecd-18d2-437b-b6ba-433772531d2e.png">


