### PR TITLE
feat(experience): [closes #460] Grant experience for selling coal, ores, and stones

### DIFF
--- a/src/game-logic/reducers/sellItem.test.js
+++ b/src/game-logic/reducers/sellItem.test.js
@@ -1,7 +1,7 @@
 import { testItem } from '../../test-utils'
 import { LOAN_PAYOFF } from '../../templates'
 import { carrot } from '../../data/crops'
-import { bronzeOre, coal, milk1 } from '../../data/items'
+import { bronzeOre, coal, milk1, saltRock } from '../../data/items'
 import { carrotSoup } from '../../data/recipes'
 
 import { sellItem } from './sellItem'
@@ -236,6 +236,7 @@ describe('sellItem', () => {
     coal,
     carrotSoup,
     bronzeOre,
+    saltRock,
   ].map(item => [item.type, item])
 
   test.each(experienceTestArgs)(

--- a/src/game-logic/reducers/sellItem.test.js
+++ b/src/game-logic/reducers/sellItem.test.js
@@ -1,5 +1,8 @@
 import { testItem } from '../../test-utils'
 import { LOAN_PAYOFF } from '../../templates'
+import { carrot } from '../../data/crops'
+import { bronzeOre, coal, milk1 } from '../../data/items'
+import { carrotSoup } from '../../data/recipes'
 
 import { sellItem } from './sellItem'
 
@@ -226,4 +229,36 @@ describe('sellItem', () => {
       })
     })
   })
+
+  const experienceTestArgs = [
+    carrot,
+    milk1,
+    coal,
+    carrotSoup,
+    bronzeOre,
+  ].map(item => [item.type, item])
+
+  test.each(experienceTestArgs)(
+    'selling item of type %s gives experience',
+    (_, item) => {
+      const state = sellItem(
+        {
+          experience: 0,
+          inventory: [testItem({ id: item.id, quantity: 1 })],
+          itemsSold: {},
+          loanBalance: 0,
+          money: 100,
+          pendingPeerMessages: [],
+          todaysNotifications: [],
+          revenue: 0,
+          todaysRevenue: 0,
+          valueAdjustments: { [item.id]: 1 },
+        },
+        testItem({ id: item.id }),
+        1
+      )
+
+      expect(state.experience).toEqual(1)
+    }
+  )
 })

--- a/src/utils/isItemAFarmProduct.js
+++ b/src/utils/isItemAFarmProduct.js
@@ -1,8 +1,14 @@
+/** @typedef {import('../index').farmhand.item} farmhand.item */
 import { itemType } from '../enums'
 
 import { isItemAGrownCrop } from './isItemAGrownCrop'
 
-const FARM_PRODUCT_TYPES = [itemType.MILK, itemType.CRAFTED_ITEM]
+const FARM_PRODUCT_TYPES = [
+  itemType.CRAFTED_ITEM,
+  itemType.FUEL,
+  itemType.MILK,
+  itemType.ORE,
+]
 
 /**
  * @param {farmhand.item} item

--- a/src/utils/isItemAFarmProduct.js
+++ b/src/utils/isItemAFarmProduct.js
@@ -8,6 +8,7 @@ const FARM_PRODUCT_TYPES = [
   itemType.FUEL,
   itemType.MILK,
   itemType.ORE,
+  itemType.STONE,
 ]
 
 /**


### PR DESCRIPTION
### What this PR does

For #460, this PR gives the player one experience point for selling Coal, ores, and stones.

### How this change can be validated

Sell Coal, any ore, and any stone (Stone or Salt Rock items) and observe that you receive 1 experience point each.