### PR TITLE
#522 adding media query to hide spacer at certain breakpoint 

### DIFF
--- a/src/components/Farmhand/Farmhand.sass
+++ b/src/components/Farmhand/Farmhand.sass
@@ -260,6 +260,8 @@ body
   // interacting with the elements within them.
   .spacer
     min-height: 7.5em
+    @media (min-width: #{$break-md})
+      display: none
 
   .danger-text
     color: $error-color


### PR DESCRIPTION
Simple change that hides the spacer in the manu above medium window width breakpoint.


