### PR TITLE
feat: Improve display of highlighted plots when watering

### DIFF
--- a/src/components/Plot/Plot.sass
+++ b/src/components/Plot/Plot.sass
@@ -1,7 +1,7 @@
 .Plot
   $colorGenericHighlight: rgba(255, 255, 255, 0.8)
   $colorRedDanger: rgba(255, 0, 0, 0.5)
-  $colorBlueWater: rgba(125, 245, 255, 0.75)
+  $colorBlueWater: rgba(125, 245, 255, 0.6)
   $colorBrownFertilize: rgba(125, 56, 0, .75)
   $colorGreenOk: rgba(0, 255, 0, 0.5)
   $colorYellow: rgba(255, 255, 0, 0.75)
@@ -24,7 +24,7 @@
     cursor: pointer
 
   .water-mode &.is-in-hover-range
-    border-color: $colorBlueWater
+    background-color: $colorBlueWater
 
   .fertilize-mode &.can-be-fertilized
     background-color: $colorBrownFertilize


### PR DESCRIPTION
### What this PR does

Based on [discussion in Discord](https://discord.com/channels/714539345050075176/847884323330850847/1040121234454757377), this PR changes how highlighted plots are displayed when the watering can is selected.

### How this change can be validated

Select the watering can and hover over some plots. Change the range slider to increase/decrease the watering range.

### Additional information

#### Old design
![image](https://user-images.githubusercontent.com/366330/201133829-f51e84bb-bd91-460f-8115-9bef281decb5.png)

#### New design:
![image](https://user-images.githubusercontent.com/366330/201133655-43adf13a-f263-49b3-be51-430036a31de7.png)
