### PR TITLE
fix: [fixes #340] prevent seed sales from counting as revenue

### DIFF
--- a/src/game-logic/reducers/sellItem.js
+++ b/src/game-logic/reducers/sellItem.js
@@ -17,7 +17,6 @@ import { decrementItemFromInventory } from './decrementItemFromInventory'
 import { processLevelUp } from './processLevelUp'
 import { addRevenue } from './addRevenue'
 import { updateLearnedRecipes } from './updateLearnedRecipes'
-
 import { adjustLoan } from './adjustLoan'
 
 import { prependPendingPeerMessage } from './index'
@@ -68,9 +67,13 @@ export const sellItem = (state, { id }, howMany = 1) => {
 
   const newItemsSold = { ...itemsSold, [id]: (itemsSold[id] || 0) + howMany }
 
-  // money needs to be passed in explicitly here because state.money gets
-  // mutated above and addRevenue needs its initial value.
-  state = addRevenue({ ...state, money: initialMoney }, saleValue)
+  if (item.isPlantableCrop) {
+    state = { ...state, money: moneyTotal(initialMoney, saleValue) }
+  } else {
+    // money needs to be passed in explicitly here because state.money gets
+    // mutated above and addRevenue needs its initial value.
+    state = addRevenue({ ...state, money: initialMoney }, saleValue)
+  }
 
   state = {
     ...state,

--- a/src/game-logic/reducers/sellItem.test.js
+++ b/src/game-logic/reducers/sellItem.test.js
@@ -29,6 +29,29 @@ describe('sellItem', () => {
     expect(state.itemsSold).toEqual({ 'sample-item-1': 1 })
   })
 
+  test('does not change revenue for seed sales', () => {
+    const state = sellItem(
+      {
+        inventory: [testItem({ id: 'sample-crop-seeds-1', quantity: 1 })],
+        itemsSold: {},
+        loanBalance: 0,
+        money: 100,
+        pendingPeerMessages: [],
+        todaysNotifications: [],
+        revenue: 0,
+        todaysRevenue: 0,
+        valueAdjustments: { 'sample-crop-seeds-1': 1 },
+      },
+      testItem({ id: 'sample-crop-seeds-1' })
+    )
+
+    expect(state.inventory).toEqual([])
+    expect(state.money).toEqual(101)
+    expect(state.revenue).toEqual(0)
+    expect(state.todaysRevenue).toEqual(0)
+    expect(state.itemsSold).toEqual({ 'sample-crop-seeds-1': 1 })
+  })
+
   test('updates learnedRecipes', () => {
     const { learnedRecipes } = sellItem(
       {
@@ -72,8 +95,8 @@ describe('sellItem', () => {
 
         expect(state.loanBalance).toEqual(100)
         expect(state.money).toEqual(130)
-        expect(state.revenue).toEqual(30)
-        expect(state.todaysRevenue).toEqual(30)
+        expect(state.revenue).toEqual(0)
+        expect(state.todaysRevenue).toEqual(0)
       })
     })
 


### PR DESCRIPTION
### What this PR does

This PR addresses an exploit that was [reported by M8theone on Discord](https://discord.com/channels/714539345050075176/822068921653788683/1039629286740611192):

> Currently selling seeds counts towards the all time total revenue

### How this change can be validated

- Sell a seed and observe that neither "Today's Revenue" or "All-Time Total Revenue" stats change.
- Sell a non-seed item and observe that both "Today's Revenue" or "All-Time Total Revenue" stats increase appropriately.