### PR TITLE
feat: Show Recipe description

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -221,6 +221,8 @@ If you're playing on a mobile device, all you need to do is [add it to your home
 
 * Crops need to be watered daily to grow.
 
+* Keep the field free of weeds with the scythe or the hoe.
+
 * Crafting items out of harvested crops in the Workshop is an excellent way to make money!
 
 * Purchasing a cow pen will allow you to buy, sell, milk, and breed cows. Can you breed the mythical Rainbow Cow?

--- a/src/components/Recipe/Recipe.js
+++ b/src/components/Recipe/Recipe.js
@@ -3,7 +3,9 @@ import classNames from 'classnames'
 import Button from '@material-ui/core/Button'
 import Card from '@material-ui/core/Card'
 import CardHeader from '@material-ui/core/CardHeader'
+import CardContent from '@material-ui/core/CardContent'
 import CardActions from '@material-ui/core/CardActions'
+import Typography from '@material-ui/core/Typography'
 import { array, func, number, object } from 'prop-types'
 
 import {
@@ -30,7 +32,7 @@ const Recipe = ({
   inventoryLimit,
   playerInventoryQuantities,
   recipe,
-  recipe: { id, name },
+  recipe: { id, name, description },
 }) => {
   const [quantity, setQuantity] = useState(1)
 
@@ -86,6 +88,11 @@ const Recipe = ({
           ),
         }}
       />
+      {description && (
+        <CardContent>
+          <Typography>{description}</Typography>
+        </CardContent>
+      )}
       <CardActions>
         <Button
           {...{


### PR DESCRIPTION
### What this PR does

It addresses #313 by rendering recipe descriptions in the Workshop.

It also adds a bit of info about weeds on the Home screen.

### How this change can be validated

Verify that Fertilizer and Compost descriptions appear in the Workshop and that the new info about weeds appears on the Home screen.

### Additional information

![image](https://user-images.githubusercontent.com/366330/180352921-45d607d2-5b4d-4b66-9b0c-494458defe8d.png)
