### PR TITLE
fix quantity inputs allowing unacceptable values

### DIFF
--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -66,41 +66,61 @@ const QuantityInput = ({
   maxQuantity,
   setQuantity,
   value,
-}) => (
-  <div className="QuantityInput">
-    <QuantityTextInput
-      {...{ handleSubmit, handleUpdateNumber, maxQuantity, value }}
-    />
-    <span className="quantity">
-      /{' '}
-      <AnimatedNumber {...{ number: maxQuantity, formatter: integerString }} />
-    </span>
-    <div className="number-nudger-container">
-      <Fab
-        disabled={!value}
-        {...{
-          'aria-label': 'Increment',
-          color: 'primary',
-          onClick: () => setQuantity(++value > maxQuantity ? 1 : value),
-          size: 'small',
-        }}
-      >
-        <KeyboardArrowUp />
-      </Fab>
-      <Fab
-        disabled={!value}
-        {...{
-          'aria-label': 'Decrement',
-          color: 'primary',
-          onClick: () => setQuantity(--value === 0 ? maxQuantity : value),
-          size: 'small',
-        }}
-      >
-        <KeyboardArrowDown />
-      </Fab>
+}) => {
+  const decrementQuantity = () => {
+    var newValue = value - 1
+    if (newValue === 0) {
+      newValue = maxQuantity
+    }
+    setQuantity(newValue)
+  }
+
+  const incrementValue = () => {
+    var newValue = value + 1
+    if (newValue > maxQuantity) {
+      newValue = 1
+    }
+    setQuantity(newValue)
+  }
+
+  return (
+    <div className="QuantityInput">
+      <QuantityTextInput
+        {...{ handleSubmit, handleUpdateNumber, maxQuantity, value }}
+      />
+      <span className="quantity">
+        /{' '}
+        <AnimatedNumber
+          {...{ number: maxQuantity, formatter: integerString }}
+        />
+      </span>
+      <div className="number-nudger-container">
+        <Fab
+          disabled={!value}
+          {...{
+            'aria-label': 'Increment',
+            color: 'primary',
+            onClick: incrementValue,
+            size: 'small',
+          }}
+        >
+          <KeyboardArrowUp />
+        </Fab>
+        <Fab
+          disabled={!value}
+          {...{
+            'aria-label': 'Decrement',
+            color: 'primary',
+            onClick: decrementQuantity,
+            size: 'small',
+          }}
+        >
+          <KeyboardArrowDown />
+        </Fab>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 QuantityInput.propTypes = {
   handleSubmit: func.isRequired,

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -68,15 +68,15 @@ const QuantityInput = ({
   value,
 }) => {
   const decrementQuantity = () => {
-    var newValue = value - 1
+    let newValue = value - 1
     if (newValue === 0) {
       newValue = maxQuantity
     }
     setQuantity(newValue)
   }
 
-  const incrementValue = () => {
-    var newValue = value + 1
+  const incrementQuantity = () => {
+    let newValue = value + 1
     if (newValue > maxQuantity) {
       newValue = 1
     }
@@ -100,7 +100,7 @@ const QuantityInput = ({
           {...{
             'aria-label': 'Increment',
             color: 'primary',
-            onClick: incrementValue,
+            onClick: incrementQuantity,
             size: 'small',
           }}
         >


### PR DESCRIPTION
### What this PR does

fixes a bug where the QuantityInput would start to count up while pressing the decrement button. it doesn't really do much other than move away from using `--value` in favor of a more functional approach which seems to fix the problem.

### How this change can be validated

load up a fresh game and sell all but one of the jack-o-lanterns that are currently being put in the inventory (since it's october). then press 'decrement' and notice it does not start counting up like production currently is doing. after selling the jack-o-lanterns some fertilizer will have appeared, so press increment and decrement on that and make sure it is still functioning as expecting with the wrapping behavior.

### Questions or concerns about this change

### Additional information

this bug was reported in discord #bug-reports channel