### PR TITLE
feat(multiplayer): Optimize API usage

### DIFF
--- a/api-etc/constants.js
+++ b/api-etc/constants.js
@@ -7,5 +7,3 @@ export const ACCEPTED_ORIGINS = new Set([
   'https://www.farmhand.life',
   'https://v6p9d9t4.ssl.hwcdn.net', // itch.io's CDN that the game is served from
 ])
-
-export const MAX_ROOM_SIZE = 25

--- a/api/get-market-data.js
+++ b/api/get-market-data.js
@@ -5,8 +5,6 @@ const { promisify } = require('util')
 
 require('redis')
 require('../src/common/utils')
-const { SERVER_ERRORS } = require('../src/common/constants')
-const { MAX_ROOM_SIZE } = require('../api-etc/constants')
 // End explicit requires for serverless builds
 
 const {
@@ -15,7 +13,6 @@ const {
   getRoomData,
   getRoomName,
 } = require('../api-etc/utils')
-const { HEARTBEAT_INTERVAL_PERIOD } = require('../src/common/constants')
 
 const client = getRedisClient()
 
@@ -23,47 +20,15 @@ const get = promisify(client.get).bind(client)
 const set = promisify(client.set).bind(client)
 
 module.exports = allowCors(async (req, res) => {
-  const { farmId = null } = req.query
   const roomKey = getRoomName(req)
 
   const roomData = await getRoomData(roomKey, get, set)
-  const { activePlayers, valueAdjustments } = roomData
+  const { valueAdjustments } = roomData
 
-  const now = Date.now()
-
-  if (farmId) {
-    activePlayers[farmId] = now
-  }
-
-  let numberOfActivePlayers = 0
-
-  const activePlayerIds = Object.keys(activePlayers)
-
-  // Multiply HEARTBEAT_INTERVAL_PERIOD by some amount to account for network
-  // latency and other transient heartbeat delays
-  const evictionTimeout = HEARTBEAT_INTERVAL_PERIOD * 2.5
-
-  // Clean up stale activePlayers data
-  activePlayerIds.forEach(activePlayerId => {
-    const timestamp = activePlayers[activePlayerId]
-    const delta = now - timestamp
-
-    if (delta > evictionTimeout) {
-      delete activePlayers[activePlayerId]
-    } else {
-      numberOfActivePlayers++
-    }
-  })
-
-  // Note: Eviction logic (above) must happen before potentially bailing out
-  // here to ensure that rooms can drain appropriately.
-  if (farmId && numberOfActivePlayers > MAX_ROOM_SIZE) {
-    return res.status(403).json({ errorCode: SERVER_ERRORS.ROOM_FULL })
-  }
-
-  set(roomKey, JSON.stringify({ ...roomData, activePlayers }))
+  set(roomKey, JSON.stringify(roomData))
 
   res
     .status(200)
-    .json({ activePlayers: numberOfActivePlayers, valueAdjustments })
+    // TODO: activePlayers: 1 is for legacy backwards compatibility. Remove it after 10/1/2024.
+    .json({ valueAdjustments, activePlayers: 1 })
 })

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,7 +1,3 @@
 export const MAX_ROOM_NAME_LENGTH = 25
 
 export const HEARTBEAT_INTERVAL_PERIOD = 10 * 1000 // 10 seconds
-
-export const SERVER_ERRORS = {
-  ROOM_FULL: 'ROOM_FULL',
-}

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,3 +1,1 @@
 export const MAX_ROOM_NAME_LENGTH = 25
-
-export const HEARTBEAT_INTERVAL_PERIOD = 10 * 1000 // 10 seconds

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -678,7 +678,7 @@ export default class Farmhand extends FarmhandReducers {
       }))
     }
 
