### PR TITLE
[closes #259] added scarecrow to inventory at initial state of the game

### DIFF
--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -101,6 +101,8 @@ import {
 } from '../../strings'
 import { endpoints, rtcConfig, trackerUrls } from '../../config'
 
+import { scarecrow } from '../../data/items'
+
 import { getInventoryQuantities } from './helpers/getInventoryQuantities'
 import FarmhandContext from './Farmhand.context'
 
@@ -386,7 +388,7 @@ export default class Farmhand extends Component {
       historicalValueAdjustments: [],
       hoveredPlotRangeSize: 0,
       id: uuid(),
-      inventory: [],
+      inventory: [{ id: scarecrow.id, quantity: 1 }],
       inventoryLimit: INITIAL_STORAGE_LIMIT,
       isAwaitingCowTradeRequest: false,
       isAwaitingNetworkRequest: false,


### PR DESCRIPTION
### What this PR does
It adds a scarecrow at the beginning of the game by including an item object at inventory of initial state

### How this change can be validated
By running a new game, and the scarecrow will be seen in the inventory. You can also see the scarecrow at the side menu in the fields tab.

### Questions or concerns about this change
Currently the scarecrow is added but the $500 at the start still remains. Should it be reduced by $160 to account for the scarecrow?

Should addItemToInventory be used instead of "hardcoding" it into the initial state?

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
