### PR TITLE
Fix missing space between hugging machine and and

### DIFF
--- a/src/components/CowCard/Subheader/Subheader.js
+++ b/src/components/CowCard/Subheader/Subheader.js
@@ -150,7 +150,7 @@ const Subheader = (
               placement: 'top',
               title: (
                 <Typography>
-                  Check this box to put {cow.name} into a {huggingMachine.name}
+                  Check this box to put {cow.name} into a {huggingMachine.name}{' '}
                   and automatically hug them at the start of every day. Requires
                   a Hugging Machine in your inventory.
                 </Typography>


### PR DESCRIPTION
### What this PR does

Fixes this typo 
![image](https://github.com/user-attachments/assets/b9fbdf8b-6e36-41b4-ba59-0e07d2d1e996)
