### PR TITLE
refactor(types): Make `Farmhand` component type-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       # https://stackoverflow.com/a/69634516
       - name: Reconfigure git to use HTTP authentication
         run: >
@@ -18,14 +19,23 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm ci
-      - run: npm test -- --reporters=default --reporters=jest-junit
+
+      - name: 'Install dependencies'
+        run: npm ci
+
+      - name: 'Run tests'
+        run: npm test -- --reporters=default --reporters=jest-junit
+
       - name: Test Report
         uses: dorny/test-reporter@v1
         with:
           name: Jest Tests # Name of the check run which will be created
           path: reports/jest-*.xml # Path to test results
           reporter: jest-junit # Format of test results
+
+      - name: 'Check types'
+        # TODO: Change this to check:types when all type errors are fixed
+        run: npm run check:types:noerror
 
       - name: 'Build web app artifacts'
         run: |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build": "react-scripts --openssl-legacy-provider build",
     "build:native": "cross-env PUBLIC_URL='./' npm run build && electron-builder --publish=always",
     "build:analyze": "npm run build && source-map-explorer 'build/static/js/*.js'",
+    "check:types": "tsc",
+    "check:types:noerror": "tsc; exit 0",
     "dev": "mprocs \"cross-env REACT_APP_TRACKER_URL='ws://localhost:8000' npm run start\" \"npm run start:api\" \"npm run start:backend\" \"npm run start:tracker\"",
     "dev:native": "mprocs \"BROWSER=none npm run start\" \"npm run start:api\" \"npm run start:backend\" \"npm run electron\"",
     "electron": "wait-on tcp:3000 && electron .",

--- a/src/components/AppBar/AppBar.test.js
+++ b/src/components/AppBar/AppBar.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { noop } from '../../utils/noop'
+
 import AppBar from './AppBar'
 
 let component
