### PR TITLE
fix(online): [fixes #442] Show correct peer cow state

### DIFF
--- a/src/components/CowCard/CowCard.js
+++ b/src/components/CowCard/CowCard.js
@@ -101,8 +101,10 @@ export const CowCard = (
 
   const [displayName, setDisplayName] = useState(cowDisplayName)
   const [cowImage, setCowImage] = useState(pixel)
-  const cardRef = useRef()
-  const scrollAnchorRef = useRef()
+
+  // @see https://github.com/microsoft/TypeScript/issues/27387#issuecomment-659671940
+  const cardRef = useRef(/** @type {Element|null} */ (null))
+  const scrollAnchorRef = useRef(/** @type {HTMLAnchorElement|null} */ (null))
 
   const isCowPurchased =
     !!cowInventory.find(({ id }) => id === cow.id) &&
@@ -220,7 +222,7 @@ export const CowCard = (
                 disabled:
                   cowValue > money ||
                   cowInventory.length >=
-                    PURCHASEABLE_COW_PENS.get(purchasedCowPen).cows,
+                    (PURCHASEABLE_COW_PENS.get(purchasedCowPen)?.cows ?? 0),
                 onClick: () => handleCowPurchaseClick(cow),
                 variant: 'contained',
               }}
@@ -347,6 +349,9 @@ CowCard.propTypes = {
   purchasedCowPen: number.isRequired,
 }
 
+/**
+ * @param {CowCardProps} props
+ */
 export default function Consumer(props) {
   return (
     <FarmhandContext.Consumer>

--- a/src/components/CowCard/CowCard.js
+++ b/src/components/CowCard/CowCard.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../../components/Farmhand/Farmhand').farmhand.state} farmhand.state */
+/** @typedef {import('../../index').farmhand.cow} farmhand.cow */
 import React, { useEffect, useRef, useState } from 'react'
 
 import { array, bool, func, number, object, string } from 'prop-types'
@@ -35,31 +37,39 @@ const genderIcons = {
   [genders.MALE]: faMars,
 }
 
-export const CowCard = ({
-  allowCustomPeerCowNames,
-  cow,
-  cowBreedingPen,
-  cowIdOfferedForTrade,
-  cowInventory,
-  debounced,
-  handleCowAutomaticHugChange,
-  handleCowBreedChange,
-  handleCowHugClick,
-  handleCowOfferClick,
-  handleCowPurchaseClick,
-  handleCowWithdrawClick,
-  handleCowSellClick,
-  handleCowTradeClick,
-  id,
-  inventory,
-  isCowOfferedForTradeByPeer,
-  isSelected,
-  isOnline,
-  money,
-  purchasedCowPen,
+export const CowCard = (
+  /**
+   * @type {{
+   *   cow: farmhand.cow,
+   *   id: farmhand.state['id']
+   * }}
+   */
+  {
+    allowCustomPeerCowNames,
+    cow,
+    cowBreedingPen,
+    cowIdOfferedForTrade,
+    cowInventory,
+    debounced,
+    handleCowAutomaticHugChange,
+    handleCowBreedChange,
+    handleCowHugClick,
+    handleCowOfferClick,
+    handleCowPurchaseClick,
+    handleCowWithdrawClick,
+    handleCowSellClick,
+    handleCowTradeClick,
+    id,
+    inventory,
+    isCowOfferedForTradeByPeer,
+    isSelected,
+    isOnline,
+    money,
+    purchasedCowPen,
 
-  huggingMachinesRemain = areHuggingMachinesInInventory(inventory),
-}) => {
+    huggingMachinesRemain = areHuggingMachinesInInventory(inventory),
+  }
+) => {
   const cowDisplayName = getCowDisplayName(cow, id, allowCustomPeerCowNames)
 
   const [displayName, setDisplayName] = useState(cowDisplayName)
@@ -70,7 +80,9 @@ export const CowCard = ({
   const isCowPurchased =
     !!cowInventory.find(({ id }) => id === cow.id) &&
     !isCowOfferedForTradeByPeer
-  const cowValue = getCowValue(cow, isCowPurchased)
+
+  // cow.originalOwnerId is only an empty string when it is for sale.
+  const cowValue = getCowValue(cow, cow.originalOwnerId !== '')
   const cowCanBeTradedAway =
     isOnline && !isCowInBreedingPen(cow, cowBreedingPen)
   const canCowBeTradedFor = Boolean(

--- a/src/components/CowCard/CowCard.js
+++ b/src/components/CowCard/CowCard.js
@@ -1,5 +1,8 @@
+/** @typedef {import('../../handlers/ui-events')['default']} farmhand.uiHandlers */
 /** @typedef {import('../../components/Farmhand/Farmhand').farmhand.state} farmhand.state */
+/** @typedef {import('../../components/Farmhand/Farmhand').default} Farmhand */
 /** @typedef {import('../../index').farmhand.cow} farmhand.cow */
+/** @typedef {import('../../index').farmhand.cowBreedingPen} farmhand.cowBreedingPen */
 import React, { useEffect, useRef, useState } from 'react'
 
 import { array, bool, func, number, object, string } from 'prop-types'
@@ -37,12 +40,36 @@ const genderIcons = {
   [genders.MALE]: faMars,
 }
 
+/**
+ * @typedef {{
+ *   allowCustomPeerCowNames: boolean,
+ *   cow: farmhand.cow,
+ *   cowBreedingPen: farmhand.cowBreedingPen,
+ *   cowInventory: farmhand.state['cowInventory'],
+ *   cowIdOfferedForTrade: farmhand.cow['id'],
+ *   debounced: Farmhand['handlers']['debounced'],
+ *   handleCowAutomaticHugChange: farmhand.uiHandlers['handleCowAutomaticHugChange'],
+ *   handleCowBreedChange: farmhand.uiHandlers['handleCowBreedChange'],
+ *   handleCowHugClick: farmhand.uiHandlers['handleCowHugClick'],
+ *   handleCowOfferClick: farmhand.uiHandlers['handleCowOfferClick'],
+ *   handleCowPurchaseClick: farmhand.uiHandlers['handleCowPurchaseClick'],
+ *   handleCowWithdrawClick: farmhand.uiHandlers['handleCowWithdrawClick'],
+ *   handleCowSellClick: farmhand.uiHandlers['handleCowSellClick'],
+ *   handleCowTradeClick: farmhand.uiHandlers['handleCowTradeClick'],
+ *   id: farmhand.state['id'],
+ *   inventory: farmhand.state['inventory'],
+ *   isCowOfferedForTradeByPeer: boolean,
+ *   isSelected: boolean,
+ *   isOnline: boolean,
+ *   money: farmhand.state['money'],
+ *   purchasedCowPen: farmhand.state['purchasedCowPen'],
+ *   huggingMachinesRemain?: boolean,
+ * }} CowCardProps
+ */
+
 export const CowCard = (
   /**
-   * @type {{
-   *   cow: farmhand.cow,
-   *   id: farmhand.state['id']
-   * }}
+   * @type CowCardProps
    */
   {
     allowCustomPeerCowNames,

--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../../../components/Farmhand/Farmhand').farmhand.state} farmhand.state */
+/** @typedef {import('../../../index').farmhand.cow} farmhand.cow */
 import React from 'react'
 import { array, bool, func, object, string } from 'prop-types'
 import Checkbox from '@material-ui/core/Checkbox'
@@ -36,19 +38,27 @@ const getCowMapById = memoize(cowInventory =>
   }, {})
 )
 
-const Subheader = ({
-  canCowBeTradedFor,
-  cow,
-  cowBreedingPen,
-  cowIdOfferedForTrade,
-  cowInventory,
-  cowValue,
-  handleCowAutomaticHugChange,
-  handleCowBreedChange,
-  huggingMachinesRemain,
-  id: playerId,
-  isCowPurchased,
-}) => {
+const Subheader = (
+  /**
+   * @type {{
+   *   cow: farmhand.cow,
+   *   id: farmhand.state['id']
+   * }}
+   */
+  {
+    canCowBeTradedFor,
+    cow,
+    cowBreedingPen,
+    cowIdOfferedForTrade,
+    cowInventory,
+    cowValue,
+    handleCowAutomaticHugChange,
+    handleCowBreedChange,
+    huggingMachinesRemain,
+    id: playerId,
+    isCowPurchased,
+  }
+) => {
   const numberOfFullHearts = cow.happiness * 10
   const isInBreedingPen = isCowInBreedingPen(cow, cowBreedingPen)
   const isRoomInBreedingPen =
@@ -80,7 +90,9 @@ const Subheader = ({
       )}
       <p>Color: {COW_COLOR_NAMES[cow.color]}</p>
       <p>
-        {isCowPurchased ? 'Value' : 'Price'}: {moneyString(cowValue)}
+        {/* cow.originalOwnerId is only an empty string when it is for sale. */}
+        {cow.originalOwnerId === '' ? 'Value' : 'Price'}:{' '}
+        {moneyString(cowValue)}
       </p>
       <p>Weight: {getCowWeight(cow)} lbs.</p>
       {(isCowPurchased || canCowBeTradedFor) && (

--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -91,7 +91,7 @@ const Subheader = (
       <p>Color: {COW_COLOR_NAMES[cow.color]}</p>
       <p>
         {/* cow.originalOwnerId is only an empty string when it is for sale. */}
-        {cow.originalOwnerId === '' ? 'Value' : 'Price'}:{' '}
+        {cow.originalOwnerId === '' ? 'Price' : 'Value'}:{' '}
         {moneyString(cowValue)}
       </p>
       <p>Weight: {getCowWeight(cow)} lbs.</p>

--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -1,5 +1,6 @@
 /** @typedef {import('../../../components/Farmhand/Farmhand').farmhand.state} farmhand.state */
 /** @typedef {import('../../../index').farmhand.cow} farmhand.cow */
+/** @typedef {import('../CowCard').CowCardProps} CowCardProps */
 import React from 'react'
 import { array, bool, func, object, string } from 'prop-types'
 import Checkbox from '@material-ui/core/Checkbox'
@@ -28,23 +29,44 @@ import './Subheader.sass'
 
 // The extra 0.5 is for rounding up to the next full heart. This allows a fully
 // happy cow to have full hearts on the beginning of a new day.
+/**
+ * @param {number} heartIndex
+ * @param {number} numberOfFullHearts
+ */
 const isHeartFull = (heartIndex, numberOfFullHearts) =>
   heartIndex + 0.5 < numberOfFullHearts
 
-const getCowMapById = memoize(cowInventory =>
-  cowInventory.reduce((acc, cow) => {
-    acc[cow.id] = cow
-    return acc
-  }, {})
+const getCowMapById = memoize(
+  /**
+   * @param {farmhand.state['cowInventory']} cowInventory
+   */
+  cowInventory =>
+    cowInventory.reduce((acc, cow) => {
+      acc[cow.id] = cow
+      return acc
+    }, {})
 )
 
+/**
+ * @typedef {Pick<
+ *    CowCardProps,
+ *    'cow' |
+ *    'cowBreedingPen' |
+ *    'cowIdOfferedForTrade' |
+ *    'cowInventory' |
+ *    'handleCowAutomaticHugChange' |
+ *    'handleCowBreedChange' |
+ *    'huggingMachinesRemain' |
+ *    'id'
+ *  > & {
+ *    canCowBeTradedFor: boolean,
+ *    cowValue: number,
+ *    isCowPurchased: boolean,
+ *  }} SubheaderProps
+ */
+
 const Subheader = (
-  /**
-   * @type {{
-   *   cow: farmhand.cow,
-   *   id: farmhand.state['id']
-   * }}
-   */
+  /** @type {SubheaderProps} */
   {
     canCowBeTradedFor,
     cow,
@@ -66,7 +88,7 @@ const Subheader = (
   const isThisCowOfferedForTrade = cowIdOfferedForTrade === cow.id
 
   const mateId = cowBreedingPen.cowId1 ?? cowBreedingPen.cowId2
-  const mate = getCowMapById(cowInventory)[mateId]
+  const mate = getCowMapById(cowInventory)[mateId ?? '']
   const isEligibleToBreed = cow.gender !== mate?.gender
 
   const canBeMovedToBreedingPen =

--- a/src/components/CowCard/Subheader/Subheader.test.js
+++ b/src/components/CowCard/Subheader/Subheader.test.js
@@ -6,7 +6,7 @@ import { moneyString } from '../../../utils/moneyString'
 
 import Subheader from './Subheader'
 
-const cowValueStub = 1000
+const COW_VALUE = 1000
 
 describe('Subheader', () => {
   let baseProps
@@ -19,7 +19,7 @@ describe('Subheader', () => {
       cowBreedingPen: { cowId1: null, cowId2: null, daysUntilBirth: -1 },
       cowIdOfferedForTrade: '',
       cowInventory: [],
-      cowValue: cowValueStub,
+      cowValue: COW_VALUE,
       huggingMachinesRemain: false,
       id: '',
       isCowPurchased: false,
@@ -84,7 +84,7 @@ describe('Subheader', () => {
         <Subheader {...baseProps} cow={getCowStub({ originalOwnerId: '' })} />
       )
 
-      const price = screen.getByText(`Price: ${moneyString(cowValueStub)}`)
+      const price = screen.getByText(`Price: ${moneyString(COW_VALUE)}`)
       expect(price).toBeInTheDocument()
     })
 
@@ -96,7 +96,7 @@ describe('Subheader', () => {
         />
       )
 
-      const value = screen.getByText(`Value: ${moneyString(cowValueStub)}`)
+      const value = screen.getByText(`Value: ${moneyString(COW_VALUE)}`)
       expect(value).toBeInTheDocument()
     })
   })

--- a/src/components/CowCard/Subheader/Subheader.test.js
+++ b/src/components/CowCard/Subheader/Subheader.test.js
@@ -80,7 +80,12 @@ describe('Subheader', () => {
 
   describe('price/value display', () => {
     test('displays price for cows that can be purchased', () => {
-      render(<Subheader {...baseProps} />)
+      render(
+        <Subheader
+          {...baseProps}
+          cow={getCowStub({ originalOwnerId: 'abc123' })}
+        />
+      )
 
       const price = screen.getByText(`Price: ${moneyString(cowValueStub)}`)
       expect(price).toBeInTheDocument()

--- a/src/components/CowCard/Subheader/Subheader.test.js
+++ b/src/components/CowCard/Subheader/Subheader.test.js
@@ -1,10 +1,12 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
-import { generateCow } from '../../../utils'
-import { cowColors } from '../../../enums'
+import { getCowStub } from '../../../test-utils/stubs/cowStub'
+import { moneyString } from '../../../utils/moneyString'
 
 import Subheader from './Subheader'
+
+const cowValueStub = 1000
 
 describe('Subheader', () => {
   let baseProps
@@ -13,16 +15,11 @@ describe('Subheader', () => {
     jest.spyOn(Math, 'random').mockReturnValue(0)
     baseProps = {
       canCowBeTradedFor: false,
-      cow: generateCow({
-        color: cowColors.WHITE,
-        happiness: 0,
-        name: '',
-        baseWeight: 100,
-      }),
+      cow: getCowStub(),
       cowBreedingPen: { cowId1: null, cowId2: null, daysUntilBirth: -1 },
       cowIdOfferedForTrade: '',
       cowInventory: [],
-      cowValue: 1000,
+      cowValue: cowValueStub,
       huggingMachinesRemain: false,
       id: '',
       isCowPurchased: false,
@@ -52,11 +49,8 @@ describe('Subheader', () => {
           <Subheader
             {...{
               ...baseProps,
-              cow: generateCow({
-                color: cowColors.WHITE,
+              cow: getCowStub({
                 happiness: 0.5,
-                name: '',
-                baseWeight: 100,
               }),
               isCowPurchased: true,
             }}
@@ -71,11 +65,8 @@ describe('Subheader', () => {
           <Subheader
             {...{
               ...baseProps,
-              cow: generateCow({
-                color: cowColors.WHITE,
+              cow: getCowStub({
                 happiness: 1,
-                name: '',
-                baseWeight: 100,
               }),
               isCowPurchased: true,
             }}
@@ -84,6 +75,24 @@ describe('Subheader', () => {
 
         expect(container.querySelectorAll('.heart.is-full')).toHaveLength(10)
       })
+    })
+  })
+
+  describe('price/value display', () => {
+    test('displays price for cows that can be purchased', () => {
+      render(<Subheader {...baseProps} />)
+
+      const price = screen.getByText(`Price: ${moneyString(cowValueStub)}`)
+      expect(price).toBeInTheDocument()
+    })
+
+    test('displays value for cows that have been purchased', () => {
+      render(
+        <Subheader {...baseProps} cow={getCowStub({ originalOwnerId: '' })} />
+      )
+
+      const value = screen.getByText(`Value: ${moneyString(cowValueStub)}`)
+      expect(value).toBeInTheDocument()
     })
   })
 })

--- a/src/components/CowCard/Subheader/Subheader.test.js
+++ b/src/components/CowCard/Subheader/Subheader.test.js
@@ -81,10 +81,7 @@ describe('Subheader', () => {
   describe('price/value display', () => {
     test('displays price for cows that can be purchased', () => {
       render(
-        <Subheader
-          {...baseProps}
-          cow={getCowStub({ originalOwnerId: 'abc123' })}
-        />
+        <Subheader {...baseProps} cow={getCowStub({ originalOwnerId: '' })} />
       )
 
       const price = screen.getByText(`Price: ${moneyString(cowValueStub)}`)
@@ -93,7 +90,10 @@ describe('Subheader', () => {
 
     test('displays value for cows that have been purchased', () => {
       render(
-        <Subheader {...baseProps} cow={getCowStub({ originalOwnerId: '' })} />
+        <Subheader
+          {...baseProps}
+          cow={getCowStub({ originalOwnerId: 'abc123' })}
+        />
       )
 
       const value = screen.getByText(`Value: ${moneyString(cowValueStub)}`)

--- a/src/handlers/ui-events.js
+++ b/src/handlers/ui-events.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import("../index").farmhand.item} item
  * @typedef {import("../index").farmhand.keg} keg
+ * @typedef {import("../index").farmhand.cow} farmhand.cow
  */
 import { saveAs } from 'file-saver'
 import window from 'global/window'

--- a/src/handlers/ui-events.js
+++ b/src/handlers/ui-events.js
@@ -111,7 +111,7 @@ export default {
   },
 
   /**
-   * @param {external:React.SyntheticEvent} e
+   * @param {React.SyntheticEvent} e
    * @param {farmhand.cow} cow
    */
   handleCowAutomaticHugChange({ target: { checked } }, cow) {
@@ -119,7 +119,7 @@ export default {
   },
 
   /**
-   * @param {external:React.SyntheticEvent} e
+   * @param {React.SyntheticEvent} e
    * @param {farmhand.cow} cow
    */
   handleCowBreedChange({ target: { checked } }, cow) {
@@ -148,7 +148,7 @@ export default {
   },
 
   /**
-   * @param {external:React.SyntheticEvent} e
+   * @param {React.SyntheticEvent} e
    * @param {farmhand.cow} cow
    */
   handleCowNameInputChange({ target: { value } }, cow) {
@@ -164,7 +164,7 @@ export default {
   },
 
   /**
-   * @param {external:React.SyntheticEvent} e
+   * @param {React.SyntheticEvent} e
    */
   handleViewChange({ target: { value } }) {
     this.setState({ stageFocus: value })

--- a/src/test-utils/stubs/cowStub.js
+++ b/src/test-utils/stubs/cowStub.js
@@ -4,7 +4,10 @@ import { v4 as uuid } from 'uuid'
 
 import { cowColors, genders } from '../../enums'
 
-export const getCowStub = () => {
+/**
+ * @param {Partial<farmhand.cow>?} overrides
+ */
+export const getCowStub = (overrides = {}) => {
   /** @type farmhand.cow */
   const cow = {
     baseWeight: 1000,
@@ -24,6 +27,7 @@ export const getCowStub = () => {
     ownerId: uuid(),
     timesTraded: 0,
     weightMultiplier: 1,
+    ...overrides,
   }
 
   return cow

--- a/src/test-utils/stubs/cowStub.js
+++ b/src/test-utils/stubs/cowStub.js
@@ -1,34 +1,15 @@
 /** @typedef {import('../../index').farmhand.cow} farmhand.cow */
 
-import { v4 as uuid } from 'uuid'
-
-import { cowColors, genders } from '../../enums'
+import { generateCow } from '../../utils'
 
 /**
  * @param {Partial<farmhand.cow>?} overrides
  */
 export const getCowStub = (overrides = {}) => {
-  /** @type farmhand.cow */
-  const cow = {
+  const cow = generateCow({
     baseWeight: 1000,
-    color: cowColors.BLUE,
-    colorsInBloodline: {},
-    daysOld: 1,
-    daysSinceMilking: 0,
-    daysSinceProducingFertilizer: 0,
-    gender: genders.FEMALE,
-    happiness: 0,
-    happinessBoostsToday: 0,
-    id: uuid(),
-    isBred: false,
-    isUsingHuggingMachine: false,
-    name: '',
-    originalOwnerId: uuid(),
-    ownerId: uuid(),
-    timesTraded: 0,
-    weightMultiplier: 1,
     ...overrides,
-  }
+  })
 
   return cow
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -763,12 +763,12 @@ export const inventorySpaceRemaining = ({ inventory, inventoryLimit }) =>
 export const doesInventorySpaceRemain = state =>
   inventorySpaceRemaining(state) > 0
 
-/**
- * @param {Array.<farmhand.item>} inventory
- * @return {boolean}
- */
-export const areHuggingMachinesInInventory = memoize(inventory =>
-  inventory.some(({ id }) => id === HUGGING_MACHINE_ITEM_ID)
+export const areHuggingMachinesInInventory = memoize(
+  /**
+   * @param {farmhand.state['inventory']} inventory
+   * @return {boolean}
+   */
+  inventory => inventory.some(({ id }) => id === HUGGING_MACHINE_ITEM_ID)
 )
 
 /**


### PR DESCRIPTION
### What this PR does

For #442 (reported by @jmmullins), this PR changes how cows offered by online peers are presented. Previously, cows were incorrectly shown to peers as if they were for sale (such as when they are first purchased). Now, they are correctly shown with their sale value.

This PR also updates the `CowCard` and its helper `Subheader` component files to be type-safe.

### How this change can be validated

1. Ensure that cows for sale show their "Price": 
![Cow for sale screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/6bf0fbfa-c050-4c9a-9c0b-0f81d429f0bf)
2. Ensure that cows in the cow pen inventory show their "Value": 
![Cow in inventory screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/79222d7f-74b8-49a8-a9fa-7ff23aa2af22)
3. Ensure that cows being offered show their "Value": 
![Cow being offered screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/e0148efa-beab-4ef5-be01-70955a3e6c06)
4. Ensure that cows that can be traded for show their "Value": 
![Cow to be traded for screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/88b056a3-51c9-4c8b-b490-60df1a5cd3c9)

### Additional information

I highly recommend disabling whitespace changes when reviewing this PR.