### PR TITLE
feat(ui): Improve `QuantityInput` spacing

### DIFF
--- a/src/components/AnimatedNumber/AnimatedNumber.js
+++ b/src/components/AnimatedNumber/AnimatedNumber.js
@@ -1,12 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import { tween } from 'shifty'
-import { func, number } from 'prop-types'
+import { func, number, object } from 'prop-types'
 
+import { Span } from '../Elements'
 import './AnimatedNumber.sass'
 
 const defaultFormatter = number => `${number}`
 
-const AnimatedNumber = ({ number, formatter = defaultFormatter }) => {
+const AnimatedNumber = ({
+  number,
+  animatedNumberSx,
+  formatter = defaultFormatter,
+}) => {
   const [displayedNumber, setDisplayedNumber] = useState(number)
   const [previousNumber, setPreviousNumber] = useState(number)
   const [currentTweenable, setCurrentTweenable] = useState()
@@ -42,12 +47,17 @@ const AnimatedNumber = ({ number, formatter = defaultFormatter }) => {
       }
     }
   }, [currentTweenable, number, previousNumber])
-  return <span className="AnimatedNumber">{formatter(displayedNumber)}</span>
+  return (
+    <Span className="AnimatedNumber" sx={animatedNumberSx}>
+      {formatter(displayedNumber)}
+    </Span>
+  )
 }
 
 AnimatedNumber.propTypes = {
   formatter: func,
   number: number.isRequired,
+  animatedNumberSx: object,
 }
 
 export default AnimatedNumber

--- a/src/components/AnimatedNumber/AnimatedNumber.js
+++ b/src/components/AnimatedNumber/AnimatedNumber.js
@@ -1,17 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { tween } from 'shifty'
-import { func, number, object } from 'prop-types'
+import { func, number } from 'prop-types'
 
-import { Span } from '../Elements'
 import './AnimatedNumber.sass'
 
-const defaultFormatter = number => `${number}`
+const defaultFormatter = (/** @type {number} */ number) => `${number}`
 
-const AnimatedNumber = ({
-  number,
-  animatedNumberSx,
-  formatter = defaultFormatter,
-}) => {
+const AnimatedNumber = ({ number, formatter = defaultFormatter }) => {
   const [displayedNumber, setDisplayedNumber] = useState(number)
   const [previousNumber, setPreviousNumber] = useState(number)
   const [currentTweenable, setCurrentTweenable] = useState()
@@ -47,17 +42,13 @@ const AnimatedNumber = ({
       }
     }
   }, [currentTweenable, number, previousNumber])
-  return (
-    <Span className="AnimatedNumber" sx={animatedNumberSx}>
-      {formatter(displayedNumber)}
-    </Span>
-  )
+
+  return <span className="AnimatedNumber">{formatter(displayedNumber)}</span>
 }
 
 AnimatedNumber.propTypes = {
   formatter: func,
   number: number.isRequired,
-  animatedNumberSx: object,
 }
 
 export default AnimatedNumber

--- a/src/components/Elements/index.js
+++ b/src/components/Elements/index.js
@@ -1,3 +1,8 @@
 import styled from '@mui/material/styles/styled'
 
+// NOTE: Elements in this file are intended to make standard DOM elements easy
+// to style with MUI's sx prop.
+// @see: https://mui.com/system/styled/
+// @see: https://mui.com/system/getting-started/the-sx-prop/
+
 export const Span = styled('span')({})

--- a/src/components/Elements/index.js
+++ b/src/components/Elements/index.js
@@ -1,0 +1,3 @@
+import styled from '@mui/material/styles/styled'
+
+export const Span = styled('span')({})

--- a/src/components/Farmhand/Farmhand.sass
+++ b/src/components/Farmhand/Farmhand.sass
@@ -231,12 +231,11 @@ body
     padding: 16px
 
   .MuiCardActions-root
-    flex-wrap: wrap
 
     button
       margin-bottom: 0.3em
       margin-left: 0.25em
-      margin-right: 0.25em
+      margin-right: 1em
 
   h1,
   h2,

--- a/src/components/Farmhand/Farmhand.sass
+++ b/src/components/Farmhand/Farmhand.sass
@@ -230,13 +230,6 @@ body
     // Overrides an unhelpful MUI default
     padding: 16px
 
