### PR TITLE
feat: add total price to Item

### DIFF
--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -82,6 +82,24 @@ const SellValueIndicator = ({
   />
 )
 
+const TotalPrice = ({ quantity, pricePerUnit }) => {
+  if (!quantity || quantity <= 1) return null
+
+  return (
+    <span>
+      {' '}
+      (Total:{' '}
+      <AnimatedNumber
+        {...{
+          number: quantity * pricePerUnit,
+          formatter: moneyString,
+        }}
+      />
+      )
+    </span>
+  )
+}
+
 export const Item = ({
   completedAchievements,
   handleItemPurchaseClick,
@@ -203,6 +221,12 @@ export const Item = ({
                       <AnimatedNumber
                         {...{ number: adjustedValue, formatter: moneyString }}
                       />
+                      <TotalPrice
+                        {...{
+                          quantity: purchaseQuantity,
+                          pricePerUnit: adjustedValue,
+                        }}
+                      />
                     </span>
                   </Tooltip>
                   {completedAchievements['unlock-crop-price-guide'] &&
@@ -231,6 +255,9 @@ export const Item = ({
                       Sell price:{' '}
                       <AnimatedNumber
                         {...{ number: sellPrice, formatter: moneyString }}
+                      />
+                      <TotalPrice
+                        {...{ quantity: sellQuantity, pricePerUnit: sellPrice }}
                       />
                     </span>
                   </Tooltip>


### PR DESCRIPTION
### What this PR does

This PR adds total price next to item price in the Item card when quantity is greater than one.

### How this change can be validated

Go to the store and view the Seeds tab, click the up arrow on a seed card.

In the inventory on the left sidebar, click the up arrow on a card that has the option of selling more than one.

### Questions or concerns about this change

For sell price, I'm not sure what happens if the text content runs into the edge of the card.

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
