### PR TITLE
fix(forest): Keep Forest unlock notification behind feature flag

### DIFF
--- a/src/components/Navigation/DayAndProgressContainer.js
+++ b/src/components/Navigation/DayAndProgressContainer.js
@@ -13,6 +13,7 @@ import {
   integerString,
   scaleNumber,
 } from '../../utils'
+import { EXPERIENCE_GAUGE_TOOLTIP_LABEL } from '../../templates'
 
 export function DayAndProgressContainer({ dayCount, experience, itemsSold }) {
   const currentLevel = levelAchieved(experience)
@@ -25,11 +26,9 @@ export function DayAndProgressContainer({ dayCount, experience, itemsSold }) {
     100
   )
 
-  const tooltipText = `${integerString(
+  const experiencePointsToNextLevel =
     experienceNeededForLevel(currentLevel + 1) - experience
-  )} more experience points needed to reach level ${integerString(
-    currentLevel + 1
-  )}`
+  const nextLevel = currentLevel + 1
 
   return (
     <h2 className="day-and-progress-container">
@@ -38,7 +37,7 @@ export function DayAndProgressContainer({ dayCount, experience, itemsSold }) {
         {...{
           arrow: true,
           placement: 'top',
-          title: tooltipText,
+          title: EXPERIENCE_GAUGE_TOOLTIP_LABEL`${experiencePointsToNextLevel}${nextLevel}`,
         }}
       >
         <Box>

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,12 @@ export const endpoints = {
 // them via URL query parameters. This can be done by constructing a query
 // parameter that looks like:
 //
-//   ?enable_MINING=true
+//   ?enable_FOREST=true
+/**
+ * @type {{
+ *   FOREST?: boolean
+ * }}
+ */
 export const features = Object.keys(process.env).reduce((acc, key) => {
   const matches = key.match(/REACT_APP_ENABLE_(.*)/)
 

--- a/src/data/levels.js
+++ b/src/data/levels.js
@@ -1,4 +1,5 @@
 import { stageFocusType, toolType } from '../enums'
+import { features } from '../config'
 
 import * as items from './items'
 import * as recipes from './recipes'
@@ -45,8 +46,10 @@ levels[14] = {
   unlocksShopItem: items.potatoSeed.id,
 }
 
-levels[15] = {
-  unlocksStageFocusType: stageFocusType.FOREST,
+if (features.FOREST) {
+  levels[15] = {
+    unlocksStageFocusType: stageFocusType.FOREST,
+  }
 }
 
 levels[16] = {

--- a/src/templates.js
+++ b/src/templates.js
@@ -380,3 +380,25 @@ export const NEW_COW_OFFERED_FOR_TRADE = (_, peerMetadata) =>
  */
 export const FOREST_EXPANDED = (_, numTrees) =>
   `The Forest has expanded! You can now plant up to ${numTrees} trees.`
+
+/**
+ * @param {TemplatesStringsArray} _
+ * @param {number} experiencePointsToNextLevel
+ * @param {number} nextLevel
+ * @returns {string}
+ */
+export const EXPERIENCE_GAUGE_TOOLTIP_LABEL = (
+  _,
+  experiencePointsToNextLevel,
+  nextLevel
+) => {
+  if (experiencePointsToNextLevel === 1) {
+    return `Just 1 more experience point needed to reach level ${integerString(
+      nextLevel
+    )}!`
+  }
+
+  return `${integerString(
+    experiencePointsToNextLevel
+  )} more experience points needed to reach level ${integerString(nextLevel)}`
+}


### PR DESCRIPTION
### What this PR does

This PR fixes [an issue that was discovered by a player](https://discord.com/channels/714539345050075176/714539345637408793/1251318040122101903): The Forest unlock notification was being shown in Production. This feature is still in development, so this notification should be withheld by a feature flag.

This PR also improves the experience gauge tooltip by showing an alternate label when there is one point left to reach the next level.

### How this change can be validated

You can use [this test save](https://gist.github.com/jeremyckahn/0d3fd8c49a8ce41d036974496e354c93) to aid in validation.

- [ ] With the `FOREST` feature flag disabled (default behavior for preview deployment), verify that the forest unlock notification **does not** appear when the player reaches level 15
  - In the test save linked above, this can be done by selling the Carrot that is in the inventory
- [ ] With the `FOREST` feature flag enabled (add `?enable_FOREST=1` to the preview deployment URL), verify that the forest unlock notification **does** appear when the player reaches level 15

----------

- [ ] When there is **one** experience point left to reach the next level, verify that the experience gauge tooltip reads `Just 1 more experience point needed to reach level XX!`
- [ ] When there is **more than one** experience point needed to reach the next level, verify that the experience gauge tooltip reads `XX more experience points needed to reach level YY`