### PR TITLE
feat: Show holiday header during December

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -18,7 +18,7 @@ import { achievementsMap } from '../../data/achievements'
 import FarmhandContext from '../Farmhand/Farmhand.context'
 import { STANDARD_LOAN_AMOUNT } from '../../constants'
 import { stageFocusType } from '../../enums'
-import { memoize } from '../../utils'
+import { isDecember, memoize } from '../../utils'
 import Achievement from '../Achievement'
 
 import './Home.sass'
@@ -61,7 +61,16 @@ const Home = ({
   ),
 }) => (
   <div className="Home">
-    <h1>Welcome!</h1>
+    {isDecember() ? (
+      <h1 className="holiday-greeting">
+        Happy holidays!{' '}
+        <span role="img" aria-label="Snowman">
+          ⛄️
+        </span>
+      </h1>
+    ) : (
+      <h1>Welcome!</h1>
+    )}
     <Accordion>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <h2>Click to read a note from the developer</h2>

--- a/src/components/Home/Home.sass
+++ b/src/components/Home/Home.sass
@@ -7,6 +7,9 @@
     margin-bottom: 1em
     text-align: center
 
+    &.holiday-greeting
+      line-height: 1.25em
+
   p
     font-size: 1.2em
     line-height: 1.3em

--- a/src/utils.js
+++ b/src/utils.js
@@ -1291,5 +1291,10 @@ export const isCowInBreedingPen = (cow, cowBreedingPen) =>
  */
 export const isOctober = () => new Date().getMonth() === 9
 
+/**
+ * @returns {boolean}
+ */
+export const isDecember = () => new Date().getMonth() === 11
+
 export { default as isRandomNumberLessThan } from './utils/isRandomNumberLessThan'
 export { default as totalIngredientsInRecipe } from './utils/totalIngredientsInRecipe'


### PR DESCRIPTION
### What this PR does

This PR shows an alternate header on the Home screen during the month of December.

### How this change can be validated

Ensure that the alternate header appears when playing during December and not during any other month. You can simulate another month by running something like the following in your browser's console:

```js
Date.prototype.getMonth = () => 0
```

And then navigating away from the Home page and then back to it.

### Additional information

Desktop view: 
![Desktop screenshot](https://user-images.githubusercontent.com/366330/205092402-118fadef-9716-42ac-82b8-abffa10a1ebd.png)

Mobile view:
![Mobile screnshot](https://user-images.githubusercontent.com/366330/205092500-7abde79c-0953-4da9-9247-7bb7a0bfbdbf.png)