### PR TITLE
feat: show age for cows offered for trade (#443)

### DIFF
--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -106,7 +106,7 @@ const Subheader = (
   return (
     <div {...{ className: 'Subheader' }}>
       <Bloodline {...{ colorsInBloodline: cow.colorsInBloodline }} />
-      {isCowPurchased && (
+      {(isCowPurchased || cowIdOfferedForTrade) && (
         <p>
           {cow.daysOld} {cow.daysOld === 1 ? 'day' : 'days'} old
         </p>

--- a/src/components/CowCard/Subheader/Subheader.test.js
+++ b/src/components/CowCard/Subheader/Subheader.test.js
@@ -100,4 +100,34 @@ describe('Subheader', () => {
       expect(value).toBeInTheDocument()
     })
   })
+
+  describe('cow age display', () => {
+    const ageRegex = /days? old/
+    test('displays when purchased', () => {
+      render(<Subheader {...baseProps} isCowPurchased={true} />)
+
+      const age = screen.queryByText(ageRegex)
+      expect(age).not.toBeNull()
+    })
+
+    test('displays when offered as trade', () => {
+      render(
+        <Subheader
+          {...baseProps}
+          cowIdOfferedForTrade="1234"
+          isCowPurchased={false}
+        />
+      )
+
+      const age = screen.queryByText(ageRegex)
+      expect(age).not.toBeNull()
+    })
+
+    test('hidden when unpurchased from shop', () => {
+      render(<Subheader {...baseProps} isCowPurchased={false} />)
+
+      const age = screen.queryByText(ageRegex)
+      expect(age).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
### What this PR does
Closes #443 by displaying age of cows offered for trade

### How this change can be validated
New tests added, one of which fails without this Subheader.js change

### Questions or concerns about this change
Are the tests too much?

### Additional information