### PR TITLE
crow logic updates

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -63,7 +63,7 @@ export const PURCHASEABLE_COW_PENS = freeze(
 )
 
 // Buff/nerf chances
-export const CROW_CHANCE = 0.1
+export const CROW_CHANCE = 0.4
 export const MAX_CROWS = 5
 export const PRECIPITATION_CHANCE = 0.1
 export const STORM_CHANCE = 0.5

--- a/src/constants.js
+++ b/src/constants.js
@@ -64,6 +64,7 @@ export const PURCHASEABLE_COW_PENS = freeze(
 
 // Buff/nerf chances
 export const CROW_CHANCE = 0.1
+export const MAX_CROWS = 5
 export const PRECIPITATION_CHANCE = 0.1
 export const STORM_CHANCE = 0.5
 

--- a/src/game-logic/reducers/applyCrows.js
+++ b/src/game-logic/reducers/applyCrows.js
@@ -1,5 +1,5 @@
 import { doesPlotContainCrop } from '../../utils'
-import { MAX_CROWS } from '../../constants'
+import { CROW_CHANCE, MAX_CROWS } from '../../constants'
 import { CROWS_DESTROYED } from '../../templates'
 
 import { modifyFieldPlotAt } from './modifyFieldPlotAt'
@@ -14,8 +14,8 @@ import { fieldHasScarecrow } from './helpers'
 export const applyCrows = state => {
   const { field, purchasedField } = state
 
-  if (fieldHasScarecrow(field)) {
-    return field
+  if (fieldHasScarecrow(field) || Math.random() > CROW_CHANCE) {
+    return state
   }
 
   const newDayNotifications = [...state.newDayNotifications]

--- a/src/game-logic/reducers/applyCrows.js
+++ b/src/game-logic/reducers/applyCrows.js
@@ -1,4 +1,4 @@
-import { doesPlotContainCrop } from '../../utils'
+import { doesPlotContainCrop, isRandomNumberLessThan } from '../../utils'
 import { CROW_CHANCE, MAX_CROWS } from '../../constants'
 import { CROWS_DESTROYED } from '../../templates'
 
@@ -14,7 +14,7 @@ import { fieldHasScarecrow } from './helpers'
 export const applyCrows = state => {
   const { field, purchasedField } = state
 
-  if (fieldHasScarecrow(field) || Math.random() > CROW_CHANCE) {
+  if (fieldHasScarecrow(field) || !isRandomNumberLessThan(CROW_CHANCE)) {
     return state
   }
 

--- a/src/game-logic/reducers/applyCrows.js
+++ b/src/game-logic/reducers/applyCrows.js
@@ -3,6 +3,7 @@ import { CROW_CHANCE, MAX_CROWS } from '../../constants'
 import { CROWS_DESTROYED } from '../../templates'
 
 import { modifyFieldPlotAt } from './modifyFieldPlotAt'
+import { forRange } from './forRange'
 
 import { fieldHasScarecrow } from './helpers'
 
@@ -14,7 +15,7 @@ import { fieldHasScarecrow } from './helpers'
 export const applyCrows = state => {
   const { field, purchasedField } = state
 
-  if (fieldHasScarecrow(field) || !isRandomNumberLessThan(CROW_CHANCE)) {
+  if (fieldHasScarecrow(field) || isRandomNumberLessThan(1 - CROW_CHANCE)) {
     return state
   }
 
@@ -23,12 +24,18 @@ export const applyCrows = state => {
   let notificationMessages = []
   const plotsWithCrops = []
 
-  field.forEach((row, y) =>
-    row.forEach((plotContents, x) => {
-      if (doesPlotContainCrop(plotContents)) {
+  forRange(
+    state,
+    (_, x, y) => {
+      if (doesPlotContainCrop(state.field[y][x])) {
         plotsWithCrops.push({ x, y })
       }
-    })
+
+      return state
+    },
+    Infinity,
+    0,
+    0
   )
 
   const numCrows = Math.min(

--- a/src/game-logic/reducers/applyCrows.js
+++ b/src/game-logic/reducers/applyCrows.js
@@ -3,11 +3,26 @@ import { CROW_CHANCE, MAX_CROWS } from '../../constants'
 import { CROWS_DESTROYED } from '../../templates'
 
 import { modifyFieldPlotAt } from './modifyFieldPlotAt'
-import { forRange } from './forRange'
 
 import { fieldHasScarecrow } from './helpers'
 
-// TODO: Add tests for this reducer.
+/**
+ * @param {farmhand.state} state
+ * @callback {forEachPlotCallback} callback
+ */
+function forEachPlot(state, callback) {
+  state.field.forEach((row, y) =>
+    row.forEach((plotContents, x) => callback(plotContents, x, y))
+  )
+}
+
+/**
+ * @callback forEachPlotCallback
+ * @param {object} plotContents - the contents of the plot
+ * @param {number} x - the X coordinate for the plot
+ * @param {number} y - the Y coordinate for the plot
+ */
+
 /**
  * @param {farmhand.state} state
  * @returns {farmhand.state}
@@ -24,19 +39,11 @@ export const applyCrows = state => {
   let notificationMessages = []
   const plotsWithCrops = []
 
-  forRange(
-    state,
-    (_, x, y) => {
-      if (doesPlotContainCrop(state.field[y][x])) {
-        plotsWithCrops.push({ x, y })
-      }
-
-      return state
-    },
-    Infinity,
-    0,
-    0
-  )
+  forEachPlot(state, (plotContents, x, y) => {
+    if (doesPlotContainCrop(state.field[y][x])) {
+      plotsWithCrops.push({ x, y })
+    }
+  })
 
   const numCrows = Math.min(
     plotsWithCrops.length,

--- a/src/game-logic/reducers/applyCrows.js
+++ b/src/game-logic/reducers/applyCrows.js
@@ -10,7 +10,7 @@ import { fieldHasScarecrow } from './helpers'
  * @param {farmhand.state} state
  * @callback {forEachPlotCallback} callback
  */
-function forEachPlot(state, callback) {
+export function forEachPlot(state, callback) {
   state.field.forEach((row, y) =>
     row.forEach((plotContents, x) => callback(plotContents, x, y))
   )

--- a/src/game-logic/reducers/applyCrows.test.js
+++ b/src/game-logic/reducers/applyCrows.test.js
@@ -1,0 +1,94 @@
+import { findInField, isRandomNumberLessThan } from '../../utils'
+import { MAX_CROWS, SCARECROW_ITEM_ID } from '../../constants'
+
+import { applyCrows, forEachPlot } from './applyCrows'
+
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  isRandomNumberLessThan: jest.fn(),
+}))
+
+const CARROT = 'carrot'
+
+describe('applyCrows', () => {
+  let state
+
+  const addToField = itemId => state.field[0].push({ itemId })
+  const findCarrot = plot => plot?.itemId === CARROT
+
+  beforeEach(() => {
+    state = {
+      field: [[]],
+      purchasedField: 0,
+      newDayNotifications: [],
+    }
+
+    addToField(CARROT)
+
+    jest.spyOn(Math, 'random')
+  })
+
+  describe('no crows spawned', () => {
+    it('does not affect plots if a scarecrow is present', () => {
+      addToField(SCARECROW_ITEM_ID)
+
+      const newState = applyCrows(state)
+
+      expect(newState.field).toEqual(state.field)
+    })
+
+    it('does not modify plots if rng fails', () => {
+      isRandomNumberLessThan.mockReturnValue(true)
+      const newState = applyCrows(state)
+
+      expect(newState.field).toEqual(state.field)
+    })
+
+    it('does not create a notification if crops are not destroyed', () => {
+      addToField(SCARECROW_ITEM_ID)
+      const newState = applyCrows(state)
+
+      expect(newState.newDayNotifications).toHaveLength(0)
+    })
+  })
+
+  describe('crows spawned', () => {
+    beforeEach(() => {
+      isRandomNumberLessThan.mockReturnValue(false)
+      Math.random.mockReturnValueOnce(1) // spawn max amount of crows
+    })
+
+    it('destroys a crop for every crow spawned', () => {
+      const newState = applyCrows(state)
+
+      expect(findInField(newState.field, findCarrot)).toEqual(null)
+    })
+
+    it('will not destroy more crops than the max number of crows', () => {
+      for (let i = 0; i < MAX_CROWS; i++) {
+        addToField(CARROT)
+      }
+
+      const newState = applyCrows(state)
+
+      let numCarrotsRemaining = 0
+
+      forEachPlot(newState, plotContents => {
+        if (plotContents?.itemId === CARROT) {
+          numCarrotsRemaining += 1
+        }
+      })
+
+      expect(numCarrotsRemaining).toEqual(1)
+    })
+
+    it('creates a notification when crops are destroyed', () => {
+      const newState = applyCrows(state)
+
+      expect(newState.newDayNotifications[0]).toEqual({
+        message: 'Oh no! Crows destroyed 1 crop!',
+        severity: 'error',
+      })
+    })
+  })
+})

--- a/src/game-logic/reducers/processNerfs.test.js
+++ b/src/game-logic/reducers/processNerfs.test.js
@@ -1,109 +1,13 @@
-import { testCrop } from '../../test-utils'
-import { CROW_ATTACKED } from '../../templates'
-import { SCARECROW_ITEM_ID } from '../../constants'
-import { itemsMap } from '../../data/maps'
-import { getPlotContentFromItemId } from '../../utils'
+import { applyCrows } from './applyCrows'
 
 import { processNerfs } from './processNerfs'
 
-jest.mock('../../data/maps')
-
-jest.mock('../../constants', () => ({
-  __esModule: true,
-  ...jest.requireActual('../../constants'),
-  CROW_CHANCE: 0,
-}))
+jest.mock('./applyCrows')
 
 describe('processNerfs', () => {
-  describe('crows', () => {
-    describe('crows do not attack', () => {
-      test('crop is safe', () => {
-        const state = processNerfs({
-          field: [[testCrop({ itemId: 'sample-crop-1' })]],
-          newDayNotifications: [],
-        })
+  it('invokes applyCrows', () => {
+    processNerfs({})
 
-        expect(state.field[0][0]).toEqual(testCrop({ itemId: 'sample-crop-1' }))
-        expect(state.newDayNotifications).toEqual([])
-      })
-    })
-
-    describe('crows attack', () => {
-      test('crop is destroyed', () => {
-        jest.resetModules()
-        jest.mock('../../constants', () => ({
-          CROW_CHANCE: 1,
-        }))
-
-        const { processNerfs } = jest.requireActual('./processNerfs')
-        const state = processNerfs({
-          field: [[testCrop({ itemId: 'sample-crop-1' })]],
-          newDayNotifications: [],
-        })
-
-        expect(state.field[0][0]).toBe(null)
-        expect(state.newDayNotifications).toEqual([
-          {
-            message: CROW_ATTACKED`${itemsMap['sample-crop-1']}`,
-            severity: 'error',
-          },
-        ])
-      })
-
-      test('multiple messages are grouped', () => {
-        jest.resetModules()
-        jest.mock('../../constants', () => ({
-          CROW_CHANCE: 1,
-        }))
-
-        const { processNerfs } = jest.requireActual('./processNerfs')
-        const state = processNerfs({
-          field: [
-            [
-              testCrop({ itemId: 'sample-crop-1' }),
-              testCrop({ itemId: 'sample-crop-2' }),
-            ],
-          ],
-          newDayNotifications: [],
-        })
-
-        expect(state.field[0][0]).toBe(null)
-        expect(state.newDayNotifications).toEqual([
-          {
-            message: [
-              CROW_ATTACKED`${itemsMap['sample-crop-1']}`,
-              CROW_ATTACKED`${itemsMap['sample-crop-2']}`,
-            ].join('\n\n'),
-            severity: 'error',
-          },
-        ])
-      })
-
-      describe('there is a scarecrow', () => {
-        test('crow attack is prevented', () => {
-          jest.resetModules()
-          jest.mock('../../constants', () => ({
-            CROW_CHANCE: 1,
-            SCARECROW_ITEM_ID: 'scarecrow',
-          }))
-
-          const { processNerfs } = jest.requireActual('./processNerfs')
-          const state = processNerfs({
-            field: [
-              [
-                testCrop({ itemId: 'sample-crop-1' }),
-                getPlotContentFromItemId(SCARECROW_ITEM_ID),
-              ],
-            ],
-            newDayNotifications: [],
-          })
-
-          expect(state.field[0][0]).toEqual(
-            testCrop({ itemId: 'sample-crop-1' })
-          )
-          expect(state.newDayNotifications).toEqual([])
-        })
-      })
-    })
+    expect(applyCrows).toHaveBeenCalled()
   })
 })

--- a/src/templates.js
+++ b/src/templates.js
@@ -19,6 +19,11 @@ import { itemsMap } from './data/maps'
  */
 export const CROW_ATTACKED = (_, crop) => `Oh no a crow ate your ${crop.name}!`
 
+export const CROWS_DESTROYED = (_, numCropsDestroyed) =>
+  `Crows destroyed ${numCropsDestroyed} crop${
+    numCropsDestroyed > 1 ? 's' : ''
+  }!`
+
 /**
  * @param {number} cows
  * @returns {string}

--- a/src/templates.js
+++ b/src/templates.js
@@ -19,8 +19,12 @@ import { itemsMap } from './data/maps'
  */
 export const CROW_ATTACKED = (_, crop) => `Oh no a crow ate your ${crop.name}!`
 
+/**
+ * @param {number} numCropsDestroyed
+ * @returns {string}
+ */
 export const CROWS_DESTROYED = (_, numCropsDestroyed) =>
-  `Crows destroyed ${numCropsDestroyed} crop${
+  `Oh no! Crows destroyed ${numCropsDestroyed} crop${
     numCropsDestroyed > 1 ? 's' : ''
   }!`
 


### PR DESCRIPTION
### What this PR does

this change alters crow logic so that there is a maximum number of crows that can be spawned and those crows then pick from plots that currently have crops at random to destroy them. previously, all plots were subject to an attack based on a random chance which could result in a lot of crops being destroyed at once.

this change also updates the notification after crows destroy plots to mention the number of plots destroyed in a single notification instead of one per plot destroyed which would often result in a flood of notifications that were hard to read before they would disappear.

### How this change can be validated

Plant crops and then advance days. If there is no scarecrow, you should see some crops destroyed and the new notification. There is also a random chance no crops will be destroyed over night. When a scarecrow is present, no crops should ever be destroyed.

### Questions or concerns about this change

If it's preferred to go back to a notification per destroyed crop, or to bundle them up in a different way (such as a notification per crop _type_ destroyed) I can make that change. I wasn't sure how much it really mattered to know about every single one since they kinda disappear faster than they can be read when there's a lot anyways.

There is currently no spec for the `applyCrows` logic so I will work on adding that as well.

### Additional information

<img width="478" alt="Screen Shot 2022-12-28 at 10 06 51 AM" src="https://user-images.githubusercontent.com/628757/209856266-2b1e4db4-390f-478a-ac3e-69aaab4b85d2.png">

<img width="430" alt="Screen Shot 2022-12-28 at 10 07 08 AM" src="https://user-images.githubusercontent.com/628757/209856269-ec38f70c-82bc-4009-a5d9-a8adde8a8951.png">

