### PR TITLE
chore(deps): [closes #531] Swap `typeface-*` packages for `@fontsource/*`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@fontsource/francois-one": "^5.1.0",
+        "@fontsource/public-sans": "^5.1.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",
         "@fortawesome/free-regular-svg-icons": "^5.12.1",
         "@fortawesome/free-solid-svg-icons": "^5.12.1",
@@ -60,8 +62,6 @@
         "shifty": "^3.0.1",
         "stream": "npm:stream-browserify@^3.0.0",
         "trystero": "^0.20.0",
-        "typeface-francois-one": "0.0.71",
-        "typeface-public-sans": "^1.1.4",
         "url": "^0.11.0",
         "usehooks-ts": "^3.1.0",
         "uuid": "^3.4.0",
@@ -3710,6 +3710,16 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
       "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+    },
+    "node_modules/@fontsource/francois-one": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/francois-one/-/francois-one-5.1.0.tgz",
+      "integrity": "sha512-PjvH1BMrNnQwROu3Et11oVJel4ALoffGOsznKLFm5fW29QDwEXEounyRUI2VTtet8wh3xoavERWQmQFetS/E1w=="
+    },
+    "node_modules/@fontsource/public-sans": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/public-sans/-/public-sans-5.1.1.tgz",
+      "integrity": "sha512-BEJEc9kpLBowHLqeOlex1lMJPZ/6mzKn3ArhbvWY9dvMcjSqH7jzJyTN44j0H78FTOrVjIW1g4A8nDdbx8VV5Q=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
@@ -30253,17 +30263,6 @@
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
       "integrity": "sha512-vjMKrfSoUDN8/Vnqitw2FmstOfuJ73G6CrSEKnf11A6RmasVxHqfeBcnTb6RsL4pTMuV5Zsv9IiHRphMZyckUw=="
     },
-    "node_modules/typeface-francois-one": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/typeface-francois-one/-/typeface-francois-one-0.0.71.tgz",
-      "integrity": "sha512-l9BjLtsxsAmwJHn1JZ6cshiMMt9EWXZ6lz2lc5NOOQ0DnsKmTV2KnV69d4PcKfsl75KDGobk/DufwinIx/1z2Q=="
-    },
-    "node_modules/typeface-public-sans": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-public-sans/-/typeface-public-sans-1.1.13.tgz",
-      "integrity": "sha512-cBrpPUvIeaYIacxtxPeCpKM7vAJb27+8E9HAT7R3ZA2zrj9ntm630tpSgBCn/Ip6D11pWSmKVR4eZ8Pr1Yxnog==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
-    },
     "node_modules/typescript": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
@@ -35697,6 +35696,16 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
       "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+    },
+    "@fontsource/francois-one": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/francois-one/-/francois-one-5.1.0.tgz",
+      "integrity": "sha512-PjvH1BMrNnQwROu3Et11oVJel4ALoffGOsznKLFm5fW29QDwEXEounyRUI2VTtet8wh3xoavERWQmQFetS/E1w=="
+    },
+    "@fontsource/public-sans": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/public-sans/-/public-sans-5.1.1.tgz",
+      "integrity": "sha512-BEJEc9kpLBowHLqeOlex1lMJPZ/6mzKn3ArhbvWY9dvMcjSqH7jzJyTN44j0H78FTOrVjIW1g4A8nDdbx8VV5Q=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
@@ -55755,16 +55764,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
       "integrity": "sha512-vjMKrfSoUDN8/Vnqitw2FmstOfuJ73G6CrSEKnf11A6RmasVxHqfeBcnTb6RsL4pTMuV5Zsv9IiHRphMZyckUw=="
-    },
-    "typeface-francois-one": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/typeface-francois-one/-/typeface-francois-one-0.0.71.tgz",
-      "integrity": "sha512-l9BjLtsxsAmwJHn1JZ6cshiMMt9EWXZ6lz2lc5NOOQ0DnsKmTV2KnV69d4PcKfsl75KDGobk/DufwinIx/1z2Q=="
-    },
-    "typeface-public-sans": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-public-sans/-/typeface-public-sans-1.1.13.tgz",
-      "integrity": "sha512-cBrpPUvIeaYIacxtxPeCpKM7vAJb27+8E9HAT7R3ZA2zrj9ntm630tpSgBCn/Ip6D11pWSmKVR4eZ8Pr1Yxnog=="
     },
     "typescript": {
       "version": "5.5.4",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@fontsource/francois-one": "^5.1.0",
+    "@fontsource/public-sans": "^5.1.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/free-regular-svg-icons": "^5.12.1",
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
@@ -144,8 +146,6 @@
     "shifty": "^3.0.1",
     "stream": "npm:stream-browserify@^3.0.0",
     "trystero": "^0.20.0",
-    "typeface-francois-one": "0.0.71",
-    "typeface-public-sans": "^1.1.4",
     "url": "^0.11.0",
     "usehooks-ts": "^3.1.0",
     "uuid": "^3.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@ import { HashRouter as Router, Route } from 'react-router-dom'
 import './index.sass'
 import Farmhand from './components/Farmhand/index.js'
 import { features } from './config.js'
-import 'typeface-francois-one'
-import 'typeface-public-sans'
+import '@fontsource/francois-one'
+import '@fontsource/public-sans'
 
 // eslint-disable-next-line no-unused-vars
 import { cropFamily, grapeVariety } from './enums.js'


### PR DESCRIPTION
### What this PR does

For #531, this PR updates Farmhand to use actively-maintained font packages.

### How this change can be validated

- [x] Validate that the fonts look correct (unchanged)