### PR TITLE
fix(utils): [closes #430] Make `findInField` return the correct plot

### DIFF
--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -2,7 +2,6 @@ import { addItemToInventory } from '../game-logic/reducers/'
 import {
   doesPlotContainCrop,
   dollarString,
-  findInField,
   getCropLifeStage,
   getProfitRecord,
   integerString,
@@ -11,6 +10,7 @@ import {
   percentageString,
 } from '../utils'
 import { memoize } from '../utils/memoize'
+import { findInField } from '../utils/findInField'
 import { cropLifeStage, standardCowColors } from '../enums'
 import { COW_FEED_ITEM_ID, I_AM_RICH_BONUSES } from '../constants'
 

--- a/src/game-logic/reducers/applyCrows.test.js
+++ b/src/game-logic/reducers/applyCrows.test.js
@@ -1,5 +1,5 @@
-import { findInField } from '../../utils'
 import { MAX_CROWS, SCARECROW_ITEM_ID } from '../../constants'
+import { findInField } from '../../utils/findInField'
 
 import { randomNumberService } from '../../common/services/randomNumber'
 

--- a/src/game-logic/reducers/helpers.js
+++ b/src/game-logic/reducers/helpers.js
@@ -1,7 +1,8 @@
 import { itemType } from '../../enums'
 
 import { SCARECROW_ITEM_ID } from '../../constants'
-import { findInField, getPlotContentType } from '../../utils'
+import { getPlotContentType } from '../../utils'
+import { findInField } from '../../utils/findInField'
 
 // This file is designed to contain common logic that is needed across multiple
 // reducers.

--- a/src/utils/findInField.js
+++ b/src/utils/findInField.js
@@ -10,20 +10,15 @@ export const findInField = memoize(
    * @returns {?farmhand.plotContent}
    */
   (field, condition) => {
-    /** @type {?farmhand.plotContent} */
-    let foundPlot = null
-
-    field.find(row => {
-      const matchingPlot = row.find(condition)
-
-      if (matchingPlot) {
-        foundPlot = matchingPlot
+    for (const row of field) {
+      for (const plot of row) {
+        if (condition(plot)) {
+          return plot
+        }
       }
+    }
 
-      return matchingPlot
-    })
-
-    return foundPlot
+    return null
   },
   {
     serializer: memoizationSerializer,

--- a/src/utils/findInField.js
+++ b/src/utils/findInField.js
@@ -1,0 +1,31 @@
+/** @typedef {import("../index").farmhand.plotContent} farmhand.plotContent */
+import { memoize } from './memoize'
+
+import { memoizationSerializer } from './'
+
+export const findInField = memoize(
+  /**
+   * @param {(?farmhand.plotContent)[][]} field
+   * @param {function(?farmhand.plotContent): boolean} condition
+   * @returns {?farmhand.plotContent}
+   */
+  (field, condition) => {
+    /** @type {?farmhand.plotContent} */
+    let foundPlot = null
+
+    field.find(row => {
+      const matchingPlot = row.find(condition)
+
+      if (matchingPlot) {
+        foundPlot = matchingPlot
+      }
+
+      return matchingPlot
+    })
+
+    return foundPlot
+  },
+  {
+    serializer: memoizationSerializer,
+  }
+)

--- a/src/utils/findInField.test.js
+++ b/src/utils/findInField.test.js
@@ -1,0 +1,33 @@
+/**
+ * @typedef {import("../components/Farmhand/Farmhand").farmhand.state['field']} farmhand.state.field
+ */
+
+import { carrot, pumpkin } from '../data/crops'
+
+import { findInField } from './findInField'
+
+const carrotPlot = {
+  itemId: carrot.id,
+  fertilizerType: 'NONE',
+}
+
+describe('findInField', () => {
+  /** @type farmhand.state.field} */
+  const field = [[null, carrotPlot, null]]
+
+  test('returns the desired plot from the field', () => {
+    const foundPlot = findInField(field, plot => {
+      return plot?.itemId === carrot.id
+    })
+
+    expect(foundPlot).toEqual(carrotPlot)
+  })
+
+  test('yields null if desired plot is not in the field', () => {
+    const foundPlot = findInField(field, plot => {
+      return plot?.itemId === pumpkin.id
+    })
+
+    expect(foundPlot).toEqual(null)
+  })
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -138,7 +138,7 @@ export const chooseRandom = list => list[chooseRandomIndex(list)]
  * accept function arguments.
  * @param {any[]} args
  */
-const memoizationSerializer = args =>
+export const memoizationSerializer = args =>
   JSON.stringify(
     [...args].map(arg => (typeof arg === 'function' ? arg.toString() : arg))
   )
@@ -713,33 +713,6 @@ export const getPriceEventForCrop = cropItem => ({
   daysRemaining:
     getCropLifecycleDuration(cropItem) - PRICE_EVENT_STANDARD_DURATION_DECREASE,
 })
-
-export const findInField = memoize(
-  /**
-   * @param {(?farmhand.plotContent)[][]} field
-   * @param {function(?farmhand.plotContent): boolean} condition
-   * @returns {?farmhand.plotContent}
-   */
-  (field, condition) => {
-    /** @type {?farmhand.plotContent} */
-    let foundPlot = null
-
-    field.find(row => {
-      const matchingPlot = row.find(condition)
-
-      if (matchingPlot) {
-        foundPlot = matchingPlot
-      }
-
-      return matchingPlot
-    })
-
-    return foundPlot
-  },
-  {
-    serializer: memoizationSerializer,
-  }
-)
 
 export const doesMenuObstructStage = () => window.innerWidth < BREAKPOINTS.MD
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -721,12 +721,20 @@ export const findInField = memoize(
    * @returns {?farmhand.plotContent}
    */
   (field, condition) => {
-    const [plot = null] =
-      field.find(row => {
-        return row.find(condition)
-      }) ?? []
+    /** @type {?farmhand.plotContent} */
+    let foundPlot = null
 
-    return plot
+    field.find(row => {
+      const matchingPlot = row.find(condition)
+
+      if (matchingPlot) {
+        foundPlot = matchingPlot
+      }
+
+      return matchingPlot
+    })
+
+    return foundPlot
   },
   {
     serializer: memoizationSerializer,


### PR DESCRIPTION
### What this PR does

For #430, this PR fixes an implementation bug that manifested in Scarecrows not working if they weren't the first plot in a Field row.

### How this change can be validated

Place a Scarecrow somewhere in the middle of the Field and ensure that crows do not attack when ending the day.

### Additional information

It seems that this bug may have been introduced here: https://github.com/jeremyckahn/farmhand/pull/427/files#diff-ebd8554ec43b07366bd40d16b09d1d063d9e8d5921fa30de4eb80bffdf82668dR718-R727

In any case, this issue wasn't noticed until #427 was shipped.

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