-  .MuiCardActions-root
-
-    button
-      margin-bottom: 0.3em
-      margin-left: 0.25em
-      margin-right: 1em
-
   h1,
   h2,
   h3,

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -341,7 +341,7 @@ export const Item = ({
           </>
         )}
         {isSellView && (
-          <Box display="flex" pr={0.5}>
+          <Box display="flex">
             <Button
               {...{
                 className: 'sell',

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp'
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import Button from '@mui/material/Button'
+import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
@@ -340,7 +341,7 @@ export const Item = ({
           </>
         )}
         {isSellView && (
-          <>
+          <Box display="flex" pr={0.5}>
             <Button
               {...{
                 className: 'sell',
@@ -361,7 +362,7 @@ export const Item = ({
                 value: sellQuantity,
               }}
             />
-          </>
+          </Box>
         )}
       </CardActions>
     </Card>

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -6,9 +6,9 @@ import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import NumberFormat from 'react-number-format'
 import TextField from '@mui/material/TextField'
 
-import AnimatedNumber from '../AnimatedNumber'
-
 import { integerString } from '../../utils'
+import AnimatedNumber from '../AnimatedNumber'
+import { Span } from '../Elements'
 
 import './QuantityInput.sass'
 
@@ -63,12 +63,11 @@ const QuantityTextInput = ({
         inputComponent: QuantityNumberFormat,
         endAdornment: (
           <>
-            /{' '}
+            <Span sx={{ px: 1 }}>/</Span>
             <AnimatedNumber
               {...{
                 number: maxQuantity,
                 formatter: integerString,
-                animatedNumberSx: { pl: 1 },
               }}
             />
           </>

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -97,7 +97,11 @@ const QuantityInput = ({
       <span className="quantity">
         /{' '}
         <AnimatedNumber
-          {...{ number: maxQuantity, formatter: integerString }}
+          {...{
+            number: maxQuantity,
+            formatter: integerString,
+            animatedNumberSx: { pl: 1 },
+          }}
         />
       </span>
       <div className="number-nudger-container">

--- a/src/components/QuantityInput/QuantityInput.js
+++ b/src/components/QuantityInput/QuantityInput.js
@@ -61,6 +61,18 @@ const QuantityTextInput = ({
 
       InputProps: {
         inputComponent: QuantityNumberFormat,
+        endAdornment: (
+          <>
+            /{' '}
+            <AnimatedNumber
+              {...{
+                number: maxQuantity,
+                formatter: integerString,
+                animatedNumberSx: { pl: 1 },
+              }}
+            />
+          </>
+        ),
       },
     }}
   />
@@ -94,16 +106,6 @@ const QuantityInput = ({
       <QuantityTextInput
         {...{ handleSubmit, handleUpdateNumber, maxQuantity, value }}
       />
-      <span className="quantity">
-        /{' '}
-        <AnimatedNumber
-          {...{
-            number: maxQuantity,
-            formatter: integerString,
-            animatedNumberSx: { pl: 1 },
-          }}
-        />
-      </span>
       <div className="number-nudger-container">
         <Fab
           disabled={!value}

--- a/src/components/QuantityInput/QuantityInput.sass
+++ b/src/components/QuantityInput/QuantityInput.sass
@@ -8,7 +8,7 @@
       margin-left: 1em
 
   .quantity
-    line-height: 2.8em
+    line-height: 2.3em
 
   .MuiInput-root
     max-width: 75px

--- a/src/components/QuantityInput/QuantityInput.sass
+++ b/src/components/QuantityInput/QuantityInput.sass
@@ -11,12 +11,10 @@
     line-height: 2.3em
 
   .MuiInput-root
-    max-width: 75px
     margin: 1px 0.25em 0
 
     @media (max-width: #{$break-medium-phone})
       margin: 0 0.25em 0 0.5em
-      max-width: 65px
 
     input
       text-align: right
@@ -25,11 +23,11 @@
     display: flex
     flex-direction: column
     position: absolute
-    top: 0
+    top: 0.25em
     right: 0
 
     button
-      margin: 0.25em
+      margin: 0.25em .5em
 
       svg
         // Needed to override

--- a/src/components/QuantityInput/QuantityInput.sass
+++ b/src/components/QuantityInput/QuantityInput.sass
@@ -1,14 +1,6 @@
 @import ../../styles/variables.sass
 
 .QuantityInput
-  // Needed to override the .MuiCardActions-root to work well with the MUI card
-  // action item spacing.
-  .MuiCardActions-root &
-    button
-      margin-left: 1em
-
-  .quantity
-    line-height: 2.3em
 
   .MuiInput-root
     margin: 1px 0.25em 0

--- a/src/mui-theme.js
+++ b/src/mui-theme.js
@@ -21,9 +21,6 @@ export default createTheme({
       styleOverrides: {
         root: {
           margin: '1rem 0',
-          '& input': {
-            padding: '0.5rem',
-          },
         },
       },
     },


### PR DESCRIPTION
### What this PR does

This PR improves a regression that I believe was introduced by #470. It improves the display of the `QuantityInput` component.

### How this change can be validated

Ensure that quantity input looks and works correctly throughout the game.

### Additional information

Before:

![Screenshot of before change](https://github.com/jeremyckahn/farmhand/assets/366330/8a56b5bd-9e4a-464c-9d9e-c774c888cd59)

After:

![Screenshot of after change](https://github.com/jeremyckahn/farmhand/assets/366330/6bbada63-ebc5-4ff5-a6db-12863ed94ab3)
