### PR TITLE
feat(sprinklers): Increase Sprinkler range at level 25

### DIFF
--- a/src/data/levels.js
+++ b/src/data/levels.js
@@ -69,6 +69,10 @@ levels[24] = {
   unlocksShopItem: items.asparagusSeed.id,
 }
 
+levels[25] = {
+  increasesSprinklerRange: true,
+}
+
 levels[26] = {
   unlocksShopItem: items.jalapenoSeed.id,
 }


### PR DESCRIPTION
### What this PR does

This PR increases the Sprinkler range to 4 at level 25 (previous max was 3).

### How this change can be validated

- [ ] Reach level 25 and verify that Sprinklers cover all plots that are 4 spaces out from them.

### Additional information

![Sprinkler range of 4 screenshot](https://github.com/jeremyckahn/farmhand/assets/366330/fd04d706-619a-4372-af6d-7f79eecd7d4c)