-    if (newIsOnline !== prevState.isOnline || room !== prevState.room) {
+    if (isOnline !== prevState.isOnline || room !== prevState.room) {
       this.syncToRoom()
 
       if (!isOnline && typeof heartbeatTimeoutId === 'number') {

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -90,13 +90,13 @@ import {
 import {
   COW_TRADE_TIMEOUT,
   DEFAULT_ROOM,
+  HEARTBEAT_INTERVAL_PERIOD,
   INITIAL_STORAGE_LIMIT,
   STAGE_TITLE_MAP,
   STANDARD_LOAN_AMOUNT,
   Z_INDEX,
   STANDARD_VIEW_LIST,
 } from '../../constants'
-import { HEARTBEAT_INTERVAL_PERIOD } from '../../common/constants'
 import {
   CONNECTED_TO_ROOM,
   LOAN_INCREASED,
@@ -947,6 +947,7 @@ export default class Farmhand extends FarmhandReducers {
 
       console.error(e)
 
+      // NOTE: Syncing failed, so take the user offline
       this.setState(() => {
         return {
           redirect: '/',
@@ -1075,6 +1076,7 @@ export default class Farmhand extends FarmhandReducers {
           severity: 'error',
         })
 
+        // NOTE: Takes the user offline
         this.setState({
           redirect: '/',
           cowIdOfferedForTrade: '',

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -668,6 +668,7 @@ export default class Farmhand extends FarmhandReducers {
 
     const decodedRoom = decodeURIComponent(newRoom)
 
+    // NOTE: This indicates that the client should attempt to connect to the server
     const newIsOnline = path.startsWith('/online')
 
     if (newIsOnline !== this.state.isOnline || decodedRoom !== room) {
@@ -679,7 +680,9 @@ export default class Farmhand extends FarmhandReducers {
     }
 
     if (isOnline !== prevState.isOnline || room !== prevState.room) {
-      this.syncToRoom()
+      if (newIsOnline) {
+        this.syncToRoom()
+      }
 
       if (!isOnline && typeof heartbeatTimeoutId === 'number') {
         clearTimeout(heartbeatTimeoutId)

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -1053,6 +1053,11 @@ export default class Farmhand extends FarmhandReducers {
           inventory
         )
 
+        const { valueAdjustments } = await postData(endpoints.postDayResults, {
+          positions,
+          room,
+        })
+
         if (Object.keys(positions).length) {
           serverMessages.push({
             message: POSITIONS_POSTED_NOTIFICATION`${'You'}${positions}`,
@@ -1061,11 +1066,6 @@ export default class Farmhand extends FarmhandReducers {
 
           broadcastedPositionMessage = POSITIONS_POSTED_NOTIFICATION`${''}${positions}`
         }
-
-        const { valueAdjustments } = await postData(endpoints.postDayResults, {
-          positions,
-          room,
-        })
 
         nextDayState.valueAdjustments = applyPriceEvents(
           valueAdjustments,

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -939,15 +939,20 @@ export default class Farmhand extends FarmhandReducers {
 
       this.showNotification(CONNECTED_TO_ROOM`${room}`, 'success')
     } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unexpected error'
-
       // TODO: Add some reasonable fallback behavior in case the server request
       // fails. Possibility: Regenerate valueAdjustments and notify the user
       // they are offline.
 
-      this.showNotification(`Server error: ${message}`, 'error')
+      this.showNotification(SERVER_ERROR, 'error')
 
       console.error(e)
+
+      this.setState(() => {
+        return {
+          redirect: '/',
+          cowIdOfferedForTrade: '',
+        }
+      })
     }
 
     this.setState({
@@ -1064,9 +1069,15 @@ export default class Farmhand extends FarmhandReducers {
           nextDayState.priceSurges
         )
       } catch (e) {
+        // NOTE: This will get reached when there's an issue posting data to the server.
         serverMessages.push({
           message: SERVER_ERROR,
           severity: 'error',
+        })
+
+        this.setState({
+          redirect: '/',
+          cowIdOfferedForTrade: '',
         })
 
         console.error(e)

--- a/src/components/Farmhand/Farmhand.js
+++ b/src/components/Farmhand/Farmhand.js
@@ -678,7 +678,7 @@ export default class Farmhand extends FarmhandReducers {
       }))
     }
 
-    if (isOnline !== prevState.isOnline || room !== prevState.room) {
+    if (newIsOnline !== prevState.isOnline || room !== prevState.room) {
       this.syncToRoom()
 
       if (!isOnline && typeof heartbeatTimeoutId === 'number') {

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -154,7 +154,7 @@ const OnlineControls = ({
               variant: 'contained',
             }}
           >
-            Active players: {integerString(activePlayers)}
+            Connected players: {integerString(activePlayers)}
           </Button>
           {isChatAvailable ? (
             <Button

--- a/src/components/OnlinePeersView/OnlinePeersView.js
+++ b/src/components/OnlinePeersView/OnlinePeersView.js
@@ -38,7 +38,9 @@ const OnlinePeersView = ({
 
   return (
     <div {...{ className: 'OnlinePeersView' }}>
-      {activePlayers - 1 > populatedPeers.length && <p>Waiting for peers...</p>}
+      {activePlayers - 1 > populatedPeers.length && (
+        <p>Getting player information...</p>
+      )}
       <h3>Your player name</h3>
       <Card>
         <CardContent>

--- a/src/constants.js
+++ b/src/constants.js
@@ -314,3 +314,5 @@ export const STANDARD_VIEW_LIST = [stageFocusType.SHOP, stageFocusType.FIELD]
 export const Z_INDEX = {
   END_DAY_BUTTON: 1100,
 }
+
+export const HEARTBEAT_INTERVAL_PERIOD = 10 * 1000 // 10 seconds

--- a/src/game-logic/reducers/addPeer.js
+++ b/src/game-logic/reducers/addPeer.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../../components/Farmhand/Farmhand').farmhand.state} farmhand.state
+ */
+
 // TODO: Add tests for this reducer
 /**
  * @param {farmhand.state} state
@@ -8,5 +12,5 @@ export const addPeer = (state, peerId) => {
   const peers = { ...state.peers }
   peers[peerId] = null
 
-  return { ...state, peers }
+  return { ...state, peers, activePlayers: (state.activePlayers ?? 1) + 1 }
 }

--- a/src/game-logic/reducers/removePeer.js
+++ b/src/game-logic/reducers/removePeer.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../../components/Farmhand/Farmhand').farmhand.state} farmhand.state
+ */
+
 // TODO: Add tests for this reducer
 /**
  * @param {farmhand.state} state
@@ -8,5 +12,5 @@ export const removePeer = (state, peerId) => {
   const peers = { ...state.peers }
   delete peers[peerId]
 
-  return { ...state, peers }
+  return { ...state, peers, activePlayers: (state.activePlayers ?? 1) - 1 }
 }

--- a/src/strings.js
+++ b/src/strings.js
@@ -14,7 +14,7 @@ export const INVALID_DATA_PROVIDED = 'Invalid Farmhand data provided.'
 export const UPDATE_AVAILABLE =
   "A game update is available! Click this message to reload and see what's new."
 export const SERVER_ERROR =
-  "There was an issue communicating with the server. You can keep playing offline, and you'll be reconnected as soon as things improve."
+  'There was an issue connecting to the server. Please try again in a moment.'
 export const CONNECTING_TO_SERVER = 'Connecting...'
 export const DISCONNECTING_FROM_SERVER = 'Disconnecting...'
 export const DISCONNECTED_FROM_SERVER = 'You are now playing offline.'


### PR DESCRIPTION
### What this PR does

This PR optimizes multiplayer API usage by eliminating polling. Rather than using the Vercel-based central API to determine room occupancy, the number of connected peers is used.

### How this change can be validated

:bangbang: Please **DO NOT** test this in the default `global` room, as that affects Production data. Instead, use another room such as `global-test`.

- [ ] Ensure that peers can connect to each other
- [ ] Ensure that the disconnection of peer A is (eventually) accurately reflected in peer B
- [ ] Ensure that there are no noticeable regressions with online play (note: cow trading should be unaffected by this change)

### Additional information

This change is needed because Farmhand is getting so much multiplayer activity that we're exceeding the capacity of the free Vercel tier that is powering it.