### PR TITLE
refactor: Convert purchase and sale tests to use React Testing Library

### DIFF
--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -1313,6 +1313,7 @@ export default class Farmhand extends Component {
                     className: 'sidebar-wrapper',
                     open: gameState.isMenuOpen,
                     variant: 'persistent',
+                    'data-testid': 'menu',
                     PaperProps: {
                       className: 'sidebar',
                     },

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -1313,7 +1313,7 @@ export default class Farmhand extends Component {
                     className: 'sidebar-wrapper',
                     open: gameState.isMenuOpen,
                     variant: 'persistent',
-                    'data-testid': 'menu',
+                    role: 'complementary',
                     PaperProps: {
                       className: 'sidebar',
                     },

--- a/src/components/Plot/Plot.js
+++ b/src/components/Plot/Plot.js
@@ -161,7 +161,9 @@ export const Plot = ({
             backgroundImage: showPlotImage ? `url(${image})` : undefined,
           },
           src: pixel,
-          alt: itemsMap[plotContent?.itemId ?? plotContent?.oreId]?.name || '',
+          alt:
+            itemsMap[plotContent?.itemId ?? plotContent?.oreId]?.name ||
+            'Empty plot',
         }}
       />
     </div>

--- a/src/components/Plot/Plot.rtl.test.js
+++ b/src/components/Plot/Plot.rtl.test.js
@@ -31,7 +31,7 @@ describe('class states', () => {
   })
 
   test('renders standard classes', () => {
-    const img = screen.queryByAltText('')
+    const img = screen.queryByAltText('Empty plot')
     const { classList } = img.closest('.Plot')
 
     expect(classList).toContain('is-empty')

--- a/src/components/Stage/Stage.js
+++ b/src/components/Stage/Stage.js
@@ -38,6 +38,7 @@ export const Stage = ({
       {...{
         className: 'Stage',
         'data-stage-focus': stageFocus,
+        'data-testid': 'stage',
         ref,
       }}
     >

--- a/src/components/Stage/Stage.js
+++ b/src/components/Stage/Stage.js
@@ -38,7 +38,7 @@ export const Stage = ({
       {...{
         className: 'Stage',
         'data-stage-focus': stageFocus,
-        'data-testid': 'stage',
+        role: 'main',
         ref,
       }}
     >

--- a/src/game-logic/field-purchase.test.js
+++ b/src/game-logic/field-purchase.test.js
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react'
+import { within } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+
+import { farmhandStub } from '../test-utils/stubs/farmhandStub'
+import { saveDataStubFactory } from '../test-utils/stubs/saveDataStubFactory'
+import { nextView } from '../test-utils/ui'
+
+describe('field expansion purchasing', () => {
+  test('field expansion can be purchased', async () => {
+    const loadedState = saveDataStubFactory({
+      money: 1000,
+    })
+
+    await farmhandStub({
+      localforage: {
+        getItem: () => Promise.resolve(loadedState),
+        setItem: (_key, data) => Promise.resolve(data),
+      },
+    })
+
+    await nextView()
+
+    const upgradesTab = screen.getByText('Upgrades')
+    userEvent.click(upgradesTab)
+
+    const expandFieldContainer = screen
+      .getByText('Expand field')
+      .closest('.TierPurchase')
+
+    // Open the list of field options
+    userEvent.click(within(expandFieldContainer).getAllByRole('button')[1])
+
+    userEvent.click(screen.getByRole('option', { name: '$1,000: 8 x 12' }))
+
+    // Make the purchase
+    userEvent.click(within(expandFieldContainer).getAllByRole('button')[0])
+
+    await nextView()
+
+    const emptyPlots = screen.getAllByAltText('Empty plot')
+    expect(emptyPlots).toHaveLength(96)
+  })
+})

--- a/src/game-logic/item-purchase.test.js
+++ b/src/game-logic/item-purchase.test.js
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react'
+import { within } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+
+import { farmhandStub } from '../test-utils/stubs/farmhandStub'
+import { nextView } from '../test-utils/ui'
+
+describe('item purchasing', () => {
+  test('item can be purchased and added to the inventory', async () => {
+    await farmhandStub()
+    await nextView()
+
+    const stage = screen.getByTestId('stage')
+    const carrotSeedShopItem = within(stage)
+      .getByText('Carrot Seed')
+      .closest('.Item')
+    const buyButton = within(carrotSeedShopItem).getByText('Buy')
+    userEvent.click(buyButton)
+
+    const menu = screen.getByTestId('menu')
+    expect(within(menu).getByText('Carrot Seed')).toBeInTheDocument()
+  })
+})

--- a/src/game-logic/item-purchase.test.js
+++ b/src/game-logic/item-purchase.test.js
@@ -10,14 +10,14 @@ describe('item purchasing', () => {
     await farmhandStub()
     await nextView()
 
-    const stage = screen.getByTestId('stage')
-    const carrotSeedShopItem = within(stage)
+    const main = screen.getByRole('main')
+    const carrotSeedShopItem = within(main)
       .getByText('Carrot Seed')
       .closest('.Item')
     const buyButton = within(carrotSeedShopItem).getByText('Buy')
     userEvent.click(buyButton)
 
-    const menu = screen.getByTestId('menu')
+    const menu = screen.getByRole('complementary')
     expect(within(menu).getByText('Carrot Seed')).toBeInTheDocument()
   })
 })

--- a/src/game-logic/item-sell.test.js
+++ b/src/game-logic/item-sell.test.js
@@ -1,0 +1,30 @@
+import { screen } from '@testing-library/react'
+import { within } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+
+import { farmhandStub } from '../test-utils/stubs/farmhandStub'
+import { saveDataStubFactory } from '../test-utils/stubs/saveDataStubFactory'
+
+describe('item selling', () => {
+  test('item in inventory can be sold', async () => {
+    const loadedState = saveDataStubFactory({
+      inventory: [{ id: 'carrot-seed', quantity: 1 }],
+    })
+
+    await farmhandStub({
+      localforage: {
+        getItem: () => Promise.resolve(loadedState),
+        setItem: (_key, data) => Promise.resolve(data),
+      },
+    })
+
+    const menu = screen.getByTestId('menu')
+    const carrotSeedMenuItem = within(menu)
+      .getByText('Carrot Seed')
+      .closest('.Item')
+    const sellButton = within(carrotSeedMenuItem).getByText('Sell')
+    userEvent.click(sellButton)
+
+    expect(within(menu).queryByText('Carrot Seed')).not.toBeInTheDocument()
+  })
+})

--- a/src/game-logic/item-sell.test.js
+++ b/src/game-logic/item-sell.test.js
@@ -18,7 +18,7 @@ describe('item selling', () => {
       },
     })
 
-    const menu = screen.getByTestId('menu')
+    const menu = screen.getByRole('complementary')
     const carrotSeedMenuItem = within(menu)
       .getByText('Carrot Seed')
       .closest('.Item')

--- a/src/handlers/ui-events.test.js
+++ b/src/handlers/ui-events.test.js
@@ -29,18 +29,6 @@ beforeEach(() => {
   component = shallow(<Farmhand />)
 })
 
-describe('handleItemSellClick', () => {
-  test('calls sellItem', () => {
-    jest.spyOn(component.instance(), 'sellItem').mockImplementation(() => {})
-    handlers().handleItemSellClick(testItem({ id: 'sample-item-1' }))
-
-    expect(component.instance().sellItem).toHaveBeenCalledWith(
-      testItem({ id: 'sample-item-1' }),
-      1
-    )
-  })
-})
-
 describe('handleFieldModeSelect', () => {
   beforeEach(() => {
     component.setState({

--- a/src/handlers/ui-events.test.js
+++ b/src/handlers/ui-events.test.js
@@ -93,14 +93,6 @@ describe('handleClickEndDayButton', () => {
   })
 })
 
-describe('handleFieldPurchase', () => {
-  test('calls purchaseField', () => {
-    jest.spyOn(component.instance(), 'purchaseField').mockImplementation()
-    handlers().handleFieldPurchase()
-    expect(component.instance().purchaseField).toHaveBeenCalled()
-  })
-})
-
 describe('handleMenuToggle', () => {
   test('toggle menu state', () => {
     const { isMenuOpen } = component.state()

--- a/src/handlers/ui-events.test.js
+++ b/src/handlers/ui-events.test.js
@@ -29,20 +29,6 @@ beforeEach(() => {
   component = shallow(<Farmhand />)
 })
 
-describe('handleItemPurchaseClick', () => {
-  test('calls purchaseItem', () => {
-    jest
-      .spyOn(component.instance(), 'purchaseItem')
-      .mockImplementation(() => {})
-    handlers().handleItemPurchaseClick(testItem({ id: 'sample-item-1' }), 3)
-
-    expect(component.instance().purchaseItem).toHaveBeenCalledWith(
-      testItem({ id: 'sample-item-1' }),
-      3
-    )
-  })
-})
-
 describe('handleItemSellClick', () => {
   test('calls sellItem', () => {
     jest.spyOn(component.instance(), 'sellItem').mockImplementation(() => {})
@@ -52,16 +38,6 @@ describe('handleItemSellClick', () => {
       testItem({ id: 'sample-item-1' }),
       1
     )
-  })
-})
-
-describe('handleViewChange', () => {
-  beforeEach(() => {
-    handlers().handleViewChange({ target: { value: stageFocusType.SHOP } })
-  })
-
-  test('changes the view type', () => {
-    expect(component.state('stageFocus')).toEqual(stageFocusType.SHOP)
   })
 })
 


### PR DESCRIPTION
### What this PR does

For #269, this converts some tests related to buying and selling to use React Testing Library

### How this change can be validated

Ensure the tests pass.