### PR TITLE
feat: Improve responsive Field sizing

### DIFF
--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -26,9 +26,11 @@ $obscuringLandscapeUiVerticalOffset: $appBarOffset + $bottomControlsOffset
         max-width: calc(100vh * (12/18) - #{$obscuringPortraitUiVerticalOffset})
 
   @media (orientation: landscape)
-    margin-bottom: 5em
+    margin: 5em auto
 
     @media (min-height: #{$break-large-phone})
+      margin-top: auto
+
       &[data-purchased-field="0"]
         max-width: calc(100vh * (10/6) - #{$obscuringLandscapeUiVerticalOffset})
 
@@ -40,9 +42,6 @@ $obscuringLandscapeUiVerticalOffset: $appBarOffset + $bottomControlsOffset
 
       &[data-purchased-field="3"]
         max-width: calc(100vh * (18/12) - #{$obscuringLandscapeUiVerticalOffset})
-
-    @media (max-height: #{$break-large-phone})
-      margin-top: 5em
 
   .row
     display: flex

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -31,6 +31,7 @@ $obscuringLandscapeUiVerticalOffset: $appBarOffset + $bottomControlsOffset
     @media (min-height: #{$break-large-phone})
       margin-top: auto
 
+    @media (min-height: #{$break-sm})
       &[data-purchased-field="0"]
         max-width: calc(100vh * (10/6) - #{$obscuringLandscapeUiVerticalOffset})
 

--- a/src/components/Field/Field.sass
+++ b/src/components/Field/Field.sass
@@ -28,17 +28,18 @@ $obscuringLandscapeUiVerticalOffset: $appBarOffset + $bottomControlsOffset
   @media (orientation: landscape)
     margin-bottom: 5em
 
-    &[data-purchased-field="0"]
-      max-width: calc(100vh * (10/6) - #{$obscuringLandscapeUiVerticalOffset})
+    @media (min-height: #{$break-large-phone})
+      &[data-purchased-field="0"]
+        max-width: calc(100vh * (10/6) - #{$obscuringLandscapeUiVerticalOffset})
 
-    &[data-purchased-field="1"]
-      max-width: calc(100vh * (12/8) - #{$obscuringLandscapeUiVerticalOffset})
+      &[data-purchased-field="1"]
+        max-width: calc(100vh * (12/8) - #{$obscuringLandscapeUiVerticalOffset})
 
-    &[data-purchased-field="2"]
-      max-width: calc(100vh * (16/10) - #{$obscuringLandscapeUiVerticalOffset})
+      &[data-purchased-field="2"]
+        max-width: calc(100vh * (16/10) - #{$obscuringLandscapeUiVerticalOffset})
 
-    &[data-purchased-field="3"]
-      max-width: calc(100vh * (18/12) - #{$obscuringLandscapeUiVerticalOffset})
+      &[data-purchased-field="3"]
+        max-width: calc(100vh * (18/12) - #{$obscuringLandscapeUiVerticalOffset})
 
     @media (max-height: #{$break-large-phone})
       margin-top: 5em

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -11,21 +11,22 @@
   &.MuiPaper-root // Specificity is needed for card-style overrides
     @include card-style
 
-  @media (orientation: landscape) and (min-height: #{$break-large-phone})
+  @media (orientation: landscape)
     bottom: auto
-    left: auto
-    max-height: calc(100vh - 20em)
-    min-width: 4em
-    overflow: auto
-    right: 0.75em
-    top: 9em
-    transform: none
 
-  @media (orientation: landscape) and (max-height: #{$break-large-phone})
-    bottom: auto
-    top: 5em
-    max-width: calc(100% - 12em)
-    left: calc(50% - (#{$field-space-for-right-side-controls} / 2))
+    @media (max-height: #{$break-large-phone})
+      top: 5em
+      max-width: calc(100% - 12em)
+      left: calc(50% - (#{$field-space-for-right-side-controls} / 2))
+
+    @media (min-height: #{$break-large-phone})
+      left: auto
+      max-height: calc(100vh - 20em)
+      min-width: 4em
+      overflow: auto
+      right: 0.75em
+      top: 9em
+      transform: none
 
     .menu-open &
       display: none

--- a/src/components/QuickSelect/QuickSelect.sass
+++ b/src/components/QuickSelect/QuickSelect.sass
@@ -28,8 +28,9 @@
       top: 9em
       transform: none
 
-    .menu-open &
-      display: none
+    @media (max-width:  #{$break-md})
+      .menu-open &
+        display: none
 
   .button-array
     display: flex

--- a/src/components/Stage/Stage.sass
+++ b/src/components/Stage/Stage.sass
@@ -64,7 +64,7 @@
     margin-bottom: 0.6em
     text-align: center
 
-    @media (min-width: #{$break-medium-phone})
+    @media (min-width: #{$break-large-phone})
       display: none
 
   section


### PR DESCRIPTION
### What this PR does

It builds on #309, #302, and #300 by making more space for the Field and QuickSelect elements on more screens under more conditions.

### How this change can be validated

View the Field in a variety of conditions (portrait and landscape mode, menu open and closed) and ensure that all critical UI is reasonably accessible.

### Questions or concerns about this change

Someday I will get this part of the design right...

### Additional information

<details>
<summary>Click to see screenshots</summary>

#### iPhone 8 / SE 2

![image](https://user-images.githubusercontent.com/366330/179429021-43efe167-36bc-44f0-b1ac-c50820fde7c5.png)
![image](https://user-images.githubusercontent.com/366330/179429031-b68aefd8-78c6-4032-a809-7b3c75aeda58.png)
![image](https://user-images.githubusercontent.com/366330/179429033-34389d46-87be-4bf6-a0df-dce8c9b044cd.png)

#### iPhone 12/13 Pro Max

![image](https://user-images.githubusercontent.com/366330/179429068-7895f1a5-9d8b-477e-b7b7-7b09a98c4442.png)
![image](https://user-images.githubusercontent.com/366330/179429078-b28e99e5-6004-4708-89e7-bf4ed06f2b27.png)
![image](https://user-images.githubusercontent.com/366330/179429094-88723bdc-6596-4019-a6a2-c07f11d39ec7.png)

#### iPhone 12/13 Pro Mini

![image](https://user-images.githubusercontent.com/366330/179429112-0c284451-8d2e-4a20-b58b-acd0b13422d9.png)
![image](https://user-images.githubusercontent.com/366330/179429135-3bf0032c-ddfa-45cc-8c7f-17d36c33f792.png)
![image](https://user-images.githubusercontent.com/366330/179429141-ba24df1f-414f-4365-92b5-aaea9b8c7af7.png)

#### iPhone 12/13 Pro

![image](https://user-images.githubusercontent.com/366330/179429160-ad942c8b-0931-4ba5-b531-60dfea2e9d07.png)
![image](https://user-images.githubusercontent.com/366330/179429175-a2913f7b-96c3-440a-9d6c-62fcffb0be26.png)
![image](https://user-images.githubusercontent.com/366330/179429180-c256f5ed-a696-48b9-817d-4e6ee28507f8.png)
</details>