### PR TITLE
feat: Improve peer re-connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@jeremyckahn/farmhand",
-      "version": "1.15.11",
+      "version": "1.15.13",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.27",
@@ -47,7 +47,7 @@
         "redis": "^3.0.2",
         "shifty": "^2.15.2",
         "source-map-explorer": "^2.3.1",
-        "trystero": "^0.11.1",
+        "trystero": "github:jeremyckahn/trystero#bugfix/29__clean-up-peers",
         "typeface-francois-one": "0.0.71",
         "typeface-public-sans": "^1.1.4",
         "uuid": "^3.4.0",
@@ -34840,9 +34840,9 @@
       "dev": true
     },
     "node_modules/trystero": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/trystero/-/trystero-0.11.1.tgz",
-      "integrity": "sha512-4enMGKePEeR6WtZbWp9aGf8PkLq5K25q9+tHBIn36egxX+1enAxnXdg+6/YYhI3kcr1PDyBrMYKeZZ5H+J/2NQ==",
+      "version": "0.11.7",
+      "resolved": "git+ssh://git@github.com/jeremyckahn/trystero.git#65ca75baac7a9df40fd217c6533dea2b059a15e7",
+      "license": "MIT",
       "dependencies": {
         "firebase": "^9.6.5",
         "ipfs-core": "0.9.0",
@@ -65337,9 +65337,8 @@
       "dev": true
     },
     "trystero": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/trystero/-/trystero-0.11.1.tgz",
-      "integrity": "sha512-4enMGKePEeR6WtZbWp9aGf8PkLq5K25q9+tHBIn36egxX+1enAxnXdg+6/YYhI3kcr1PDyBrMYKeZZ5H+J/2NQ==",
+      "version": "git+ssh://git@github.com/jeremyckahn/trystero.git#65ca75baac7a9df40fd217c6533dea2b059a15e7",
+      "from": "trystero@github:jeremyckahn/trystero#bugfix/29__clean-up-peers",
       "requires": {
         "firebase": "^9.6.5",
         "ipfs-core": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "redis": "^3.0.2",
     "shifty": "^2.15.2",
     "source-map-explorer": "^2.3.1",
-    "trystero": "^0.11.1",
+    "trystero": "github:jeremyckahn/trystero#bugfix/29__clean-up-peers",
     "typeface-francois-one": "0.0.71",
     "typeface-public-sans": "^1.1.4",
     "uuid": "^3.4.0",


### PR DESCRIPTION
### What this PR does

This PR incorporates https://github.com/dmotz/trystero/pull/30 to improve peer re-connection when playing online. Typically when an online player puts their computer to sleep and wakes it up again later, the player will not be able to reconnect to peers until they refresh the page. This is an attempt to enable players to reconnect automatically without a page refresh.

### How this change can be validated

You'll need two computers to test this. On both computers, join the same Farmhand room. On computer A, turn off the WiFi. On computer B, the peer should disappear within about a minute. Turn computer A's WiFi back on. Within 1-2 minutes, computer A should successfully reconnect to computer B again. 

### Questions or concerns about this change

https://github.com/dmotz/trystero/pull/30 has not yet been accepted by Trystero's developer, so this is still experimental. However, I think it should be fairly safe to put into Production. If this ends up causing issues then rolling back (reverting this PR) should be quick, safe, and easy.

### Additional information

This does not improve re-connection for iOS Safari. See [this comment](https://github.com/dmotz/trystero/pull/30#issuecomment-1336566515) for more info. I'm still investigating how to improve things for iOS players.