### PR TITLE
chore: Build docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
           reporter: jest-junit # Format of test results
 
       - name: 'Build web app artifacts'
-        run: npm run build
+        run: |
+          npm run build
+          npm run doc
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### What this PR does

This PR updates the CI job to run the JSDoc build process to prevent JSDoc errors from being merged to stable branches.

### How this change can be validated

Ensure that the CI job for this PR succeeds.

### Additional information

This was made as a result of JSDoc errors breaking a production build: https://github.com/jeremyckahn/farmhand/actions/runs/3602696645/jobs/6069975304