### PR TITLE
feat(online) [for #432] "Cow offered" notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "shifty": "^3.0.1",
         "source-map-explorer": "^2.3.1",
         "stream": "npm:stream-browserify@^3.0.0",
-        "trystero": "^0.11.8",
+        "trystero": "^0.13.0",
         "typeface-francois-one": "0.0.71",
         "typeface-public-sans": "^1.1.4",
         "url": "^0.11.0",
@@ -32255,8 +32255,9 @@
       "license": "MIT"
     },
     "node_modules/trystero": {
-      "version": "0.11.8",
-      "license": "MIT",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/trystero/-/trystero-0.13.0.tgz",
+      "integrity": "sha512-KfsMQ6bpRm7o8PNkh3nGGDBZ+n9XpF0RAet0PynIVpMTKTQ8xS2yILpohJCiYCMnf8yypvVblSIwXSfOdrLVig==",
       "dependencies": {
         "firebase": "^9.6.5",
         "ipfs-core": "0.9.0",
@@ -56054,7 +56055,9 @@
       "dev": true
     },
     "trystero": {
-      "version": "0.11.8",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/trystero/-/trystero-0.13.0.tgz",
+      "integrity": "sha512-KfsMQ6bpRm7o8PNkh3nGGDBZ+n9XpF0RAet0PynIVpMTKTQ8xS2yILpohJCiYCMnf8yypvVblSIwXSfOdrLVig==",
       "requires": {
         "firebase": "^9.6.5",
         "ipfs-core": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "shifty": "^3.0.1",
     "source-map-explorer": "^2.3.1",
     "stream": "npm:stream-browserify@^3.0.0",
-    "trystero": "^0.11.8",
+    "trystero": "^0.13.0",
     "typeface-francois-one": "0.0.71",
     "typeface-public-sans": "^1.1.4",
     "url": "^0.11.0",

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -5,6 +5,7 @@
  * @typedef {import("../../index").farmhand.keg} farmhand.keg
  * @typedef {import("../../index").farmhand.plotContent} farmhand.plotContent
  * @typedef {import("../../index").farmhand.peerMessage} farmhand.peerMessage
+ * @typedef {import("../../index").farmhand.peerMetadata} farmhand.peerMetadata
  * @typedef {import("../../index").farmhand.priceEvent} farmhand.priceEvent
  * @typedef {import("../../index").farmhand.notification} farmhand.notification
  * @typedef {import("../../enums").cowColors} farmhand.cowColors
@@ -247,7 +248,8 @@ const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
  * @property {farmhand.notification?} latestNotification
  * @property {Array.<farmhand.notification>} newDayNotifications
  * @property {Array.<farmhand.notification>} notificationLog
- * @property {Object} peers Keys are (Trystero) peer ids, values are their respective metadata or null.
+ * @property {Record<string, farmhand.peerMetadata?>} peers Keys are (Trystero)
+ * peer ids, values are their respective metadata or null.
  * @property {Object?} peerRoom See https://github.com/dmotz/trystero
  * @property {farmhand.peerMessage[]} pendingPeerMessages An array of messages
  * to be sent to the Trystero peer room upon the next broadcast.
@@ -707,6 +709,7 @@ export default class Farmhand extends FarmhandReducers {
         const [sendPeerMetadata, getPeerMetadata] = peerRoom.makeAction(
           'peerMetadata'
         )
+
         getPeerMetadata((
           /** @type {[object, string]} */
           ...args
@@ -715,18 +718,21 @@ export default class Farmhand extends FarmhandReducers {
         const [sendCowTradeRequest, getCowTradeRequest] = peerRoom.makeAction(
           'cowTrade'
         )
+
         getCowTradeRequest((
           /** @type {[object, string]} */
           ...args
         ) => handleCowTradeRequest(this, ...args))
 
         const [sendCowAccept, getCowAccept] = peerRoom.makeAction('cowAccept')
+
         getCowAccept((
           /** @type {[object, string]} */
           ...args
         ) => handleCowTradeRequestAccept(this, ...args))
 
         const [sendCowReject, getCowReject] = peerRoom.makeAction('cowReject')
+
         getCowReject((
           /** @type {[object]} */
           ...args

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -892,12 +892,15 @@ export default class Farmhand extends FarmhandReducers {
 
       this.scheduleHeartbeat()
 
+      const trackerRedundancy = 4
+
       this.setState({
         activePlayers,
         peerRoom: joinRoom(
           {
             appId: process.env.REACT_APP_NAME,
             trackerUrls,
+            trackerRedundancy,
             rtcConfig,
           },
           room

--- a/src/components/LogView/LogView.js
+++ b/src/components/LogView/LogView.js
@@ -14,7 +14,16 @@ export const LogView = ({ notificationLog, todaysNotifications }) => (
     <ul>
       {todaysNotifications.map(({ message, onClick, severity }) => (
         <li {...{ key: message }}>
-          <Alert {...{ elevation: 3, onClick, severity }}>
+          <Alert
+            {...{
+              elevation: 3,
+              onClick,
+              severity,
+              style: {
+                cursor: onClick ? 'pointer' : 'default',
+              },
+            }}
+          >
             <ReactMarkdown {...{ source: message }} />
           </Alert>
         </li>

--- a/src/components/NotificationSystem/NotificationSystem.js
+++ b/src/components/NotificationSystem/NotificationSystem.js
@@ -18,6 +18,9 @@ export const snackbarProviderContentCallback = (
       key,
       onClick,
       severity,
+      style: {
+        cursor: onClick ? 'pointer' : 'default',
+      },
     }}
   >
     <ReactMarkdown {...{ source: message }} />

--- a/src/game-logic/reducers/showNotification.js
+++ b/src/game-logic/reducers/showNotification.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../../components/Farmhand/Farmhand").farmhand.state} state
- * @typedef {import("@material-ui/lab/Alert").Color} alertSeverity
+ * @typedef {import('@material-ui/lab/Alert').Color} alertSeverity
+ * @typedef {import('@material-ui/lab/Alert').AlertProps} AlertProps
  */
 
 // TODO: Change showNotification to accept a configuration object instead of so
@@ -10,6 +11,7 @@
  * @param {string} message
  * @param {alertSeverity} [severity] Corresponds to the `severity` prop here:
  * https://material-ui.com/api/alert/
+ * @param {AlertProps['onClick']} onClick
  * @returns {state}
  * @see https://material-ui.com/api/alert/
  */

--- a/src/game-logic/reducers/updatePeer.js
+++ b/src/game-logic/reducers/updatePeer.js
@@ -24,7 +24,7 @@ export const updatePeer = (state, farmhand, peerMetadata, peerId) => {
   const previousCowOfferedId = previousPeerMetadata?.cowOfferedForTrade?.id
   const newCowOfferedId = peerMetadata.cowOfferedForTrade?.id
 
-  const isCowNewlyBeingOfferedForTrade =
+  const isNewTrade =
     newCowOfferedId &&
     previousCowOfferedId !== peerMetadata.cowOfferedForTrade?.id
 
@@ -34,7 +34,7 @@ export const updatePeer = (state, farmhand, peerMetadata, peerId) => {
   // it here.
   const { pendingPeerMessages = [] } = peerMetadata
 
-  if (isCowNewlyBeingOfferedForTrade) {
+  if (isNewTrade) {
     state = showNotification(
       state,
       NEW_COW_OFFERED_FOR_TRADE`${peerMetadata}`,

--- a/src/game-logic/reducers/updatePeer.js
+++ b/src/game-logic/reducers/updatePeer.js
@@ -11,12 +11,12 @@ import { showNotification } from './showNotification'
 
 /**
  * @param {farmhand.state} state
- * @param {string} peerId The peer to update
- * @param {farmhand.peerMetadata} peerMetadata
  * @param {Farmhand} farmhand
+ * @param {farmhand.peerMetadata} peerMetadata
+ * @param {string} peerId The peer to update
  * @returns {farmhand.state}
  */
-export const updatePeer = (state, peerId, peerMetadata, farmhand) => {
+export const updatePeer = (state, farmhand, peerMetadata, peerId) => {
   const peers = { ...state.peers }
 
   const previousPeerMetadata = peers[peerId]

--- a/src/game-logic/reducers/updatePeer.js
+++ b/src/game-logic/reducers/updatePeer.js
@@ -1,18 +1,36 @@
+/**
+ * @typedef {import('../../components/Farmhand/Farmhand').farmhand.state} farmhand.state
+ * @typedef {import('../../index').farmhand.peerMetadata} farmhand.peerMetadata
+ */
 import { MAX_LATEST_PEER_MESSAGES } from '../../constants'
+
+import { showNotification } from './showNotification'
 
 /**
  * @param {farmhand.state} state
  * @param {string} peerId The peer to update
- * @param {Object} state
+ * @param {farmhand.peerMetadata} peerMetadata
  * @returns {farmhand.state}
  */
-export const updatePeer = (state, peerId, peerState) => {
+export const updatePeer = (state, peerId, peerMetadata) => {
   const peers = { ...state.peers }
-  peers[peerId] = peerState
+
+  const previousPeerMetadata = peers[peerId]
+
+  const isCowNewlyBeingOfferedForTrade =
+    previousPeerMetadata?.cowOfferedForTrade?.id !==
+    peerMetadata.cowOfferedForTrade?.id
+
+  peers[peerId] = peerMetadata
 
   // Out of date peer clients may not provide pendingPeerMessages, so default
   // it here.
-  const { pendingPeerMessages = [] } = peerState
+  const { pendingPeerMessages = [] } = peerMetadata
+
+  if (isCowNewlyBeingOfferedForTrade) {
+    // FIXME: Improve this message
+    state = showNotification(state, `A new cow is being offered for trade!`)
+  }
 
   return {
     ...state,

--- a/src/game-logic/reducers/updatePeer.js
+++ b/src/game-logic/reducers/updatePeer.js
@@ -1,9 +1,11 @@
 /**
+ * @typedef {import('../../components/Farmhand/Farmhand').default} Farmhand
  * @typedef {import('../../components/Farmhand/Farmhand').farmhand.state} farmhand.state
  * @typedef {import('../../index').farmhand.peerMetadata} farmhand.peerMetadata
  */
 import { MAX_LATEST_PEER_MESSAGES } from '../../constants'
 import { NEW_COW_OFFERED_FOR_TRADE } from '../../templates'
+import { dialogView } from '../../enums'
 
 import { showNotification } from './showNotification'
 
@@ -11,9 +13,10 @@ import { showNotification } from './showNotification'
  * @param {farmhand.state} state
  * @param {string} peerId The peer to update
  * @param {farmhand.peerMetadata} peerMetadata
+ * @param {Farmhand} farmhand
  * @returns {farmhand.state}
  */
-export const updatePeer = (state, peerId, peerMetadata) => {
+export const updatePeer = (state, peerId, peerMetadata, farmhand) => {
   const peers = { ...state.peers }
 
   const previousPeerMetadata = peers[peerId]
@@ -32,7 +35,14 @@ export const updatePeer = (state, peerId, peerMetadata) => {
   const { pendingPeerMessages = [] } = peerMetadata
 
   if (isCowNewlyBeingOfferedForTrade) {
-    state = showNotification(state, NEW_COW_OFFERED_FOR_TRADE`${peerMetadata}`)
+    state = showNotification(
+      state,
+      NEW_COW_OFFERED_FOR_TRADE`${peerMetadata}`,
+      'info',
+      () => {
+        farmhand.openDialogView(dialogView.ONLINE_PEERS)
+      }
+    )
   }
 
   return {

--- a/src/game-logic/reducers/updatePeer.js
+++ b/src/game-logic/reducers/updatePeer.js
@@ -24,9 +24,7 @@ export const updatePeer = (state, farmhand, peerMetadata, peerId) => {
   const previousCowOfferedId = previousPeerMetadata?.cowOfferedForTrade?.id
   const newCowOfferedId = peerMetadata.cowOfferedForTrade?.id
 
-  const isNewTrade =
-    newCowOfferedId &&
-    previousCowOfferedId !== peerMetadata.cowOfferedForTrade?.id
+  const isNewTrade = newCowOfferedId && previousCowOfferedId !== newCowOfferedId
 
   peers[peerId] = peerMetadata
 

--- a/src/game-logic/reducers/updatePeer.js
+++ b/src/game-logic/reducers/updatePeer.js
@@ -3,6 +3,7 @@
  * @typedef {import('../../index').farmhand.peerMetadata} farmhand.peerMetadata
  */
 import { MAX_LATEST_PEER_MESSAGES } from '../../constants'
+import { NEW_COW_OFFERED_FOR_TRADE } from '../../templates'
 
 import { showNotification } from './showNotification'
 
@@ -17,9 +18,12 @@ export const updatePeer = (state, peerId, peerMetadata) => {
 
   const previousPeerMetadata = peers[peerId]
 
+  const previousCowOfferedId = previousPeerMetadata?.cowOfferedForTrade?.id
+  const newCowOfferedId = peerMetadata.cowOfferedForTrade?.id
+
   const isCowNewlyBeingOfferedForTrade =
-    previousPeerMetadata?.cowOfferedForTrade?.id !==
-    peerMetadata.cowOfferedForTrade?.id
+    newCowOfferedId &&
+    previousCowOfferedId !== peerMetadata.cowOfferedForTrade?.id
 
   peers[peerId] = peerMetadata
 
@@ -28,8 +32,7 @@ export const updatePeer = (state, peerId, peerMetadata) => {
   const { pendingPeerMessages = [] } = peerMetadata
 
   if (isCowNewlyBeingOfferedForTrade) {
-    // FIXME: Improve this message
-    state = showNotification(state, `A new cow is being offered for trade!`)
+    state = showNotification(state, NEW_COW_OFFERED_FOR_TRADE`${peerMetadata}`)
   }
 
   return {

--- a/src/game-logic/reducers/updatePeer.test.js
+++ b/src/game-logic/reducers/updatePeer.test.js
@@ -1,14 +1,22 @@
+/**
+ * @typedef {import('../../index').farmhand.peerMetadata} farmhand.peerMetadata
+ */
 import Farmhand from '../../components/Farmhand'
 import { MAX_LATEST_PEER_MESSAGES } from '../../constants'
+import { NEW_COW_OFFERED_FOR_TRADE } from '../../templates'
+import { getCowStub } from '../../test-utils/stubs/cowStub'
+import { getPeerMetadataStub } from '../../test-utils/stubs/peerMetadataStub'
 
 import { updatePeer } from './updatePeer'
+
+const stubPeerMetadata = getPeerMetadataStub()
 
 describe('updatePeer', () => {
   test('updates peer data', () => {
     const { latestPeerMessages, peers } = updatePeer(
       {
         latestPeerMessages: [],
-        peers: { abc123: { foo: true } },
+        peers: { abc123: stubPeerMetadata },
       },
       Farmhand,
       { foo: false },
@@ -23,7 +31,7 @@ describe('updatePeer', () => {
     const { latestPeerMessages } = updatePeer(
       {
         latestPeerMessages: new Array(50).fill('message'),
-        peers: { abc123: { foo: true } },
+        peers: { abc123: stubPeerMetadata },
       },
       Farmhand,
       { foo: false },
@@ -31,5 +39,43 @@ describe('updatePeer', () => {
     )
 
     expect(latestPeerMessages).toHaveLength(MAX_LATEST_PEER_MESSAGES)
+  })
+
+  test('shows a notification when a new cow is offered', () => {
+    const { todaysNotifications } = updatePeer(
+      {
+        latestPeerMessages: [],
+        todaysNotifications: [],
+        peers: {
+          abc123: stubPeerMetadata,
+        },
+      },
+      Farmhand,
+      { ...stubPeerMetadata, cowOfferedForTrade: getCowStub() },
+      'abc123'
+    )
+
+    expect(todaysNotifications[0]).toEqual(
+      expect.objectContaining({
+        message: NEW_COW_OFFERED_FOR_TRADE`${stubPeerMetadata}`,
+      })
+    )
+  })
+
+  test('does not show a notification when a cow is rescinded', () => {
+    const { todaysNotifications } = updatePeer(
+      {
+        latestPeerMessages: [],
+        todaysNotifications: [],
+        peers: {
+          abc123: { ...stubPeerMetadata, cowOfferedForTrade: getCowStub() },
+        },
+      },
+      Farmhand,
+      stubPeerMetadata,
+      'abc123'
+    )
+
+    expect(todaysNotifications).toEqual([])
   })
 })

--- a/src/game-logic/reducers/updatePeer.test.js
+++ b/src/game-logic/reducers/updatePeer.test.js
@@ -10,9 +10,9 @@ describe('updatePeer', () => {
         latestPeerMessages: [],
         peers: { abc123: { foo: true } },
       },
-      'abc123',
+      Farmhand,
       { foo: false },
-      Farmhand
+      'abc123'
     )
 
     expect(latestPeerMessages).toEqual([])
@@ -25,9 +25,9 @@ describe('updatePeer', () => {
         latestPeerMessages: new Array(50).fill('message'),
         peers: { abc123: { foo: true } },
       },
-      'abc123',
+      Farmhand,
       { foo: false },
-      Farmhand
+      'abc123'
     )
 
     expect(latestPeerMessages).toHaveLength(MAX_LATEST_PEER_MESSAGES)

--- a/src/game-logic/reducers/updatePeer.test.js
+++ b/src/game-logic/reducers/updatePeer.test.js
@@ -1,3 +1,4 @@
+import Farmhand from '../../components/Farmhand'
 import { MAX_LATEST_PEER_MESSAGES } from '../../constants'
 
 import { updatePeer } from './updatePeer'
@@ -10,7 +11,8 @@ describe('updatePeer', () => {
         peers: { abc123: { foo: true } },
       },
       'abc123',
-      { foo: false }
+      { foo: false },
+      Farmhand
     )
 
     expect(latestPeerMessages).toEqual([])
@@ -24,7 +26,8 @@ describe('updatePeer', () => {
         peers: { abc123: { foo: true } },
       },
       'abc123',
-      { foo: false }
+      { foo: false },
+      Farmhand
     )
 
     expect(latestPeerMessages).toHaveLength(MAX_LATEST_PEER_MESSAGES)

--- a/src/handlers/peer-events.js
+++ b/src/handlers/peer-events.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../components/Farmhand/Farmhand').default} Farmhand */
+/** @typedef {import('../index').farmhand.peerMetadata} farmhand.peerMetadata */
 import { cowTradeRejectionReason } from '../enums'
 import { COW_TRADED_NOTIFICATION } from '../templates'
 import {
@@ -16,11 +18,11 @@ import {
 
 /**
  * @param {Farmhand} farmhand
- * @param {Object} peerState
+ * @param {farmhand.peerMetadata} peerMetadata
  * @param {string} peerId
  */
-export const handlePeerMetadataRequest = (farmhand, peerState, peerId) => {
-  farmhand.updatePeer(peerId, peerState)
+export const handlePeerMetadataRequest = (farmhand, peerMetadata, peerId) => {
+  farmhand.updatePeer(peerId, peerMetadata)
 }
 
 /**

--- a/src/handlers/peer-events.js
+++ b/src/handlers/peer-events.js
@@ -22,7 +22,7 @@ import {
  * @param {string} peerId
  */
 export const handlePeerMetadataRequest = (farmhand, peerMetadata, peerId) => {
-  farmhand.updatePeer(peerId, peerMetadata)
+  farmhand.updatePeer(peerId, peerMetadata, farmhand)
 }
 
 /**

--- a/src/handlers/peer-events.js
+++ b/src/handlers/peer-events.js
@@ -22,7 +22,7 @@ import {
  * @param {string} peerId
  */
 export const handlePeerMetadataRequest = (farmhand, peerMetadata, peerId) => {
-  farmhand.updatePeer(peerId, peerMetadata, farmhand)
+  farmhand.updatePeer(farmhand, peerMetadata, peerId)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@
  */
 
 /**
+ * @typedef {import("./components/Farmhand/Farmhand").farmhand.state} farmhand.state
+ */
+
+/**
  * @typedef {import("./enums").cropType} cropType
  * @typedef {import("./enums").cowColors} cowColors
  * @typedef {import("./enums").recipeType} recipeType
@@ -192,6 +196,17 @@
  * @property {string} id The farmhand.state.id of the peer.
  * @property {'error'|'info'|'success'|'warning'} severity
  * @property {string} message
+ */
+
+/**
+ * @typedef farmhand.offeredCow
+ * @type {farmhand.cow}
+ * @property {string} ownerId
+ */
+
+/**
+ * @typedef farmhand.peerMetadata
+ * @type {Pick<farmhand.state, 'cowsSold' | 'cropsHarvested' | 'dayCount' | 'id' | 'itemsSold' | 'money' | 'pendingPeerMessages' | 'version'> & { cowOfferedForTrade?: farmhand.offeredCow }}
  */
 
 /**

--- a/src/templates.js
+++ b/src/templates.js
@@ -360,7 +360,7 @@ export const KEG_SPOILED_MESSAGE = (_, keg) =>
   `Oh no! Your ${FERMENTED_CROP_NAME`${itemsMap[keg.itemId]}`} has spoiled!`
 
 /**
- * @param {string} _
+ * @param {TemplateStringsArray} _
  * @param {farmhand.peerMetadata} peerMetadata
  * @returns {string}
  */

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,6 +1,8 @@
 /**
  * @typedef {import("./index").farmhand.item} farmhand.item
+ * @typedef {import("./index").farmhand.crop} farmhand.crop
  * @typedef {import("./index").farmhand.keg} keg
+ * @typedef {import("./index").farmhand.peerMetadata} farmhand.peerMetadata
  */
 
 /**
@@ -13,6 +15,7 @@ import { itemsMap } from './data/maps'
 import { moneyString } from './utils/moneyString'
 import {
   getCowDisplayName,
+  getPlayerName,
   getRandomLevelUpRewardQuantity,
   integerString,
 } from './utils'
@@ -355,3 +358,11 @@ export const FERMENTED_CROP_NAME = (_, item) => `Fermented ${item.name}`
  */
 export const KEG_SPOILED_MESSAGE = (_, keg) =>
   `Oh no! Your ${FERMENTED_CROP_NAME`${itemsMap[keg.itemId]}`} has spoiled!`
+
+/**
+ * @param {string} _
+ * @param {farmhand.peerMetadata} peerMetadata
+ * @returns {string}
+ */
+export const NEW_COW_OFFERED_FOR_TRADE = (_, peerMetadata) =>
+  `A new cow is being offered for trade by ${getPlayerName(peerMetadata.id)}!`

--- a/src/test-utils/stubs/cowStub.js
+++ b/src/test-utils/stubs/cowStub.js
@@ -1,0 +1,30 @@
+/** @typedef {import('../../index').farmhand.cow} farmhand.cow */
+
+import { v4 as uuid } from 'uuid'
+
+import { cowColors, genders } from '../../enums'
+
+export const getCowStub = () => {
+  /** @type farmhand.cow */
+  const cow = {
+    baseWeight: 1000,
+    color: cowColors.BLUE,
+    colorsInBloodline: {},
+    daysOld: 1,
+    daysSinceMilking: 0,
+    daysSinceProducingFertilizer: 0,
+    gender: genders.FEMALE,
+    happiness: 0,
+    happinessBoostsToday: 0,
+    id: uuid(),
+    isBred: false,
+    isUsingHuggingMachine: false,
+    name: '',
+    originalOwnerId: uuid(),
+    ownerId: uuid(),
+    timesTraded: 0,
+    weightMultiplier: 1,
+  }
+
+  return cow
+}

--- a/src/test-utils/stubs/peerMetadataStub.js
+++ b/src/test-utils/stubs/peerMetadataStub.js
@@ -1,0 +1,19 @@
+/** @typedef {import('../../index').farmhand.peerMetadata} farmhand.peerMetadata */
+
+import { v4 as uuid } from 'uuid'
+
+export const getPeerMetadataStub = () => {
+  /** @type farmhand.peerMetadata */
+  const peerMetadata = {
+    cowsSold: {},
+    cropsHarvested: 0,
+    dayCount: 0,
+    id: uuid(),
+    itemsSold: {},
+    money: 0,
+    pendingPeerMessages: [],
+    version: '0.0.0',
+  }
+
+  return peerMetadata
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -989,13 +989,15 @@ export const transformStateDataForImport = state => {
   return sanitizedState
 }
 
-/**
- * @param {string} playerId
- * @returns {string}
- */
-export const getPlayerName = memoize(playerId => {
-  return funAnimalName(playerId)
-})
+export const getPlayerName = memoize(
+  /**
+   * @param {string} playerId
+   * @returns {string}
+   */
+  playerId => {
+    return funAnimalName(playerId)
+  }
+)
 
 /**
  * @param {number} currentInventoryLimit


### PR DESCRIPTION
### What this PR does

For #432, this PR adds a notification that is shown when an online peer offers a cow for trade. When the notification is clicked, the "Active Players" dialog is opened.

This PR also:
  - Updates Trystero to the latest version and increases tracker redundancy for improved peer connectivity.
  - Gives clickable notifications the `pointer: cursor` style.

### How this change can be validated

Set up two peers (they can be on the same computer but in different browsers) and join the same online room. Once peers are connected, offer a cow for trade. Observe that the other peer gets a notification like the one pictured below.

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->

![Screenshot of new notification](https://github.com/jeremyckahn/farmhand/assets/366330/02ad306f-8cf3-4bf2-8a66-e00ae5c05bd4)