### PR TITLE
chore(deps): Use shifty@3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "react-zoom-pan-pinch": "^1.6.1",
         "redis": "^3.0.2",
         "seedrandom": "^3.0.5",
-        "shifty": "^2.15.2",
+        "shifty": "^3.0.1",
         "source-map-explorer": "^2.3.1",
         "stream": "npm:stream-browserify@^3.0.0",
         "trystero": "^0.11.8",
@@ -30041,8 +30041,9 @@
       }
     },
     "node_modules/shifty": {
-      "version": "2.19.1",
-      "license": "MIT",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shifty/-/shifty-3.0.1.tgz",
+      "integrity": "sha512-jGbnl1VR0dG2J+x5u9E0c1gt9QqDjeFrOtopRmKhMw2zmtzZAWG4voYZD5lSpW6THct6G2STxICAPvqfU6J1Pg==",
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
@@ -54424,7 +54425,9 @@
       "dev": true
     },
     "shifty": {
-      "version": "2.19.1",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shifty/-/shifty-3.0.1.tgz",
+      "integrity": "sha512-jGbnl1VR0dG2J+x5u9E0c1gt9QqDjeFrOtopRmKhMw2zmtzZAWG4voYZD5lSpW6THct6G2STxICAPvqfU6J1Pg==",
       "requires": {
         "fsevents": "^2.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-zoom-pan-pinch": "^1.6.1",
     "redis": "^3.0.2",
     "seedrandom": "^3.0.5",
-    "shifty": "^2.15.2",
+    "shifty": "^3.0.1",
     "source-map-explorer": "^2.3.1",
     "stream": "npm:stream-browserify@^3.0.0",
     "trystero": "^0.11.8",


### PR DESCRIPTION
### What this PR does

This PR updates Farmhand to use https://github.com/jeremyckahn/shifty/releases/tag/3.0.1.

### How this change can be validated

Ensure that cow and number animations work as they did before.

### Questions or concerns about this change

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->

This isn't a necessary upgrade. I'm mostly doing it to validate the latest release of Shifty.