### PR TITLE
feat(#505): Re-balance upgrade costs

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -44,8 +44,8 @@ export const INITIAL_FIELD_HEIGHT = 10
 export const PURCHASEABLE_FIELD_SIZES = freeze(
   new Map([
     [1, { columns: 8, rows: 12, price: 1_000 }],
-    [2, { columns: 10, rows: 16, price: 2_000 }],
-    [3, { columns: 12, rows: 18, price: 3_000 }],
+    [2, { columns: 10, rows: 16, price: 5_000 }],
+    [3, { columns: 12, rows: 18, price: 20_000 }],
   ])
 )
 
@@ -68,7 +68,7 @@ export const LARGEST_PURCHASABLE_FIELD_SIZE = /** @type {farmhand.purchaseableFi
 ))
 
 export const PURCHASEABLE_COMBINES = freeze(
-  new Map([[1, { type: 'Basic', price: 500_000 }]])
+  new Map([[1, { type: 'Basic', price: 250_000 }]])
 )
 
 export const PURCHASEABLE_COMPOSTERS = freeze(
@@ -76,22 +76,22 @@ export const PURCHASEABLE_COMPOSTERS = freeze(
 )
 
 export const PURCHASEABLE_SMELTERS = freeze(
-  new Map([[1, { type: 'Basic', price: 500_000 }]])
+  new Map([[1, { type: 'Basic', price: 250_000 }]])
 )
 
 export const PURCHASEABLE_COW_PENS = freeze(
   new Map([
-    [1, { cows: 10, price: 1500 }],
-    [2, { cows: 20, price: 2500 }],
-    [3, { cows: 30, price: 3500 }],
+    [1, { cows: 10, price: 1_500 }],
+    [2, { cows: 20, price: 10_000 }],
+    [3, { cows: 30, price: 50_000 }],
   ])
 )
 
 export const PURCHASEABLE_CELLARS = freeze(
   new Map([
     [1, { space: 10, price: 250_000 }],
-    [2, { space: 20, price: 400_000 }],
-    [3, { space: 30, price: 500_000 }],
+    [2, { space: 20, price: 750_000 }],
+    [3, { space: 30, price: 2_000_000 }],
   ])
 )
 

--- a/src/game-logic/reducers/purchaseCombine.test.js
+++ b/src/game-logic/reducers/purchaseCombine.test.js
@@ -14,7 +14,10 @@ describe('purchaseCombine', () => {
   })
 
   test('deducts money', () => {
-    const { money } = purchaseCombine({ money: 500000 }, 1)
-    expect(money).toEqual(PURCHASEABLE_COMBINES.get(1).price - 500000)
+    const { money } = purchaseCombine(
+      { money: (PURCHASEABLE_COMBINES.get(1)?.price ?? 0) + 10 },
+      1
+    )
+    expect(money).toEqual(10)
   })
 })


### PR DESCRIPTION
### What this PR does

Per feedback from [M8theone on Discord](https://discord.com/channels/714539345050075176/722286738344640552/1273256123486703718), this PR modifies the costs of various upgrades:

- Increase second and third Field upgrade costs (to $5,000 and $20,000)
- Increase second and third Cow Pen upgrade costs (to $10,000 and $50,000)
- Decrease Combine Harvester cost to $250,000
- Decrease Smelter cost to $250,000
- Increase second and third Cellar upgrades (to $750,000 and $2,000,000)

### How this change can be validated

Verify that the costs of relevant upgrades matches what's listed above.

### Additional information

I'll wait to get feedback from M8theone about this change before moving it along.