### PR TITLE
fix: [fixes #385] Ensure valid breeding pen references

### DIFF
--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -57,11 +57,10 @@ const Subheader = ({
 
   const mateId = cowBreedingPen.cowId1 ?? cowBreedingPen.cowId2
   const mate = getCowMapById(cowInventory)[mateId]
+  const isEligibleToBreed = cow.gender !== mate?.gender
 
-  const isEligibleToBreed =
-    (!mate || cow.gender !== mate.gender) && !isThisCowOfferedForTrade
-
-  const canBeMovedToBreedingPen = isRoomInBreedingPen && isEligibleToBreed
+  const canBeMovedToBreedingPen =
+    isRoomInBreedingPen && isEligibleToBreed && !isThisCowOfferedForTrade
 
   const disableBreedingControlTooltip =
     !canBeMovedToBreedingPen && !isInBreedingPen

--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -46,28 +46,22 @@ const Subheader = ({
   handleCowAutomaticHugChange,
   handleCowBreedChange,
   huggingMachinesRemain,
-  id,
+  id, // Player ID, not cow ID
   isCowPurchased,
 }) => {
   const numberOfFullHearts = cow.happiness * 10
   const isInBreedingPen = isCowInBreedingPen(cow, cowBreedingPen)
-  const isBreedingPenFull =
-    cowBreedingPen.cowId1 !== null && cowBreedingPen.cowId2 !== null
+  const isRoomInBreedingPen =
+    cowBreedingPen.cowId1 === null || cowBreedingPen.cowId2 === null
+  const isThisCowOfferedForTrade = cowIdOfferedForTrade === cow.id
 
-  const isCowOfferedForTrade = !!cowInventory.find(
-    ({ id }) => id === cowIdOfferedForTrade
-  )
+  const mateId = cowBreedingPen.cowId1 ?? cowBreedingPen.cowId2
+  const mate = getCowMapById(cowInventory)[mateId]
 
-  let canBeMovedToBreedingPen = !isBreedingPenFull && !isCowOfferedForTrade
+  const isEligibleToBreed =
+    (!mate || cow.gender !== mate.gender) && !isThisCowOfferedForTrade
 
-  if (canBeMovedToBreedingPen) {
-    const potentialMateId = cowBreedingPen.cowId2 ?? cowBreedingPen.cowId1
-
-    if (potentialMateId !== null) {
-      canBeMovedToBreedingPen =
-        cow.gender !== getCowMapById(cowInventory)[potentialMateId].gender
-    }
-  }
+  const canBeMovedToBreedingPen = isRoomInBreedingPen && isEligibleToBreed
 
   const disableBreedingControlTooltip =
     !canBeMovedToBreedingPen && !isInBreedingPen

--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -46,7 +46,7 @@ const Subheader = ({
   handleCowAutomaticHugChange,
   handleCowBreedChange,
   huggingMachinesRemain,
-  id, // Player ID, not cow ID
+  id: playerId,
   isCowPurchased,
 }) => {
   const numberOfFullHearts = cow.happiness * 10
@@ -66,7 +66,9 @@ const Subheader = ({
     !canBeMovedToBreedingPen && !isInBreedingPen
 
   const showOriginalOwner =
-    isCowPurchased && id !== cow.originalOwnerId && id === cow.ownerId
+    isCowPurchased &&
+    playerId !== cow.originalOwnerId &&
+    playerId === cow.ownerId
 
   return (
     <div {...{ className: 'Subheader' }}>

--- a/src/game-logic/reducers/changeCowBreedingPenResident.js
+++ b/src/game-logic/reducers/changeCowBreedingPenResident.js
@@ -1,6 +1,24 @@
 import { COW_GESTATION_PERIOD_DAYS } from '../../constants'
 
 /**
+ * @param {farmhand.cow} cow
+ * @param {farmhand.cowBreedingPen} cowBreedingPen
+ * @param {Array.<farmhand.cow>} cowInventory
+ * @return {boolean}
+ */
+const cowCanBeAdded = (cow, cowBreedingPen, cowInventory) => {
+  const { cowId1, cowId2 } = cowBreedingPen
+  const isBreedingPenFull = cowId1 !== null && cowId2 !== null
+  const isCowInBreedingPen = cowId1 === cow.id || cowId2 === cow.id
+
+  const isCowInInventory = !!cowInventory.find(({ id }) => {
+    return id === cow.id
+  })
+
+  return isCowInInventory && !isBreedingPenFull && !isCowInBreedingPen
+}
+
+/**
  * @param {farmhand.state} state
  * @param {farmhand.cow} cow
  * @param {boolean} isAdding If true, cow will be added to the breeding pen. If
@@ -10,26 +28,21 @@ import { COW_GESTATION_PERIOD_DAYS } from '../../constants'
 export const changeCowBreedingPenResident = (state, cow, isAdding) => {
   const { cowBreedingPen, cowInventory } = state
   const { cowId1, cowId2 } = cowBreedingPen
-  const isBreedingPenFull = cowId1 !== null && cowId2 !== null
   const isCowInBreedingPen = cowId1 === cow.id || cowId2 === cow.id
   let newCowBreedingPen = { ...cowBreedingPen }
 
-  const isCowInInventory = !!cowInventory.find(({ id }) => {
-    return id === cow.id
-  })
+  if (isAdding && !cowCanBeAdded(cow, cowBreedingPen, cowInventory)) {
+    return state
+  }
+
+  if (!isAdding && !isCowInBreedingPen) {
+    return state
+  }
 
   if (isAdding) {
-    if (!isCowInInventory || isBreedingPenFull || isCowInBreedingPen) {
-      return state
-    }
-
-    const cowId = cowId1 === null ? 'cowId1' : 'cowId2'
-    newCowBreedingPen = { ...newCowBreedingPen, [cowId]: cow.id }
+    const breedingPenCowId = cowId1 === null ? 'cowId1' : 'cowId2'
+    newCowBreedingPen = { ...newCowBreedingPen, [breedingPenCowId]: cow.id }
   } else {
-    if (!isCowInBreedingPen) {
-      return state
-    }
-
     if (cowId1 === cow.id) {
       newCowBreedingPen = {
         ...newCowBreedingPen,

--- a/src/game-logic/reducers/changeCowBreedingPenResident.js
+++ b/src/game-logic/reducers/changeCowBreedingPenResident.js
@@ -3,26 +3,30 @@ import { COW_GESTATION_PERIOD_DAYS } from '../../constants'
 /**
  * @param {farmhand.state} state
  * @param {farmhand.cow} cow
- * @param {boolean} doAdd If true, cow will be added to the breeding pen. If
+ * @param {boolean} isAdding If true, cow will be added to the breeding pen. If
  * false, they will be removed.
  * @returns {farmhand.state}
  */
-export const changeCowBreedingPenResident = (state, cow, doAdd) => {
-  const { cowBreedingPen } = state
+export const changeCowBreedingPenResident = (state, cow, isAdding) => {
+  const { cowBreedingPen, cowInventory } = state
   const { cowId1, cowId2 } = cowBreedingPen
-  const isPenFull = cowId1 !== null && cowId2 !== null
-  const isCowInPen = cowId1 === cow.id || cowId2 === cow.id
+  const isBreedingPenFull = cowId1 !== null && cowId2 !== null
+  const isCowInBreedingPen = cowId1 === cow.id || cowId2 === cow.id
   let newCowBreedingPen = { ...cowBreedingPen }
 
-  if (doAdd) {
-    if (isPenFull || isCowInPen) {
+  const isCowInInventory = !!cowInventory.find(({ id }) => {
+    return id === cow.id
+  })
+
+  if (isAdding) {
+    if (!isCowInInventory || isBreedingPenFull || isCowInBreedingPen) {
       return state
     }
 
     const cowId = cowId1 === null ? 'cowId1' : 'cowId2'
     newCowBreedingPen = { ...newCowBreedingPen, [cowId]: cow.id }
   } else {
-    if (!isCowInPen) {
+    if (!isCowInBreedingPen) {
       return state
     }
 

--- a/src/game-logic/reducers/changeCowBreedingPenResident.test.js
+++ b/src/game-logic/reducers/changeCowBreedingPenResident.test.js
@@ -97,6 +97,23 @@ describe('changeCowBreedingPenResident', () => {
       })
     })
 
+    describe('cow is not in inventory', () => {
+      test('no-ops', () => {
+        const inputState = {
+          cowBreedingPen: {
+            cowId1: 'cow-a',
+            cowId2: null,
+            daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
+          },
+          cowInventory: [cowA],
+        }
+
+        const state = changeCowBreedingPenResident(inputState, cowB, true)
+
+        expect(state).toBe(inputState)
+      })
+    })
+
     describe('breeding pen is full', () => {
       test('no-ops', () => {
         const inputState = {

--- a/src/game-logic/reducers/changeCowBreedingPenResident.test.js
+++ b/src/game-logic/reducers/changeCowBreedingPenResident.test.js
@@ -3,6 +3,10 @@ import { generateCow } from '../../utils'
 
 import { changeCowBreedingPenResident } from './changeCowBreedingPenResident'
 
+const cowA = generateCow({ id: 'cow-a' })
+const cowB = generateCow({ id: 'cow-b' })
+const cowC = generateCow({ id: 'cow-c' })
+
 describe('changeCowBreedingPenResident', () => {
   describe('doAdd === false', () => {
     describe('cow is not in breeding pen', () => {
@@ -13,13 +17,10 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: 'cow-b',
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB, cowC],
         }
 
-        const state = changeCowBreedingPenResident(
-          inputState,
-          generateCow({ id: 'cow-c' }),
-          false
-        )
+        const state = changeCowBreedingPenResident(inputState, cowC, false)
 
         expect(state).toBe(inputState)
       })
@@ -34,8 +35,9 @@ describe('changeCowBreedingPenResident', () => {
               cowId2: 'cow-b',
               daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
             },
+            cowInventory: [cowA, cowB],
           },
-          generateCow({ id: 'cow-a' }),
+          cowA,
           false
         )
 
@@ -45,6 +47,7 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: null,
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB],
         })
       })
     })
@@ -58,8 +61,9 @@ describe('changeCowBreedingPenResident', () => {
               cowId2: 'cow-b',
               daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
             },
+            cowInventory: [cowA, cowB],
           },
-          generateCow({ id: 'cow-b' }),
+          cowB,
           false
         )
 
@@ -69,6 +73,7 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: null,
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB],
         })
       })
     })
@@ -83,13 +88,10 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: 'cow-b',
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB],
         }
 
-        const state = changeCowBreedingPenResident(
-          inputState,
-          generateCow({ id: 'cow-a' }),
-          true
-        )
+        const state = changeCowBreedingPenResident(inputState, cowA, true)
 
         expect(state).toBe(inputState)
       })
