### PR TITLE
feat: Automatically update wiki tables

### DIFF
--- a/.github/workflow_helpers/update-tables.sh
+++ b/.github/workflow_helpers/update-tables.sh
@@ -13,8 +13,10 @@ npm run --silent print:crops > Crops.md
 
 echo "Updated Crops.md"
 
-git config --global user.email "github-actions@users.noreply.github.com"
-git config --global user.name "github-actions[bot]"
-git add Crops.md
-git commit -m "Update tables"
-git push origin master
+if [[ `git status --short | wc -l` > 0 ]]; then
+  git config --global user.email "github-actions@users.noreply.github.com"
+  git config --global user.name "github-actions[bot]"
+  git add Crops.md
+  git commit -m "Update tables"
+  git push origin master
+fi

--- a/.github/workflow_helpers/update-tables.sh
+++ b/.github/workflow_helpers/update-tables.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# https://spinscale.de/posts/2021-10-29-github-actions-updating-github-wiki-after-edit.html
+
+#########
+# some debug output to check in case of failures
+# also exit on any error
+set -xe
+
+cd $1
+
+npm run --silent print:crops > Crops.md
+
+echo "Updated Crops.md"
+
+git config --global user.email "github-actions@users.noreply.github.com"
+git config --global user.name "github-actions[bot]"
+git add Crops.md
+git commit -m "Update tables"
+git push origin master

--- a/.github/workflow_helpers/update-tables.sh
+++ b/.github/workflow_helpers/update-tables.sh
@@ -19,4 +19,6 @@ if [[ `git status --short | wc -l` > 0 ]]; then
   git add Crops.md
   git commit -m "Update tables"
   git push origin master
+else
+  echo "No table changes were made. Skipping wiki update."
 fi

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -1,0 +1,29 @@
+# https://spinscale.de/posts/2021-10-29-github-actions-updating-github-wiki-after-edit.html
+name: Update Wiki
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'feature/automatically-update-tables'
+
+jobs:
+  update_wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - name: Check out wiki
+        uses: actions/checkout@v3
+        with:
+          repository: 'jeremyckahn/farmhand.wiki'
+          ref: 'master'
+          path: 'farmhand.wiki'
+      - name: Update tables
+        working-directory: ./.github/workflow_helpers
+        run: |
+          ./update-tables.sh $GITHUB_WORKSPACE/farmhand.wiki

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'feature/automatically-update-tables'
 
 jobs:
   update_wiki:

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -1,6 +1,8 @@
 # https://spinscale.de/posts/2021-10-29-github-actions-updating-github-wiki-after-edit.html
 name: Update Wiki
 
+# TODO: Consider rolling this into run-release.yml
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
### What this PR does

This PR builds on #405 by automating crop table wiki updates when a release occurs.

### How this change can be validated

Open https://github.com/jeremyckahn/farmhand/wiki/Crops and observe that the table was committed by `github-actions[bot]`.

### Additional information

I'd like to expand this over time by automatically generating tables for things like Recipes.