### PR TITLE
fix: Prevent accessing Shovel via keyboard shortcut when it is unavailable

### DIFF
--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -490,7 +490,11 @@ export default class Farmhand extends Component {
       selectHoe: () => this.handlers.handleFieldModeSelect(CLEANUP),
       selectScythe: () => this.handlers.handleFieldModeSelect(HARVEST),
       selectWateringCan: () => this.handlers.handleFieldModeSelect(WATER),
-      selectShovel: () => this.handlers.handleFieldModeSelect(MINE),
+      selectShovel: () => {
+        if (this.state.toolLevels[toolType.SHOVEL] !== toolLevel.UNAVAILABLE) {
+          this.handlers.handleFieldModeSelect(MINE)
+        }
+      },
       toggleMenu: () => this.handlers.handleMenuToggle(),
     }
 

--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -6,6 +6,7 @@ import {
   getCropLifeStage,
   getProfitRecord,
   integerString,
+  isOctober,
   memoize,
   moneyTotal,
   percentageString,
@@ -109,7 +110,7 @@ const achievements = [
     name: 'Halloween Harvest',
     description: 'Play Farmhand in October and get the gift of the season.',
     rewardDescription: `${reward} units of ${itemsMap.jackolantern.name}`,
-    condition: () => new Date().getMonth() === 9,
+    condition: () => isOctober(),
     reward: state =>
       addItemToInventory(state, itemsMap.jackolantern, reward, true),
   }))(),


### PR DESCRIPTION
### What this PR does

This PR addresses [a bug report from Reddit](https://www.reddit.com/r/incremental_games/comments/xxda0f/comment/iref8k9/?utm_source=reddit&utm_medium=web2x&context=3):

> you can use shift+4 way before unlocking the shovel, used it to pay the loans day1 and get started

### How this change can be validated

Start a new Farmhand game and ensure that the Shovel can't be accessed via the Shift + 4 keyboard shortcut. Once the Shovel is unlocked, ensure that it can be accessed via the Shift + 4 keyboard shortcut.