### PR TITLE
feat(Cellar): [closes #418] Keg spoilage

### DIFF
--- a/src/components/Cellar/Keg.js
+++ b/src/components/Cellar/Keg.js
@@ -17,6 +17,7 @@ import { FERMENTED_CROP_NAME } from '../../templates'
 import AnimatedNumber from '../AnimatedNumber'
 
 import './Keg.sass'
+import { getKegSpoilageRate } from '../../utils/getKegSpoilageRate'
 
 /**
  * @param {Object} props
@@ -54,6 +55,9 @@ export function Keg({ keg }) {
   const kegValue =
     getKegValue(keg) * getSalePriceMultiplier(completedAchievements)
 
+  const spoilageRate = getKegSpoilageRate(keg)
+  const spoilageRateDisplayValue = Number((spoilageRate * 100).toPrecision(2))
+
   return (
     <Card className="Keg">
       <CardHeader
@@ -69,18 +73,19 @@ export function Keg({ keg }) {
         subheader={
           <>
             {canBeSold ? (
-              <p>Days since ready: {Math.abs(keg.daysUntilMature)}</p>
+              <>
+                <p>Days since ready: {Math.abs(keg.daysUntilMature)}</p>
+                <p>
+                  Current value:{' '}
+                  <AnimatedNumber
+                    {...{ number: kegValue, formatter: moneyString }}
+                  />
+                </p>
+                <p>Potential for spoilage: {spoilageRateDisplayValue}%</p>
+              </>
             ) : (
               <p>Days until ready: {keg.daysUntilMature}</p>
             )}
-            {canBeSold ? (
-              <p>
-                Current value:{' '}
-                <AnimatedNumber
-                  {...{ number: kegValue, formatter: moneyString }}
-                />
-              </p>
-            ) : null}
           </>
         }
       ></CardHeader>

--- a/src/constants.js
+++ b/src/constants.js
@@ -254,3 +254,4 @@ export const COW_TRADE_TIMEOUT = 10000
 export const WEEDS_SPAWN_CHANCE = 0.15
 
 export const KEG_INTEREST_RATE = 0.02
+export const KEG_SPOILAGE_RATE_MULTIPLIER = 0.001

--- a/src/data/crops/carrot.js
+++ b/src/data/crops/carrot.js
@@ -1,3 +1,5 @@
+/** @typedef {import("../../index").farmhand.item} item */
+
 import { crop, fromSeed } from '../crop'
 import { cropLifeStage, cropType } from '../../enums'
 
@@ -5,7 +7,7 @@ const { SEED, GROWING } = cropLifeStage
 
 /**
  * @property farmhand.module:items.carrotSeed
- * @type {farmhand.item}
+ * @type {item}
  */
 export const carrotSeed = crop({
   cropType: cropType.CARROT,
@@ -21,7 +23,7 @@ export const carrotSeed = crop({
 
 /**
  * @property farmhand.module:items.carrot
- * @type {farmhand.item}
+ * @type {item}
  */
 export const carrot = crop({
   ...fromSeed(carrotSeed, { canBeFermented: true }),

--- a/src/game-logic/reducers/processCellar.js
+++ b/src/game-logic/reducers/processCellar.js
@@ -1,10 +1,13 @@
 /** @typedef {import("../../components/Farmhand/Farmhand").farmhand.state} state */
 
+import { processCellarSpoilage } from './processCellarSpoilage'
+
 /**
  * @param {state} state
  * @returns state
  */
 export const processCellar = state => {
+  state = processCellarSpoilage(state)
   const { cellarInventory } = state
 
   const newCellarInventory = [...cellarInventory]

--- a/src/game-logic/reducers/processCellarSpoilage.js
+++ b/src/game-logic/reducers/processCellarSpoilage.js
@@ -1,0 +1,29 @@
+/** @typedef {import("../../components/Farmhand/Farmhand").farmhand.state} state */
+
+import { randomNumberService } from '../../common/services/randomNumber'
+import { getKeySpoilageRate } from '../../utils/getKegSpoilageRate'
+
+import { removeKegFromCellar } from './removeKegFromCellar'
+
+/**
+ * @param {state} state
+ * @returns state
+ */
+export const processCellarSpoilage = state => {
+  const { cellarInventory } = state
+
+  const newCellarInventory = [...cellarInventory]
+
+  for (let i = newCellarInventory.length - 1; i > -1; i--) {
+    const keg = newCellarInventory[i]
+    const spoilageRate = getKeySpoilageRate(keg)
+
+    if (randomNumberService.isRandomNumberLessThan(spoilageRate)) {
+      state = removeKegFromCellar(state, keg)
+    }
+  }
+
+  state = { ...state }
+
+  return state
+}

--- a/src/game-logic/reducers/processCellarSpoilage.js
+++ b/src/game-logic/reducers/processCellarSpoilage.js
@@ -1,7 +1,7 @@
 /** @typedef {import("../../components/Farmhand/Farmhand").farmhand.state} state */
 
 import { randomNumberService } from '../../common/services/randomNumber'
-import { getKeySpoilageRate } from '../../utils/getKegSpoilageRate'
+import { getKegSpoilageRate } from '../../utils/getKegSpoilageRate'
 
 import { removeKegFromCellar } from './removeKegFromCellar'
 
@@ -16,7 +16,7 @@ export const processCellarSpoilage = state => {
 
   for (let i = newCellarInventory.length - 1; i > -1; i--) {
     const keg = newCellarInventory[i]
-    const spoilageRate = getKeySpoilageRate(keg)
+    const spoilageRate = getKegSpoilageRate(keg)
 
     if (randomNumberService.isRandomNumberLessThan(spoilageRate)) {
       state = removeKegFromCellar(state, keg)

--- a/src/game-logic/reducers/processCellarSpoilage.js
+++ b/src/game-logic/reducers/processCellarSpoilage.js
@@ -1,6 +1,7 @@
 /** @typedef {import("../../components/Farmhand/Farmhand").farmhand.state} state */
 
 import { randomNumberService } from '../../common/services/randomNumber'
+import { KEG_SPOILED_MESSAGE } from '../../templates'
 import { getKegSpoilageRate } from '../../utils/getKegSpoilageRate'
 
 import { removeKegFromCellar } from './removeKegFromCellar'
@@ -20,6 +21,16 @@ export const processCellarSpoilage = state => {
 
     if (randomNumberService.isRandomNumberLessThan(spoilageRate)) {
       state = removeKegFromCellar(state, keg.id)
+      state = {
+        ...state,
+        newDayNotifications: [
+          ...state.newDayNotifications,
+          {
+            message: KEG_SPOILED_MESSAGE`${keg}`,
+            severity: 'error',
+          },
+        ],
+      }
     }
   }
 

--- a/src/game-logic/reducers/processCellarSpoilage.js
+++ b/src/game-logic/reducers/processCellarSpoilage.js
@@ -19,7 +19,7 @@ export const processCellarSpoilage = state => {
     const spoilageRate = getKegSpoilageRate(keg)
 
     if (randomNumberService.isRandomNumberLessThan(spoilageRate)) {
-      state = removeKegFromCellar(state, keg)
+      state = removeKegFromCellar(state, keg.id)
     }
   }
 

--- a/src/game-logic/reducers/processCellarSpoilage.test.js
+++ b/src/game-logic/reducers/processCellarSpoilage.test.js
@@ -1,0 +1,60 @@
+import { randomNumberService } from '../../common/services/randomNumber'
+import { KEG_SPOILED_MESSAGE } from '../../templates'
+import { getKegStub } from '../../test-utils/stubs/getKegStub'
+
+import { processCellarSpoilage } from './processCellarSpoilage'
+
+describe('processCellarSpoilage', () => {
+  test('does not remove kegs that have not spoiled', () => {
+    jest
+      .spyOn(randomNumberService, 'isRandomNumberLessThan')
+      .mockReturnValueOnce(false)
+
+    const keg = getKegStub()
+    const cellarInventory = [keg]
+    const newDayNotifications = []
+    const expectedState = processCellarSpoilage({
+      cellarInventory,
+      newDayNotifications,
+    })
+
+    expect(expectedState.cellarInventory).toHaveLength(1)
+  })
+
+  test('removes kegs that have spoiled', () => {
+    jest
+      .spyOn(randomNumberService, 'isRandomNumberLessThan')
+      .mockReturnValueOnce(true)
+
+    const keg = getKegStub()
+    const cellarInventory = [keg]
+    const newDayNotifications = []
+    const expectedState = processCellarSpoilage({
+      cellarInventory,
+      newDayNotifications,
+    })
+
+    expect(expectedState.cellarInventory).toHaveLength(0)
+  })
+
+  test('shows notification for kegs that have spoiled', () => {
+    jest
+      .spyOn(randomNumberService, 'isRandomNumberLessThan')
+      .mockReturnValueOnce(true)
+
+    const keg = getKegStub()
+    const cellarInventory = [keg]
+    const newDayNotifications = []
+    const expectedState = processCellarSpoilage({
+      cellarInventory,
+      newDayNotifications,
+    })
+
+    expect(expectedState.newDayNotifications).toEqual([
+      {
+        message: KEG_SPOILED_MESSAGE`${keg}`,
+        severity: 'error',
+      },
+    ])
+  })
+})

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,4 +1,7 @@
-/** @typedef {import("./index").farmhand.item} farmhand.item */
+/**
+ * @typedef {import("./index").farmhand.item} farmhand.item
+ * @typedef {import("./index").farmhand.keg} keg
+ */
 
 /**
  * @module farmhand.templates
@@ -335,3 +338,11 @@ export const SHOVELED_PLOT = (_, item) => `Shoveled plot of ${item.name}`
  * @returns {string}
  */
 export const FERMENTED_CROP_NAME = (_, item) => `Fermented ${item.name}`
+
+/**
+ * @param {string} _
+ * @param {keg} keg
+ * @returns {string}
+ */
+export const KEG_SPOILED_MESSAGE = (_, keg) =>
+  `Oh no! Your ${FERMENTED_CROP_NAME`${itemsMap[keg.itemId]}`} has spoiled!`

--- a/src/test-utils/stubs/getKegStub.js
+++ b/src/test-utils/stubs/getKegStub.js
@@ -1,0 +1,18 @@
+/** @typedef {import("../../index").farmhand.keg} keg */
+
+import { v4 as uuid } from 'uuid'
+
+import { carrot } from '../../data/crops'
+
+/**
+ * @param {Partial<keg>} overrides
+ * @returns keg
+ */
+export const getKegStub = overrides => {
+  return {
+    id: uuid(),
+    itemId: carrot.id,
+    daysUntilMature: carrot.daysToFerment,
+    ...overrides,
+  }
+}

--- a/src/utils/getKegSpoilageRate.js
+++ b/src/utils/getKegSpoilageRate.js
@@ -1,0 +1,15 @@
+/** @typedef {import("../index").farmhand.keg} keg */
+
+/**
+ * @param {keg} keg
+ * @returns number
+ */
+export const getKeySpoilageRate = keg => {
+  if (keg.daysUntilMature > 0) {
+    return 0
+  }
+
+  // FIXME: Determine keg spoilage rate here
+
+  return 0
+}

--- a/src/utils/getKegSpoilageRate.js
+++ b/src/utils/getKegSpoilageRate.js
@@ -1,6 +1,6 @@
 /** @typedef {import("../index").farmhand.keg} keg */
 
-const KEG_SPOILAGE_RATE_MULTIPLIER = 0.001
+import { KEG_SPOILAGE_RATE_MULTIPLIER } from '../constants'
 
 /**
  * @param {keg} keg

--- a/src/utils/getKegSpoilageRate.js
+++ b/src/utils/getKegSpoilageRate.js
@@ -1,15 +1,18 @@
 /** @typedef {import("../index").farmhand.keg} keg */
 
+const KEG_SPOILAGE_RATE_MULTIPLIER = 0.001
+
 /**
  * @param {keg} keg
  * @returns number
  */
-export const getKeySpoilageRate = keg => {
+export const getKegSpoilageRate = keg => {
   if (keg.daysUntilMature > 0) {
     return 0
   }
 
-  // FIXME: Determine keg spoilage rate here
+  const spoilageRate =
+    Math.abs(keg.daysUntilMature) * KEG_SPOILAGE_RATE_MULTIPLIER
 
-  return 0
+  return spoilageRate
 }

--- a/src/utils/getKegSpoilageRate.test.js
+++ b/src/utils/getKegSpoilageRate.test.js
@@ -1,0 +1,27 @@
+import { getKegStub } from '../test-utils/stubs/getKegStub'
+
+import { getKegSpoilageRate } from './getKegSpoilageRate'
+
+describe('getKegSpoilageRate', () => {
+  test('handles kegs that are not mature', () => {
+    const keg = getKegStub()
+    expect(getKegSpoilageRate(keg)).toEqual(0)
+  })
+
+  test('handles kegs that are mature', () => {
+    const keg = getKegStub({ daysUntilMature: 0 })
+    expect(getKegSpoilageRate(keg)).toEqual(0)
+  })
+
+  test.each([
+    [-1, 0.001],
+    [-10, 0.01],
+    [-100, 0.1],
+  ])(
+    'handles kegs that are beyond mature',
+    (daysUntilMature, expectedSpoilageRate) => {
+      const keg = getKegStub({ daysUntilMature })
+      expect(getKegSpoilageRate(keg)).toEqual(expectedSpoilageRate)
+    }
+  )
+})


### PR DESCRIPTION
### What this PR does

This PR implements keg spoilage. The longer the player holds onto a keg, the greater the chance becomes for that keg to be spoiled and lost.

### How this change can be validated

Follow setup steps similar to #413 to populate your cellar:

1. Give yourself enough money to buy a Cellar:

```js
farmhand.setState({ money: 1_000_000 })
```

2. Purchase a Cellar in the Shop's Upgrades tab.
3. Navigate to the Cellar's screen (at the end of the screen sequence).
4. Give yourself a lot of salt:

```js
farmhand.setState({ inventory: [...farmhand.state.inventory, { id: 'salt', quantity: 1000 }]})
```

5. Make a Fermented Carrot (or whatever crops you have available).
6. Advance the days to see the keg's spoilage rate go up. Eventually the keg will spoil with a new day and it should be removed from the cellar inventory.

### Questions or concerns about this change

This PR needs some more unit tests, so it's in Draft state until I write those. However, it should stable enough for play testing.

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->

![Cellar screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/80b62079-6387-4228-9bdd-4b7265b61c52)

![Log screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/9bc4e4d3-9875-4206-bae4-f065af9a8b27)
