### PR TITLE
feat: Use relay servers for improved peer connectivity

### DIFF
--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -99,7 +99,7 @@ import {
   SERVER_ERROR,
   UPDATE_AVAILABLE,
 } from '../../strings'
-import { endpoints } from '../../config'
+import { endpoints, rtcConfig } from '../../config'
 
 import { getInventoryQuantities } from './helpers/getInventoryQuantities'
 import FarmhandContext from './Farmhand.context'
@@ -889,7 +889,13 @@ export default class Farmhand extends Component {
 
       this.setState({
         activePlayers,
-        peerRoom: joinRoom({ appId: process.env.REACT_APP_NAME }, room),
+        peerRoom: joinRoom(
+          {
+            appId: process.env.REACT_APP_NAME,
+            rtcConfig,
+          },
+          room
+        ),
         valueAdjustments: applyPriceEvents(
           valueAdjustments,
           priceCrashes,
@@ -972,7 +978,13 @@ export default class Farmhand extends Component {
           // room.
           const peerRoom =
             this.state.peerRoom ||
-            joinRoom({ appId: process.env.REACT_APP_NAME }, room)
+            joinRoom(
+              {
+                appId: process.env.REACT_APP_NAME,
+                rtcConfig,
+              },
+              room
+            )
 
           this.setState(({ money }) => ({
             activePlayers,

--- a/src/config.js
+++ b/src/config.js
@@ -38,3 +38,26 @@ for (const key of searchParams.keys()) {
     features[matches[1]] = true
   }
 }
+
+export const rtcConfig = {
+  iceServers: [
+    {
+      urls: 'stun:openrelay.metered.ca:80',
+    },
+    {
+      urls: 'turn:openrelay.metered.ca:80',
+      username: 'openrelayproject',
+      credential: 'openrelayproject',
+    },
+    {
+      urls: 'turn:openrelay.metered.ca:443',
+      username: 'openrelayproject',
+      credential: 'openrelayproject',
+    },
+    {
+      urls: 'turn:openrelay.metered.ca:443?transport=tcp',
+      username: 'openrelayproject',
+      credential: 'openrelayproject',
+    },
+  ],
+}


### PR DESCRIPTION
### What this PR does

This PR improves peer-to-peer connectivity by using a [public relay server](https://www.metered.ca/tools/openrelay/) when direct connections fail. This address the problem of peers that never connect successfully.

This video explains some of the networking specifics better than I can: https://www.youtube.com/watch?v=4dLJmZOcWFc

### How this change can be validated

It depends on whether you experience peer connection issues without this change. Personally, I was unable to connect to peers when on a mobile network. After testing this in the preview environment, my mobile device was able to connect successfully.

### Questions or concerns about this change

This change depends on a third-party service that we don't control (https://www.metered.ca/tools/openrelay/). Ideally we'd host our own server to provide the relay functionality, but that would cost money. I'm open to self-hosting the relay server and WebTorrent pairing server in the future to increase control of our stack.

### Additional information

It's worth being aware of Open Relay's [terms and conditions](https://www.metered.ca/tools/openrelay/terms-and-conditions):

> THE TURN SERVER CAN AND WILL GO DOWN WITHOUT NOTICE AND WE DO NOT PROVIDE ANY GUARANTEES OF ANY KIND REGARDING ITS WORKINGS.

I believe that our peer connections will gracefully fall back to attempting direct peer connections as they currently do, in this case.