### PR TITLE
fix: Prevent Olive Seed from being available at the start of the game

### DIFF
--- a/src/data/levels.js
+++ b/src/data/levels.js
@@ -90,7 +90,7 @@ levels[36] = {
 }
 
 levels[38] = {
-  unlocksShopItem: items.olive.id,
+  unlocksShopItem: items.oliveSeed.id,
 }
 
 levels[40] = {


### PR DESCRIPTION
### What this PR does

It prevents Olive Seed from being available at the start of the game.

### How this change can be validated

Ensure that Olive Seeds are not available for brand new save files.

### Questions or concerns about this change

### Additional information

This is a hotfix for #377.