### PR TITLE
fix(package): Include `dist` directory when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "files": [
     "src",
-    "build",
+    "dist",
     "public"
   ],
   "craGenerate": {


### PR DESCRIPTION
### What this PR does

This PR fixes a regression introduced by #510 wherein build artifacts are not included in `npm publish`.

This, along with https://github.com/jeremyckahn/farmhand/commit/77630bf6b822f1d12a48b503c4386e17f76a8b70, should make historical versions of Farmhand hosted by UNPKG work again.

### How this change can be validated

Merge, release, and see if https://unpkg.com/browse/@jeremyckahn/farmhand/build/ serves anything.