### PR TITLE
refactor: Remove `MINING` feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,3 @@ BROWSER=none
 REACT_APP_API_ROOT=https://farmhand.vercel.app/
 REACT_APP_NAME=$npm_package_name
 REACT_APP_VERSION=$npm_package_version
-REACT_APP_ENABLE_MINING=true

--- a/.env.development.local
+++ b/.env.development.local
@@ -1,3 +1,1 @@
 REACT_APP_API_ROOT=http://localhost:3001/
-
-REACT_APP_ENABLE_MINING=true

--- a/src/components/Shop/Shop.js
+++ b/src/components/Shop/Shop.js
@@ -10,7 +10,6 @@ import Tab from '@material-ui/core/Tab'
 import Tabs from '@material-ui/core/Tabs'
 import Typography from '@material-ui/core/Typography'
 
-import { features } from '../../config'
 import FarmhandContext from '../Farmhand/Farmhand.context'
 import {
   dollarString,
@@ -82,7 +81,7 @@ export const Shop = ({
       <AppBar position="static" color="primary">
         <Tabs
           value={currentTab}
-          onChange={(e, newTab) => setCurrentTab(newTab)}
+          onChange={(_e, newTab) => setCurrentTab(newTab)}
           aria-label="Shop tabs"
         >
           <Tab {...{ label: 'Seeds', ...a11yProps(0) }} />
@@ -197,7 +196,7 @@ export const Shop = ({
               }}
             />
           </li>
-          {features.MINING && toolLevels[toolType.SHOVEL] ? (
+          {toolLevels[toolType.SHOVEL] ? (
             <li>
               <TierPurchase
                 {...{

--- a/src/components/Toolbelt/Toolbelt.test.js
+++ b/src/components/Toolbelt/Toolbelt.test.js
@@ -5,13 +5,6 @@ import { fieldMode, toolLevel, toolType } from '../../enums'
 
 import { Toolbelt } from './Toolbelt'
 
-jest.mock('../../config', () => ({
-  ...jest.requireActual('../../config'),
-  features: {
-    MINING: true,
-  },
-}))
-
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
   memoize: jest.fn(callback => {

--- a/src/components/Workshop/Workshop.js
+++ b/src/components/Workshop/Workshop.js
@@ -4,7 +4,6 @@ import AppBar from '@material-ui/core/AppBar'
 import Tab from '@material-ui/core/Tab'
 import Tabs from '@material-ui/core/Tabs'
 
-import { features } from '../../config'
 import { recipeType } from '../../enums'
 
 import { recipesMap } from '../../data/maps'
@@ -39,7 +38,7 @@ const Workshop = ({
     recipeId => recipesMap[recipeId].recipeType === recipeType.RECYCLING
   )
 
-  const showForge = features.MINING && purchasedSmelter
+  const showForge = purchasedSmelter
 
   const recyclingTabIndex = showForge ? 2 : 1
 
@@ -48,7 +47,7 @@ const Workshop = ({
       <AppBar position="static" color="primary">
         <Tabs
           value={currentTab}
-          onChange={(e, newTab) => setCurrentTab(newTab)}
+          onChange={(_e, newTab) => setCurrentTab(newTab)}
           aria-label="Workshop tabs"
         >
           <Tab {...{ label: 'Kitchen', ...a11yProps(0) }} />

--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -12,7 +12,6 @@ import {
 } from '../utils'
 import { cropLifeStage, standardCowColors } from '../enums'
 import { COW_FEED_ITEM_ID, I_AM_RICH_BONUSES } from '../constants'
-import { features } from '../config'
 
 import { itemsMap } from './maps'
 
@@ -276,25 +275,18 @@ const achievements = [
     condition: state => state.revenue >= goal,
     reward: state => state,
   }))(),
-]
 
-if (features.MINING) {
-  achievements.push(
-    Object.assign(
-      {},
-      {
-        id: 'gold-digger',
-        name: 'Gold Digger',
-        description: `Dig up your first piece of gold.`,
-        rewardDescription: `A Gold Ingot`,
-        condition: state => !!state.inventory.find(i => i.id === 'gold-ore'),
-        reward: state => {
-          return addItemToInventory(state, itemsMap['gold-ingot'], 1, true)
-        },
-      }
-    )
-  )
-}
+  (() => ({
+    id: 'gold-digger',
+    name: 'Gold Digger',
+    description: `Dig up your first piece of gold.`,
+    rewardDescription: `A Gold Ingot`,
+    condition: state => !!state.inventory.find(i => i.id === 'gold-ore'),
+    reward: state => {
+      return addItemToInventory(state, itemsMap['gold-ingot'], 1, true)
+    },
+  }))(),
+]
 
 export default achievements
 

--- a/src/data/achievements.test.js
+++ b/src/data/achievements.test.js
@@ -11,12 +11,6 @@ jest.mock('./items')
 jest.mock('./levels', () => ({ levels: [] }))
 jest.mock('./recipes')
 jest.mock('./shop-inventory')
-jest.mock('../config', () => ({
-  ...jest.requireActual('../config'),
-  features: {
-    MINING: true,
-  },
-}))
 
 describe('harvest-crop', () => {
   describe('condition', () => {

--- a/src/data/levels.js
+++ b/src/data/levels.js
@@ -1,7 +1,5 @@
 import { toolType } from '../enums'
 
-import { features } from '../config'
-
 import * as items from './items'
 import * as recipes from './recipes'
 
@@ -27,10 +25,8 @@ levels[5] = {
   unlocksShopItem: items.sprinkler.id,
 }
 
-if (features.MINING) {
-  levels[6] = {
-    unlocksTool: toolType.SHOVEL,
-  }
+levels[6] = {
+  unlocksTool: toolType.SHOVEL,
 }
 
 levels[8] = {

--- a/src/data/tools.js
+++ b/src/data/tools.js
@@ -1,7 +1,5 @@
 import { fieldMode, toolType } from '../enums'
 
-import { features } from '../config'
-
 import {
   HOE_ALT_TEXT,
   HOE_HIDDEN_TEXT,
@@ -47,10 +45,7 @@ const tools = {
     order: 3,
     type: toolType.HOE,
   },
-}
-
-if (features.MINING) {
-  tools.shovel = {
+  shovel: {
     alt: SHOVEL_ALT_TEXT,
     fieldKey: 'shift+4',
     fieldMode: MINE,
@@ -59,7 +54,7 @@ if (features.MINING) {
     levelInfo: TOOL_LEVEL_INFO.SHOVEL,
     order: 4,
     type: toolType.SHOVEL,
-  }
+  },
 }
 
 export default tools


### PR DESCRIPTION
### What this PR does

This PR removes the `MINING` feature flag, which is no longer used.

### How this change can be validated

Ensure that the mining-related functionality still works.

### Questions or concerns about this change

~I'm not actually sure how any of this was working with the flag still in place. It's not clear how the flag is being enabled in Production. :grimacing:~ I figured it out: https://github.com/jeremyckahn/farmhand/commit/97ca7eef988c28d84f480a5709806af43250fd56