@@ -103,13 +105,10 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: 'cow-b',
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB],
         }
 
-        const state = changeCowBreedingPenResident(
-          inputState,
-          generateCow({ id: 'cow-c' }),
-          true
-        )
+        const state = changeCowBreedingPenResident(inputState, cowC, true)
 
         expect(state).toBe(inputState)
       })
@@ -124,8 +123,9 @@ describe('changeCowBreedingPenResident', () => {
               cowId2: null,
               daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
             },
+            cowInventory: [cowA, cowB],
           },
-          generateCow({ id: 'cow-a' }),
+          cowA,
           true
         )
 
@@ -135,6 +135,7 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: null,
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB],
         })
       })
     })
@@ -148,8 +149,9 @@ describe('changeCowBreedingPenResident', () => {
               cowId2: null,
               daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
             },
+            cowInventory: [cowA, cowB],
           },
-          generateCow({ id: 'cow-b' }),
+          cowB,
           true
         )
 
@@ -159,6 +161,7 @@ describe('changeCowBreedingPenResident', () => {
             cowId2: 'cow-b',
             daysUntilBirth: COW_GESTATION_PERIOD_DAYS,
           },
+          cowInventory: [cowA, cowB],
         })
       })
     })

--- a/src/handlers/peer-events.js
+++ b/src/handlers/peer-events.js
@@ -91,7 +91,7 @@ export const handleCowTradeRequest = async (
 
       if (!peerMetadata) {
         console.error(`No data for peer ${updatedCowOffered.ownerId}`)
-        return
+        return null
       }
 
       state = changeCowAutomaticHugState(state, cowToTradeAway, false)


### PR DESCRIPTION
### What this PR does

This PR is a **speculative** fix for #385. I wasn't able to reproduce the bug that was reported, but after spending some time with the code I believe I've identified a possible race condition related to cow trading. This race condition could lead to the breeding pen data referencing cows that don't exist in the inventory, thus corrupting the data. This PR introduces a check to ensure that such an invalid reference is never made.

### How this change can be validated

Ensure that there are no regressions related to moving cows into or out of the breeding pen or cow trading.

### Additional information

I plan to close #385 by merging this. I couldn't reproduce it and there's not much value in leaving the ticket open since we can't prove a negative. If this issue resurfaces, we can always reopen the ticket.