@@ -9,7 +11,7 @@ beforeEach(() => {
   component = shallow(
     <AppBar
       {...{
-        handleClickNotificationIndicator: () => {},
+        handleClickNotificationIndicator: noop,
         money: 0,
         showNotifications: false,
         todaysNotifications: [],

--- a/src/components/CowCard/CowCard.test.js
+++ b/src/components/CowCard/CowCard.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 
 import { generateCow } from '../../utils'
+import { noop } from '../../utils/noop'
 import { PURCHASEABLE_COW_PENS } from '../../constants'
 import { cowColors, genders } from '../../enums'
 
@@ -23,10 +24,10 @@ describe('CowCard', () => {
       daysUntilBirth: -1,
     },
     cowIdOfferedForTrade: '',
-    handleCowSelect: () => {},
-    handleCowNameInputChange: () => {},
-    handleCowPurchaseClick: () => {},
-    handleCowTradeClick: () => {},
+    handleCowSelect: noop,
+    handleCowNameInputChange: noop,
+    handleCowPurchaseClick: noop,
+    handleCowTradeClick: noop,
     id: '',
     isSelected: false,
     isOnline: false,

--- a/src/components/CowPen/CowPen.test.js
+++ b/src/components/CowPen/CowPen.test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme'
 import { generateCow } from '../../utils'
 import { cowColors } from '../../enums'
 import { pixel } from '../../img'
+import { noop } from '../../utils/noop'
 
 import { Cow } from './CowPen'
 
@@ -27,8 +28,8 @@ describe('Cow', () => {
             color: cowColors.WHITE,
           },
           cowInventory: [],
-          handleCowPenUnmount: () => {},
-          handleCowClick: () => {},
+          handleCowPenUnmount: noop,
+          handleCowClick: noop,
           id: '',
           isSelected: false,
         }}

--- a/src/components/CowPenContextMenu/CowPenContextMenu.test.js
+++ b/src/components/CowPenContextMenu/CowPenContextMenu.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 
 import { generateCow } from '../../utils'
+import { noop } from '../../utils/noop'
 
 import { CowPenContextMenu } from './CowPenContextMenu'
 
@@ -23,14 +24,14 @@ describe('CowPenContextMenu', () => {
       cowBreedingPen: { cowId1: null, cowId2: null, daysUntilBirth: -1 },
       cowForSale: generateCow(),
       cowInventory: [],
-      handleCowAutomaticHugChange: () => {},
-      handleCowBreedChange: () => {},
-      handleCowHugClick: () => {},
-      handleCowNameInputChange: () => {},
-      handleCowOfferClick: () => {},
-      handleCowSelect: () => {},
-      handleCowSellClick: () => {},
-      handleCowWithdrawClick: () => {},
+      handleCowAutomaticHugChange: noop,
+      handleCowBreedChange: noop,
+      handleCowHugClick: noop,
+      handleCowNameInputChange: noop,
+      handleCowOfferClick: noop,
+      handleCowSelect: noop,
+      handleCowSellClick: noop,
+      handleCowWithdrawClick: noop,
       purchasedCowPen: 1,
       selectedCowId: '',
     }

--- a/src/components/DebugMenu/DebugMenu.test.js
+++ b/src/components/DebugMenu/DebugMenu.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { noop } from '../../utils/noop'
+
 import { DebugMenu } from './DebugMenu'
 
 let component
@@ -9,8 +11,8 @@ beforeEach(() => {
   component = shallow(
     <DebugMenu
       {...{
-        handleAddMoneyClick: () => {},
-        handleItemPurchaseClick: () => {},
+        handleAddMoneyClick: noop,
+        handleItemPurchaseClick: noop,
       }}
     />
   )

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -1,8 +1,17 @@
 /**
  * @typedef {import("../../index").farmhand.item} farmhand.item
  * @typedef {import("../../index").farmhand.cow} farmhand.cow
+ * @typedef {import("../../index").farmhand.cowBreedingPen} farmhand.cowBreedingPen
  * @typedef {import("../../index").farmhand.keg} farmhand.keg
+ * @typedef {import("../../index").farmhand.plotContent} farmhand.plotContent
+ * @typedef {import("../../index").farmhand.peerMessage} farmhand.peerMessage
+ * @typedef {import("../../index").farmhand.priceEvent} farmhand.priceEvent
  * @typedef {import("../../index").farmhand.notification} notification
+ * @typedef {import("../../enums").cowColors} farmhand.cowColors
+ * @typedef {import("../../enums").cropType} farmhand.cropType
+ * @typedef {import("../../enums").dialogView} farmhand.dialogView
+ * @typedef {import("../../enums").fieldMode} farmhand.fieldMode
+ * @typedef {import("../../enums").stageFocusType} farmhand.stageFocusType
  */
 import React, { Component } from 'react'
 import window from 'global/window'
@@ -153,10 +162,10 @@ export const getPlantableCropInventory = memoize(inventory =>
 )
 
 /**
- * @param {Object.<number>} valueAdjustments
+ * @param {Record<string, number>} valueAdjustments
  * @param {farmhand.priceEvent} priceCrashes
  * @param {farmhand.priceEvent} priceSurges
- * @returns {Object.<number>}
+ * @returns {Record<string, number>}
  */
 const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
   const patchedValueAdjustments = { ...valueAdjustments }
@@ -177,27 +186,26 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {number?} activePlayers
  * @property {boolean} allowCustomPeerCowNames
  * @property {Array.<farmhand.keg>} cellarInventory
- * @property {farmhand.module:enums.dialogView} currentDialogView
+ * @property {farmhand.dialogView} currentDialogView
  * @property {Object.<string, boolean>} completedAchievements Keys are
  * achievement ids.
  * @property {farmhand.cow} cowForSale
  * @property {farmhand.cowBreedingPen} cowBreedingPen
  * @property {Array.<farmhand.cow>} cowInventory
- * @property {Object.<farmhand.module:enums.cowColors, number>}
- * cowColorsPurchased Keys are color enums, values are the number of that color
- * of cow purchased.
+ * @property {Object.<farmhand.cowColors, number>} cowColorsPurchased Keys are
+ * color enums, values are the number of that color of cow purchased.
  * @property {string} cowIdOfferedForTrade The ID of the cow that is currently
  * set to be traded with online peers.
  * @property {Object} cowsSold Keys are items IDs, values are the id references
  * of cow colors (rainbow-cow, etc.).
  * @property {number} cowsTraded
  * @property {number?} cowTradeTimeoutId
- * @property {Object.<farmhand.module:enums.cropType, number>} cropsHarvested A
- * map of totals of crops harvested. Keys are crop type IDs, values are the
- * number of that crop harvested.
+ * @property {Object.<farmhand.cropType, number>} cropsHarvested A map of
+ * totals of crops harvested. Keys are crop type IDs, values are the number of
+ * that crop harvested.
  * @property {number} dayCount
- * @property {Array.<Array.<?farmhand.plotContent>>} field
- * @property {farmhand.module:enums.fieldMode} fieldMode
+ * @property {(?farmhand.plotContent)[][]} field
+ * @property {farmhand.fieldMode} fieldMode
  * @property {Function?} getCowAccept https://github.com/dmotz/trystero#receiver
  * @property {Function?} getCowReject https://github.com/dmotz/trystero#receiver
  * @property {Function?} getCowTradeRequest https://github.com/dmotz/trystero#receiver
@@ -205,13 +213,13 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {number?} heartbeatTimeoutId
  * @property {Array.<number>} historicalDailyLosses
  * @property {Array.<number>} historicalDailyRevenue
- * @property {Array.<Object.<number>>} historicalValueAdjustments Currently
- * there is only one element in this array, but it will be used for more
- * historical price data analysis in the future. It is an array for
+ * @property {Record<string, number>[]} historicalValueAdjustments
+ * Currently there is only one element in this array, but it will be used for
+ * more historical price data analysis in the future. It is an array for
  * future-facing flexibility.
  * @property {number} hoveredPlotRangeSize
  * @property {string} id
- * @property {Array.<{ id: farmhand.item.id, quantity: number }>} inventory
+ * @property {{ id: farmhand.item['id'], quantity: number }[]} inventory
  * @property {number} inventoryLimit Is -1 if inventory is unlimited.
  * @property {boolean} isAwaitingCowTradeRequest
  * @property {boolean} isAwaitingNetworkRequest
@@ -236,10 +244,10 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {Array.<notification>} notificationLog
  * @property {Object} peers Keys are (Trystero) peer ids, values are their respective metadata or null.
  * @property {Object?} peerRoom See https://github.com/dmotz/trystero
- * @property {Array.<farmhand.peerMessage>} pendingPeerMessages An array of
- * messages to be sent to the Trystero peer room upon the next broadcast.
- * @property {Array.<farmhand.peerMessage>} latestPeerMessages An array of
- * messages that have been received from peers.
+ * @property {farmhand.peerMessage[]} pendingPeerMessages An array of messages
+ * to be sent to the Trystero peer room upon the next broadcast.
+ * @property {farmhand.peerMessage[]} latestPeerMessages An array of messages
+ * that have been received from peers.
  * @property {function?} sendPeerMetadata See https://github.com/dmotz/trystero
  * @property {string} selectedCowId
  * @property {string} selectedItemId
@@ -264,7 +272,7 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {Function?} sendPeerMetadata https://github.com/dmotz/trystero#sender
  * @property {boolean} showHomeScreen Option to show the Home Screen
  * @property {boolean} showNotifications
- * @property {farmhand.module:enums.stageFocusType} stageFocus
+ * @property {farmhand.stageFocusType} stageFocus
  * @property {Array.<notification>} todaysNotifications
  * @property {number} todaysLosses Should always be a negative number.
  * @property {Object} todaysPurchases Keys are item names, values are their
@@ -274,7 +282,7 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * are item names, values are their respective quantities.
  * @property {boolean} useAlternateEndDayButtonPosition Option to display the
  * Bed button on the left side of the screen.
- * @property {Object.<number>} valueAdjustments
+ * @property {Record<string, number>} valueAdjustments
  * @property {string} version Comes from the `version` property in
  * package.json.
  */

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -13,7 +13,7 @@
  * @typedef {import("../../enums").fieldMode} farmhand.fieldMode
  * @typedef {import("../../enums").stageFocusType} farmhand.stageFocusType
  */
-import React, { Component } from 'react'
+import React from 'react'
 import window from 'global/window'
 import { Redirect } from 'react-router-dom'
 import { GlobalHotKeys } from 'react-hotkeys'
@@ -119,6 +119,7 @@ import { scarecrow } from '../../data/items'
 
 import { getInventoryQuantities } from './helpers/getInventoryQuantities'
 import FarmhandContext from './Farmhand.context'
+import { FarmhandReducers } from './FarmhandReducers'
 
 const { CLEANUP, HARVEST, MINE, OBSERVE, WATER, PLANT } = fieldMode
 
@@ -289,81 +290,6 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * package.json.
  */
 
-class FarmhandReducers extends Component {
-  addCowToInventory() {}
-  addPeer() {}
-  adjustLoan() {}
-  changeCowAutomaticHugState() {}
-  changeCowBreedingPenResident() {}
-  changeCowName() {}
-  clearPlot() {}
-  computeStateForNextDay() {}
-  fertilizePlot() {}
-  forRange() {}
-  harvestPlot() {}
-  hugCow() {}
-  makeRecipe() {}
-  makeFermentationRecipe() {}
-  modifyCow() {}
-  offerCow() {}
-  plantInPlot() {}
-  prependPendingPeerMessage() {}
-  purchaseCombine() {}
-  purchaseComposter() {}
-  purchaseCow() {}
-  purchaseCowPen() {}
-  purchaseCellar() {}
-  purchaseField() {}
-  purchaseItem() {}
-  purchaseSmelter() {}
-  purchaseStorageExpansion() {}
-  removeCowFromInventory() {}
-  removeKegFromCellar() {}
-  removePeer() {}
-  selectCow() {}
-  sellCow() {}
-  sellItem() {}
-  sellKeg() {}
-  setScarecrow() {}
-  setSprinkler() {}
-  showNotification() {}
-  updatePeer() {}
-  upgradeTool() {}
-  waterAllPlots() {}
-  waterField() {}
-  waterPlot() {}
-  withdrawCow() {}
-
-  /**
-   * @param {object} props
-   */
-  constructor(props) {
-    super(props)
-
-    const reducerNames = Object.getOwnPropertyNames(
-      FarmhandReducers.prototype
-    ).filter(key => key !== 'constructor')
-
-    for (const reducerName of reducerNames) {
-      const reducer = reducers[reducerName]
-
-      if (process.env.NODE_ENV === 'development') {
-        if (typeof reducer === 'undefined') {
-          throw new Error(
-            `Reducer ${reducerName} is not exported from reducers/index.js`
-          )
-        }
-      }
-
-      this[reducerName] = (/** @type any[] */ ...args) => {
-        this.setState((/** @type {farmhand.state} */ state) =>
-          reducer(state, ...args)
-        )
-      }
-    }
-  }
-}
-
 export default class Farmhand extends FarmhandReducers {
   /*!
    * @member farmhand.Farmhand#state
@@ -393,7 +319,7 @@ export default class Farmhand extends FarmhandReducers {
   }
 
   /**
-   * @param {farmhand.state} props
+   * @param {typeof Farmhand.defaultProps} props
    */
   constructor(props) {
     super(props)

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -1149,8 +1149,11 @@ export default class Farmhand extends FarmhandReducers {
             // shown to the player when the app reloads.
             newDayNotifications: pendingNotifications,
           })
-          ;[]
-            .concat(pendingNotifications)
+
+          /** @type {farmhand.notification[]} */
+          const notifications = [...pendingNotifications]
+
+          notifications
             .concat(
               isFirstDay
                 ? []
@@ -1197,7 +1200,7 @@ export default class Farmhand extends FarmhandReducers {
   }
 
   focusNextView() {
-    if (document.activeElement.getAttribute('role') === 'tab') return
+    if (document.activeElement?.getAttribute('role') === 'tab') return
 
     const { viewList } = this
 
@@ -1209,7 +1212,7 @@ export default class Farmhand extends FarmhandReducers {
   }
 
   focusPreviousView() {
-    if (document.activeElement.getAttribute('role') === 'tab') return
+    if (document.activeElement?.getAttribute('role') === 'tab') return
 
     const { viewList } = this
 
@@ -1347,6 +1350,8 @@ export default class Farmhand extends FarmhandReducers {
                     position="static"
                     activeStep={viewList.indexOf(this.state.stageFocus)}
                     className=""
+                    backButton={null}
+                    nextButton={null}
                   />
                   <div className="fab-buttons buttons">
                     <Fab

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -572,7 +572,7 @@ export default class Farmhand extends FarmhandReducers {
 
     Object.assign(this.keyHandlers, {
       clearPersistedData: () => this.clearPersistedData(),
-      waterAllPlots: () => this.waterAllPlots(this.state),
+      waterAllPlots: () => this.waterAllPlots(),
     })
   }
 
@@ -651,7 +651,7 @@ export default class Farmhand extends FarmhandReducers {
     if (isOnline !== prevState.isOnline || room !== prevState.room) {
       this.syncToRoom().catch(errorCode => this.handleRoomSyncError(errorCode))
 
-      if (!isOnline) {
+      if (!isOnline && typeof heartbeatTimeoutId === 'number') {
         clearTimeout(heartbeatTimeoutId)
         this.setState({
           activePlayers: null,
@@ -706,18 +706,30 @@ export default class Farmhand extends FarmhandReducers {
         const [sendPeerMetadata, getPeerMetadata] = peerRoom.makeAction(
           'peerMetadata'
         )
-        getPeerMetadata((...args) => handlePeerMetadataRequest(this, ...args))
+        getPeerMetadata((
+          /** @type {[object, string]} */
+          ...args
+        ) => handlePeerMetadataRequest(this, ...args))
 
         const [sendCowTradeRequest, getCowTradeRequest] = peerRoom.makeAction(
           'cowTrade'
         )
-        getCowTradeRequest((...args) => handleCowTradeRequest(this, ...args))
+        getCowTradeRequest((
+          /** @type {[object, string]} */
+          ...args
+        ) => handleCowTradeRequest(this, ...args))
 
         const [sendCowAccept, getCowAccept] = peerRoom.makeAction('cowAccept')
-        getCowAccept((...args) => handleCowTradeRequestAccept(this, ...args))
+        getCowAccept((
+          /** @type {[object, string]} */
+          ...args
+        ) => handleCowTradeRequestAccept(this, ...args))
 
         const [sendCowReject, getCowReject] = peerRoom.makeAction('cowReject')
-        getCowReject((...args) => handleCowTradeRequestReject(this, ...args))
+        getCowReject((
+          /** @type {[object]} */
+          ...args
+        ) => handleCowTradeRequestReject(this, ...args))
 
         this.setState({
           getCowAccept,

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -289,7 +289,82 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * package.json.
  */
 
-export default class Farmhand extends Component {
+class FarmhandReducers extends Component {
+  addCowToInventory() {}
+  addPeer() {}
+  adjustLoan() {}
+  changeCowAutomaticHugState() {}
+  changeCowBreedingPenResident() {}
+  changeCowName() {}
+  clearPlot() {}
+  computeStateForNextDay() {}
+  fertilizePlot() {}
+  forRange() {}
+  harvestPlot() {}
+  hugCow() {}
+  makeRecipe() {}
+  makeFermentationRecipe() {}
+  modifyCow() {}
+  offerCow() {}
+  plantInPlot() {}
+  prependPendingPeerMessage() {}
+  purchaseCombine() {}
+  purchaseComposter() {}
+  purchaseCow() {}
+  purchaseCowPen() {}
+  purchaseCellar() {}
+  purchaseField() {}
+  purchaseItem() {}
+  purchaseSmelter() {}
+  purchaseStorageExpansion() {}
+  removeCowFromInventory() {}
+  removeKegFromCellar() {}
+  removePeer() {}
+  selectCow() {}
+  sellCow() {}
+  sellItem() {}
+  sellKeg() {}
+  setScarecrow() {}
+  setSprinkler() {}
+  showNotification() {}
+  updatePeer() {}
+  upgradeTool() {}
+  waterAllPlots() {}
+  waterField() {}
+  waterPlot() {}
+  withdrawCow() {}
+
+  /**
+   * @param {object} props
+   */
+  constructor(props) {
+    super(props)
+
+    const reducerNames = Object.getOwnPropertyNames(
+      FarmhandReducers.prototype
+    ).filter(key => key !== 'constructor')
+
+    for (const reducerName of reducerNames) {
+      const reducer = reducers[reducerName]
+
+      if (process.env.NODE_ENV === 'development') {
+        if (typeof reducer === 'undefined') {
+          throw new Error(
+            `Reducer ${reducerName} is not exported from reducers/index.js`
+          )
+        }
+      }
+
+      this[reducerName] = (/** @type any[] */ ...args) => {
+        this.setState((/** @type {farmhand.state} */ state) =>
+          reducer(state, ...args)
+        )
+      }
+    }
+  }
+}
+
+export default class Farmhand extends FarmhandReducers {
   /*!
    * @member farmhand.Farmhand#state
    * @type {farmhand.state}
@@ -324,7 +399,6 @@ export default class Farmhand extends Component {
     super(props)
 
     this.initInputHandlers()
-    this.initReducers()
 
     // This is an antipattern, but it's useful for debugging. The Farmhand
     // component assumes that it is a singleton.
@@ -561,68 +635,6 @@ export default class Farmhand extends Component {
     Object.assign(this.keyHandlers, {
       clearPersistedData: () => this.clearPersistedData(),
       waterAllPlots: () => this.waterAllPlots(this.state),
-    })
-  }
-
-  initReducers() {
-    ;[
-      'addCowToInventory',
-      'addPeer',
-      'adjustLoan',
-      'changeCowAutomaticHugState',
-      'changeCowBreedingPenResident',
-      'changeCowName',
-      'clearPlot',
-      'computeStateForNextDay',
-      'fertilizePlot',
-      'forRange',
-      'harvestPlot',
-      'hugCow',
-      'makeRecipe',
-      'makeFermentationRecipe',
-      'modifyCow',
-      'offerCow',
-      'plantInPlot',
-      'prependPendingPeerMessage',
-      'purchaseCombine',
-      'purchaseComposter',
-      'purchaseCow',
-      'purchaseCowPen',
-      'purchaseCellar',
-      'purchaseField',
-      'purchaseItem',
-      'purchaseSmelter',
-      'purchaseStorageExpansion',
-      'removeCowFromInventory',
-      'removeKegFromCellar',
-      'removePeer',
-      'selectCow',
-      'sellCow',
-      'sellItem',
-      'sellKeg',
-      'setScarecrow',
-      'setSprinkler',
-      'showNotification',
-      'updatePeer',
-      'upgradeTool',
-      'waterAllPlots',
-      'waterField',
-      'waterPlot',
-      'withdrawCow',
-    ].forEach(reducerName => {
-      const reducer = reducers[reducerName]
-
-      if (process.env.NODE_ENV === 'development') {
-        if (typeof reducer === 'undefined') {
-          throw new Error(
-            `Reducer ${reducerName} is not exported from reducers/index.js`
-          )
-        }
-      }
-
-      this[reducerName] = (...args) => {
-        this.setState(state => reducer(state, ...args))
-      }
     })
   }
 

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -206,6 +206,8 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * totals of crops harvested. Keys are crop type IDs, values are the number of
  * that crop harvested.
  * @property {number} dayCount
+ * @property {string} farmName
+ * @property {boolean} hasBooted
  * @property {(?farmhand.plotContent)[][]} field
  * @property {farmhand.fieldMode} fieldMode
  * @property {Function?} getCowAccept https://github.com/dmotz/trystero#receiver
@@ -258,9 +260,11 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {Object.<string, farmhand.priceEvent>} priceSurges Keys are
  * itemIds.
  * @property {number} purchasedCombine
+ * @property {number} purchasedComposter
  * @property {number} purchasedCowPen
  * @property {number} purchasedCellar
  * @property {number} purchasedField
+ * @property {number} purchasedSmelter
  * @property {number} profitabilityStreak
  * @property {number} record7dayProfitAverage
  * @property {number} recordProfitabilityStreak
@@ -415,10 +419,16 @@ export default class Farmhand extends FarmhandReducers {
       cowInventory: [],
       cowsSold: {},
       cowsTraded: 0,
+      cowTradeTimeoutId: -1,
       cropsHarvested: {},
       dayCount: 0,
       farmName: 'Unnamed',
       field: createNewField(),
+      fieldMode: OBSERVE,
+      getCowAccept: () => {},
+      getCowReject: () => {},
+      getCowTradeRequest: () => {},
+      getPeerMetadata: () => {},
       hasBooted: false,
       heartbeatTimeoutId: null,
       historicalDailyLosses: [],
@@ -451,7 +461,6 @@ export default class Farmhand extends FarmhandReducers {
       sendPeerMetadata: null,
       selectedCowId: '',
       selectedItemId: '',
-      fieldMode: OBSERVE,
       priceCrashes: {},
       priceSurges: {},
       profitabilityStreak: 0,
@@ -461,12 +470,15 @@ export default class Farmhand extends FarmhandReducers {
       revenue: 0,
       redirect: '',
       room: decodeURIComponent(this.props.match.params.room || DEFAULT_ROOM),
+      sendCowAccept: () => {},
+      sendCowReject: () => {},
       purchasedCombine: 0,
       purchasedComposter: 0,
       purchasedCowPen: 0,
       purchasedCellar: 0,
       purchasedField: 0,
       purchasedSmelter: 0,
+      sendCowTradeRequest: () => {},
       showHomeScreen: true,
       showNotifications: true,
       stageFocus: stageFocusType.HOME,

--- a/src/components/Farmhand/FarmhandReducers.js
+++ b/src/components/Farmhand/FarmhandReducers.js
@@ -6,7 +6,6 @@ import * as reducers from '../../game-logic/reducers'
 
 /**
  * @callback BoundReducer
- * @param {farmhand.state} state
  * @param {...any} rest
  * @returns {farmhand.state}
  */

--- a/src/components/Farmhand/FarmhandReducers.js
+++ b/src/components/Farmhand/FarmhandReducers.js
@@ -1,0 +1,228 @@
+/** @typedef {typeof import('./Farmhand').default.defaultProps} farmhand.props */
+/** @typedef {import('./Farmhand').farmhand.state} farmhand.state */
+import { Component } from 'react'
+
+import * as reducers from '../../game-logic/reducers'
+
+/**
+ * @callback BoundReducer
+ * @param {farmhand.state} state
+ * @param {...any} rest
+ * @returns {farmhand.state}
+ */
+
+/**
+ * This class serves as a sort of middleware for the main Farmhand component.
+ * It defines stub methods with names that correspond to various reducer
+ * functions. At the time of instantiation, it implements the methods with the
+ * matching reducer function and binds it to the class instance.
+ *
+ * This is done in the interest of coding convenience and decentralization of
+ * core game logic. It is implemented as a class so that the methods can be
+ * statically analyzed by the TypeScript compiler.
+ */
+export class FarmhandReducers extends Component {
+  /** @type BoundReducer */
+  addCowToInventory() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  addPeer() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  adjustLoan() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  changeCowAutomaticHugState() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  changeCowBreedingPenResident() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  changeCowName() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  clearPlot() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  computeStateForNextDay() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  fertilizePlot() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  forRange() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  harvestPlot() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  hugCow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  makeRecipe() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  makeFermentationRecipe() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  modifyCow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  offerCow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  plantInPlot() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  prependPendingPeerMessage() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseCombine() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseComposter() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseCow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseCowPen() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseCellar() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseField() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseItem() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseSmelter() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  purchaseStorageExpansion() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  removeCowFromInventory() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  removeKegFromCellar() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  removePeer() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  selectCow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  sellCow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  sellItem() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  sellKeg() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  setScarecrow() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  setSprinkler() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  showNotification() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  updatePeer() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  upgradeTool() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  waterAllPlots() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  waterField() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  waterPlot() {
+    throw new Error('Unimplemented')
+  }
+  /** @type BoundReducer */
+  withdrawCow() {
+    throw new Error('Unimplemented')
+  }
+
+  /**
+   * @param {farmhand.props} props
+   */
+  constructor(props) {
+    super(props)
+
+    const reducerNames = Object.getOwnPropertyNames(
+      FarmhandReducers.prototype
+    ).filter(key => key !== 'constructor')
+
+    for (const reducerName of reducerNames) {
+      const reducer = reducers[reducerName]
+
+      if (
+        process.env.NODE_ENV === 'development' &&
+        typeof reducer === 'undefined'
+      ) {
+        throw new Error(
+          `Reducer ${reducerName} is not exported from reducers/index.js`
+        )
+      }
+
+      // Bind the reducer to this class instance
+      this[reducerName] = (/** @type any[] */ ...args) => {
+        this.setState((/** @type {farmhand.state} */ state) =>
+          reducer(state, ...args)
+        )
+      }
+    }
+  }
+}

--- a/src/components/Field/Field.test.js
+++ b/src/components/Field/Field.test.js
@@ -5,6 +5,7 @@ import { fieldMode } from '../../enums'
 import { testItem } from '../../test-utils'
 
 import { INFINITE_STORAGE_LIMIT } from '../../constants'
+import { noop } from '../../utils/noop'
 
 import { Field, FieldContent, isInHoverRange, MemoPlot } from './Field'
 
@@ -22,8 +23,8 @@ beforeEach(() => {
       {...{
         columns: 0,
         hoveredPlotRangeSize: 0,
-        handleCombineEnabledChange: () => {},
-        handleFieldActionRangeChange: () => {},
+        handleCombineEnabledChange: noop,
+        handleFieldActionRangeChange: noop,
         itemsSold: {},
         rows: 0,
         field: [
@@ -48,7 +49,7 @@ describe('field rendering', () => {
       <FieldContent
         {...{
           columns: 0,
-          handleCombineEnabledChange: () => {},
+          handleCombineEnabledChange: noop,
           field: [
             [null, null],
             [null, null],
@@ -61,7 +62,7 @@ describe('field rendering', () => {
           itemsSold: {},
           purchasedCombine: 0,
           rows: 0,
-          setHoveredPlot: () => {},
+          setHoveredPlot: noop,
         }}
       />
     )

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -15,6 +15,7 @@ import FarmhandContext from '../Farmhand/Farmhand.context'
 import { items } from '../../img'
 import { itemsMap } from '../../data/maps'
 import { itemIds as shopItemIds } from '../../data/shop-inventory'
+import { noop } from '../../utils/noop'
 import { moneyString } from '../../utils/moneyString'
 import {
   inventorySpaceRemaining,
@@ -30,8 +31,6 @@ import QuantityInput from '../QuantityInput'
 import AnimatedNumber from '../AnimatedNumber'
 
 import './Item.sass'
-
-const noop = () => {}
 
 const ValueIndicator = ({ poorValue }) => (
   <Tooltip

--- a/src/components/Navigation/Navigation.test.js
+++ b/src/components/Navigation/Navigation.test.js
@@ -3,8 +3,8 @@ import { shallow } from 'enzyme'
 import MenuItem from '@material-ui/core/MenuItem'
 
 import { dialogView, stageFocusType } from '../../enums'
-
 import { INFINITE_STORAGE_LIMIT } from '../../constants'
+import { noop } from '../../utils/noop'
 
 import { Navigation } from './Navigation'
 
@@ -19,14 +19,14 @@ beforeEach(() => {
         currentDialogView: dialogView.NONE,
         dayCount: 0,
         farmName: '',
-        handleActivePlayerButtonClick: () => {},
-        handleClickDialogViewButton: () => {},
-        handleCloseDialogView: () => {},
-        handleDialogViewExited: () => {},
-        handleFarmNameUpdate: () => {},
-        handleOnlineToggleChange: () => {},
-        handleRoomChange: () => {},
-        handleViewChange: () => {},
+        handleActivePlayerButtonClick: noop,
+        handleClickDialogViewButton: noop,
+        handleCloseDialogView: noop,
+        handleDialogViewExited: noop,
+        handleFarmNameUpdate: noop,
+        handleOnlineToggleChange: noop,
+        handleRoomChange: noop,
+        handleViewChange: noop,
         inventory: [],
         inventoryLimit: INFINITE_STORAGE_LIMIT,
         itemsSold: {},

--- a/src/components/Plot/Plot.rtl.test.js
+++ b/src/components/Plot/Plot.rtl.test.js
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { cropLifeStage } from '../../enums'
 import { testCrop, testShoveledPlot } from '../../test-utils'
 import { getCropFromItemId, getPlotContentFromItemId } from '../../utils'
-
+import { noop } from '../../utils/noop'
 import { items } from '../../img'
 
 import { Plot } from './Plot'
@@ -19,10 +19,10 @@ describe('class states', () => {
     render(
       <Plot
         {...{
-          handlePlotClick: () => {},
+          handlePlotClick: noop,
           isInHoverRange: false,
           selectedItemId: '',
-          setHoveredPlot: () => {},
+          setHoveredPlot: noop,
           x: 0,
           y: 0,
         }}
@@ -44,10 +44,10 @@ describe('plot label', () => {
     render(
       <Plot
         {...{
-          handlePlotClick: () => {},
+          handlePlotClick: noop,
           isInHoverRange: false,
           selectedItemId: '',
-          setHoveredPlot: () => {},
+          setHoveredPlot: noop,
           plotContent: getCropFromItemId('carrot'),
           x: 0,
           y: 0,
@@ -63,10 +63,10 @@ describe('plot label', () => {
     render(
       <Plot
         {...{
-          handlePlotClick: () => {},
+          handlePlotClick: noop,
           isInHoverRange: false,
           selectedItemId: '',
-          setHoveredPlot: () => {},
+          setHoveredPlot: noop,
           plotContent: getCropFromItemId('grape-chardonnay'),
           x: 0,
           y: 0,
@@ -82,10 +82,10 @@ describe('plot label', () => {
     render(
       <Plot
         {...{
-          handlePlotClick: () => {},
+          handlePlotClick: noop,
           isInHoverRange: false,
           selectedItemId: '',
-          setHoveredPlot: () => {},
+          setHoveredPlot: noop,
           plotContent: {
             ...getCropFromItemId('carrot'),
             daysOld: 9,
@@ -108,14 +108,14 @@ describe('background image', () => {
       render(
         <Plot
           {...{
-            handlePlotClick: () => {},
+            handlePlotClick: noop,
             isInHoverRange: false,
             lifeStage: cropLifeStage.GROWN,
             plotContent: testCrop({
               itemId: 'sample-crop-1',
             }),
             selectedItemId: '',
-            setHoveredPlot: () => {},
+            setHoveredPlot: noop,
             x: 0,
             y: 0,
           }}
@@ -159,7 +159,7 @@ describe('background image', () => {
             plotProps: {
               isInHoverRange: false,
               selectedItemId: '',
-              setHoveredPlot: () => {},
+              setHoveredPlot: noop,
               x: 0,
               y: 0,
             },
@@ -194,13 +194,13 @@ describe('background image', () => {
       render(
         <Plot
           {...{
-            handlePlotClick: () => {},
+            handlePlotClick: noop,
             isInHoverRange: false,
             plotContent: {
               ...getPlotContentFromItemId('scarecrow'),
             },
             selectedItemId: '',
-            setHoveredPlot: () => {},
+            setHoveredPlot: noop,
             x: 0,
             y: 0,
           }}
@@ -219,13 +219,13 @@ describe('background image', () => {
       render(
         <Plot
           {...{
-            handlePlotClick: () => {},
+            handlePlotClick: noop,
             isInHoverRange: false,
             plotContent: {
               ...getPlotContentFromItemId('sprinkler'),
             },
             selectedItemId: '',
-            setHoveredPlot: () => {},
+            setHoveredPlot: noop,
             x: 0,
             y: 0,
           }}

--- a/src/components/Plot/Plot.test.js
+++ b/src/components/Plot/Plot.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import { getPlotContentFromItemId } from '../../utils'
+import { noop } from '../../utils/noop'
 import { testCrop } from '../../test-utils'
 import { pixel, plotStates } from '../../img'
 import { cropLifeStage, fertilizerType } from '../../enums'
@@ -21,11 +22,11 @@ beforeEach(() => {
   component = shallow(
     <Plot
       {...{
-        handlePlotClick: () => {},
+        handlePlotClick: noop,
         isInHoverRange: false,
         lifeStage: cropLifeStage.SEED,
         selectedItemId: '',
-        setHoveredPlot: () => {},
+        setHoveredPlot: noop,
         x: 0,
         y: 0,
       }}

--- a/src/components/QuantityInput/QuantityInput.test.js
+++ b/src/components/QuantityInput/QuantityInput.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { noop } from '../../utils/noop'
+
 import QuantityInput from './QuantityInput'
 
 let component
@@ -9,10 +11,10 @@ beforeEach(() => {
   component = shallow(
     <QuantityInput
       {...{
-        handleSubmit: () => {},
-        handleUpdateNumber: () => {},
+        handleSubmit: noop,
+        handleUpdateNumber: noop,
         maxQuantity: 0,
-        setQuantity: () => {},
+        setQuantity: noop,
         value: 0,
       }}
     />

--- a/src/components/QuickSelect/QuickSelect.test.js
+++ b/src/components/QuickSelect/QuickSelect.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { noop } from '../../utils/noop'
+
 import QuickSelect from './QuickSelect'
 
 let component
@@ -10,7 +12,7 @@ beforeEach(() => {
     <QuickSelect
       {...{
         fieldToolInventory: [],
-        handleItemSelectClick: () => {},
+        handleItemSelectClick: noop,
         playerInventoryQuantities: {},
         plantableCropInventory: [],
         selectedItemId: '',

--- a/src/components/SettingsView/SettingsView.test.js
+++ b/src/components/SettingsView/SettingsView.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { noop } from '../../utils/noop'
+
 import SettingsView from './SettingsView'
 
 let component
@@ -10,13 +12,13 @@ beforeEach(() => {
     <SettingsView
       {...{
         allowCustomPeerCowNames: false,
-        handleClearPersistedDataClick: () => {},
-        handleExportDataClick: () => {},
-        handleImportDataClick: () => {},
-        handleSaveButtonClick: () => {},
-        handleShowNotificationsChange: () => {},
-        handleUseAlternateEndDayButtonPositionChange: () => {},
-        handleShowHomeScreenChange: () => {},
+        handleClearPersistedDataClick: noop,
+        handleExportDataClick: noop,
+        handleImportDataClick: noop,
+        handleSaveButtonClick: noop,
+        handleShowNotificationsChange: noop,
+        handleUseAlternateEndDayButtonPositionChange: noop,
+        handleShowHomeScreenChange: noop,
         showNotifications: true,
         useAlternateEndDayButtonPosition: false,
         showHomeScreen: false,

--- a/src/components/Shop/Shop.test.js
+++ b/src/components/Shop/Shop.test.js
@@ -2,8 +2,8 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import Inventory from '../Inventory'
-
 import { INFINITE_STORAGE_LIMIT } from '../../constants'
+import { noop } from '../../utils/noop'
 
 import { Shop } from './Shop'
 
@@ -13,11 +13,11 @@ beforeEach(() => {
   component = shallow(
     <Shop
       {...{
-        handleCombinePurchase: () => {},
-        handleCowPenPurchase: () => {},
-        handleCellarPurchase: () => {},
-        handleFieldPurchase: () => {},
-        handleStorageExpansionPurchase: () => {},
+        handleCombinePurchase: noop,
+        handleCowPenPurchase: noop,
+        handleCellarPurchase: noop,
+        handleFieldPurchase: noop,
+        handleStorageExpansionPurchase: noop,
         inventoryLimit: INFINITE_STORAGE_LIMIT,
         money: 0,
         purchasedCombine: 0,

--- a/src/components/Toolbelt/Toolbelt.js
+++ b/src/components/Toolbelt/Toolbelt.js
@@ -8,14 +8,13 @@ import Tooltip from '@material-ui/core/Tooltip'
 
 import { toolLevel } from '../../enums'
 import { memoize } from '../../utils/memoize'
+import { noop } from '../../utils/noop'
 import FarmhandContext from '../Farmhand/Farmhand.context'
 import toolsData from '../../data/tools'
 
 import { tools as toolImages, craftedItems, pixel } from '../../img'
 
 import './Toolbelt.sass'
-
-const noop = () => {}
 
 const getTools = memoize(toolLevels => {
   const tools = []

--- a/src/game-logic/reducers/fertilizePlot.test.js
+++ b/src/game-logic/reducers/fertilizePlot.test.js
@@ -118,8 +118,6 @@ describe('fertilizePlot', () => {
 
     describe('FERTILIZE field mode updating', () => {
       describe('multiple fertilizer units remaining', () => {
-        beforeEach(() => {})
-
         test('does not change fieldMode', () => {
           const state = fertilizePlot(
             {

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@
  * @typedef farmhand.notification
  * @type {Object}
  * @property {'error'|'info'|'success'|'warning'} severity
- * @property {Function?} onClick
+ * @property {Function=} onClick
  * @property {string} message
  */
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,8 +1,16 @@
 /// <reference types="react-scripts" />
 
+import Farmhand from './components/Farmhand'
+
 // TODO: Contribute type definitions for 'global' package to
 // https://github.com/DefinitelyTyped/DefinitelyTyped
 // @see https://github.com/jeremyckahn/farmhand/issues/399
 declare module 'global/window' {
   export default window as Window
+}
+
+declare global {
+  interface Window {
+    farmhand?: typeof Farmhand
+  }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -760,14 +760,14 @@ export const sortItems = items => {
 
 export const inventorySpaceConsumed = memoize(
   /**
-   * @param {farmhand.item[]} inventory
+   * @param {farmhand.state['inventory']} inventory
    * @returns {number}
    */
   inventory => inventory.reduce((sum, { quantity = 0 }) => sum + quantity, 0)
 )
 
 /**
- * @param {{ inventory: Array.<farmhand.item>, inventoryLimit: number}} state
+ * @param {farmhand.state} state
  * @returns {number}
  */
 export const inventorySpaceRemaining = ({ inventory, inventoryLimit }) =>
@@ -776,11 +776,11 @@ export const inventorySpaceRemaining = ({ inventory, inventoryLimit }) =>
     : Math.max(0, inventoryLimit - inventorySpaceConsumed(inventory))
 
 /**
- * @param {{ inventory: Array.<farmhand.item>, inventoryLimit: number}} state
+ * @param {farmhand.state} state
  * @returns {boolean}
  */
-export const doesInventorySpaceRemain = ({ inventory, inventoryLimit }) =>
-  inventorySpaceRemaining({ inventory, inventoryLimit }) > 0
+export const doesInventorySpaceRemain = state =>
+  inventorySpaceRemaining(state) > 0
 
 /**
  * @param {Array.<farmhand.item>} inventory

--- a/src/utils/noop.js
+++ b/src/utils/noop.js
@@ -1,0 +1,1 @@
+export const noop = () => {}


### PR DESCRIPTION
### What this PR does

This PR:

- Fixes all of the errors in `src/components/Farmhand/Farmhand.js`
  - This required some considerable refactoring switching to patterns that are statically analyzable
- Updates CI job to check types
  - Currently this does not cause a build failure and is strictly informational
- Uses a global `noop` util

### How this change can be validated

This is a pure refactor, so a broad smoke test for regressions should be all that's necessary.

### Questions or concerns about this change

I don't really love the new `FarmhandReducers` pattern, but I couldn't find any other way to bind reducers in a statically analyzable way.