### PR TITLE
chore: Remove MacOS support

### DIFF
--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2.3.1
         with:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 
 **[Play Farmhand in your browser!](https://www.farmhand.life/)**
 
+[![CI](https://github.com/jeremyckahn/farmhand/workflows/CI/badge.svg)](https://github.com/jeremyckahn/farmhand/actions?query=workflow%3ACI) [![Release New Version](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml/badge.svg)](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml)
+
 - [Latest release](https://github.com/jeremyckahn/farmhand/releases/latest)
-- `develop`: [![CI](https://github.com/jeremyckahn/farmhand/workflows/CI/badge.svg)](https://github.com/jeremyckahn/farmhand/actions?query=workflow%3ACI) [![Release New Version](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml/badge.svg)](https://github.com/jeremyckahn/farmhand/actions/workflows/run-release.yml)
+  - Includes native app downloads for Linux and Windows. MacOS is not supported because automatic app updating doesn't work on that platform.
 - All versioned releases available at [unpkg](https://unpkg.com/browse/@jeremyckahn/farmhand/build/)
 - [Wiki](https://github.com/jeremyckahn/farmhand/wiki)
 - [Data model documentation](https://jeremyckahn.github.io/farmhand/docs/index.html)
@@ -25,6 +27,7 @@ Storefront links:
 
 - https://jeremyckahn.itch.io/farmhand
 - https://plaza.dsolver.ca/games/farmhand
+- https://www.appimagehub.com/p/1859153
 
 Farmhand is a resource management game that puts a farm in your hand. It is designed to be both desktop and mobile-friendly and fun for 30 seconds or 30 minutes at a time. Can you build a thriving farming business? Give it a try and find out!
 

--- a/package.json
+++ b/package.json
@@ -147,14 +147,6 @@
       "buildResources": "public",
       "output": "build/native"
     },
-    "mac": {
-      "target": {
-        "target": "dmg",
-        "arch": "universal"
-      },
-      "mergeASARs": false,
-      "icon": "./public/app-icons/Icon-512x512.png"
-    },
     "win": {
       "target": "nsis",
       "icon": "./public/app-icons/Icon-512x512.png"


### PR DESCRIPTION
### What this PR does

This PR removes MacOS app support. This is being done because Electron Builder (the toolchain we are using to generate native apps) [cannot enable app auto-updating without code signing](https://www.electron.build/auto-update):

> macOS application must be [signed](https://www.electron.build/code-signing) in order for auto updating to work.
> ...
> ### Where to Buy Code Signing Certificate
>
> ... Please note — Gatekeeper only recognises [Apple digital certificates](http://stackoverflow.com/questions/11833481/non-apple-issued-code-signing-certificate-can-it-work-with-mac-os-10-8-gatekeep).

[Additionally](https://stackoverflow.com/a/24464807):

> you need to ... pay $99 per year for the Apple developer program so you can get an Apple certificate.

### How this change can be validated

We'll have to run a release and ensure that the "Release New Version" workflow succeeds without generating MacOS artifacts.

### Questions or concerns about this change

This is a bummer of a change, but I think it's important to keep Farmhand fully operational with zero costs. That can't be achieved with MacOS, so unfortunately we won't be able to serve those players as well as those on other platforms. The good news is that Farmhand can be installed as a PWA on any platform, and that will provide a native app experience for all!