### PR TITLE
fix: Disable MacOS builds

### DIFF
--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### What this PR does

This PR temporarily disable MacOS builds. There is a new build breakage that's [causing the Release workflow to ultimately break](https://github.com/jeremyckahn/farmhand/actions/runs/3813347452/jobs/6487066812).

### How this change can be validated

Run a release and hope that nothing breaks. 🙃