### PR TITLE
fix: [fixes #342] Only apply sale bonuses to farm products

### DIFF
--- a/src/game-logic/reducers/sellItem.js
+++ b/src/game-logic/reducers/sellItem.js
@@ -45,8 +45,10 @@ export const sellItem = (state, { id }, howMany = 1) => {
   const adjustedItemValue = isItemSoldInShop(item)
     ? getResaleValue(item)
     : getAdjustedItemValue(valueAdjustments, id)
+
   const saleIsGarnished = isItemAFarmProduct(item)
   let saleValue = 0
+
   for (let i = 0; i < howMany; i++) {
     const loanGarnishment = saleIsGarnished
       ? Math.min(
@@ -54,9 +56,14 @@ export const sellItem = (state, { id }, howMany = 1) => {
           castToMoney(adjustedItemValue * LOAN_GARNISHMENT_RATE)
         )
       : 0
+
+    const salePriceMultiplier = isItemAFarmProduct(item)
+      ? getSalePriceMultiplier(completedAchievements)
+      : 1
+
     const garnishedProfit =
-      adjustedItemValue * getSalePriceMultiplier(completedAchievements) -
-      loanGarnishment
+      adjustedItemValue * salePriceMultiplier - loanGarnishment
+
     loanBalance = moneyTotal(loanBalance, -loanGarnishment)
     saleValue = moneyTotal(saleValue, garnishedProfit)
   }

--- a/src/game-logic/reducers/sellItem.test.js
+++ b/src/game-logic/reducers/sellItem.test.js
@@ -52,6 +52,58 @@ describe('sellItem', () => {
     expect(state.itemsSold).toEqual({ 'sample-crop-seeds-1': 1 })
   })
 
+  test('applies achievement bonus to farm products', () => {
+    const state = sellItem(
+      {
+        inventory: [testItem({ id: 'sample-item-1', quantity: 1 })],
+        itemsSold: {},
+        loanBalance: 0,
+        money: 100,
+        pendingPeerMessages: [],
+        todaysNotifications: [],
+        revenue: 0,
+        todaysRevenue: 0,
+        valueAdjustments: { 'sample-item-1': 1 },
+        completedAchievements: {
+          'i-am-rich-3': true,
+        },
+      },
+      testItem({ id: 'sample-item-1' })
+    )
+
+    expect(state.inventory).toEqual([])
+    expect(state.money).toEqual(101.25)
+    expect(state.revenue).toEqual(1.25)
+    expect(state.todaysRevenue).toEqual(1.25)
+    expect(state.itemsSold).toEqual({ 'sample-item-1': 1 })
+  })
+
+  test('does not apply achievement bonus to seeds', () => {
+    const state = sellItem(
+      {
+        inventory: [testItem({ id: 'sample-crop-seeds-1', quantity: 1 })],
+        itemsSold: {},
+        loanBalance: 0,
+        money: 100,
+        pendingPeerMessages: [],
+        todaysNotifications: [],
+        revenue: 0,
+        todaysRevenue: 0,
+        valueAdjustments: { 'sample-crop-seeds-1': 1 },
+        completedAchievements: {
+          'i-am-rich-3': true,
+        },
+      },
+      testItem({ id: 'sample-crop-seeds-1' })
+    )
+
+    expect(state.inventory).toEqual([])
+    expect(state.money).toEqual(101)
+    expect(state.revenue).toEqual(0)
+    expect(state.todaysRevenue).toEqual(0)
+    expect(state.itemsSold).toEqual({ 'sample-crop-seeds-1': 1 })
+  })
+
   test('updates learnedRecipes', () => {
     const { learnedRecipes } = sellItem(
       {


### PR DESCRIPTION
### What this PR does

This PR fixes #342 by ensuring that sale bonuses (as earned by the "Millionaire" and "Billionaire" achievements) only apply to farm products (like milk, grown crops, and crafted recipes).

### How this change can be validated

Ensure that only grown crops and milk receive sale bonuses. You can test this on a fresh save by running this in the console:

```js
farmhand.setState({
  inventory: [
    { id: "carrot-seed", quantity: 10 },
    { id: "carrot", quantity: 10 },
    { id: "carrot-soup", quantity: 10 },
    { id: "scarecrow", quantity: 10 },
  ],
  loanBalance: 0,
  completedAchievements: { "i-am-rich-3": true },
});
```

Ensure that Carrot, Carrot Seed, and Scarecrow all sell for the amount that they indicate. You can run the same code but with `completedAchievements: {}` to see how the behavior compares to when a sale bonus is not applied.