### PR TITLE
fix(closes #546): Detect and fix corrupt cowBreedingPen state

### DIFF
--- a/src/game-logic/reducers/changeCowBreedingPenResident.js
+++ b/src/game-logic/reducers/changeCowBreedingPenResident.js
@@ -1,3 +1,7 @@
+/** @typedef {import("../../index.js").farmhand.cow} farmhand.cow */
+/** @typedef {import("../../index.js").farmhand.cowBreedingPen} farmhand.cowBreedingPen */
+/** @typedef {import("../../index.js").farmhand.state} farmhand.state */
+
 import { COW_GESTATION_PERIOD_DAYS } from '../../constants.js'
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1007,17 +1007,20 @@ export const transformStateDataForImport = state => {
       {}
     )
 
-    ;[cowId1, cowId2].forEach(cowId => {
-      // If either cow is referenced in cowBreedingPen but not cowInventory,
-      // reset cowBreedingPen state
-      if (cowId && !(cowId in cowPenIdMap)) {
-        sanitizedState.cowBreedingPen = {
-          cowId1: null,
-          cowId2: null,
-          daysUntilBirth: -1,
-        }
+    const isCowInBreedingPenMissingFromInventory = [cowId1, cowId2].some(
+      cowId => {
+        return cowId && !(cowId in cowPenIdMap)
       }
-    })
+    )
+
+    if (isCowInBreedingPenMissingFromInventory) {
+      // Resets cowBreedingPen state
+      sanitizedState.cowBreedingPen = {
+        cowId1: null,
+        cowId2: null,
+        daysUntilBirth: -1,
+      }
+    }
   }
 
   return sanitizedState

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,37 +17,14 @@
 
 import { Buffer } from 'buffer'
 
-import Dinero from 'dinero.js'
 import configureJimp from '@jimp/custom'
 import jimpPng from '@jimp/png'
+import Dinero from 'dinero.js'
+import { funAnimalName } from 'fun-animal-names'
 import sortBy from 'lodash.sortby'
 import { v4 as uuid } from 'uuid'
-import { funAnimalName } from 'fun-animal-names'
 
-import cowShopInventory from '../data/shop-inventory-cow.js'
-import shopInventory from '../data/shop-inventory.js'
-import fruitNames from '../data/fruit-names.js'
-import { cropItemIdToSeedItemMap, itemsMap } from '../data/maps.js'
-import {
-  chocolateMilk,
-  milk1,
-  milk2,
-  milk3,
-  rainbowMilk1,
-  rainbowMilk2,
-  rainbowMilk3,
-} from '../data/items.js'
-import { unlockableItems } from '../data/levels.js'
-import { items as itemImages, animals, pixel } from '../img/index.js'
-import {
-  cowColors,
-  cropLifeStage,
-  fertilizerType,
-  genders,
-  itemType,
-  stageFocusType,
-  standardCowColors,
-} from '../enums.js'
+import { random } from '../common/utils.js'
 import {
   BREAKPOINTS,
   COW_COLORS_HEX_MAP,
@@ -77,13 +54,36 @@ import {
   PERSISTED_STATE_KEYS,
   PRECIPITATION_CHANCE,
   PRICE_EVENT_STANDARD_DURATION_DECREASE,
+  STANDARD_VIEW_LIST,
   STORAGE_EXPANSION_AMOUNT,
   STORAGE_EXPANSION_BASE_PRICE,
-  STORM_CHANCE,
   STORAGE_EXPANSION_SCALE_PREMIUM,
-  STANDARD_VIEW_LIST,
+  STORM_CHANCE,
 } from '../constants.js'
-import { random } from '../common/utils.js'
+import fruitNames from '../data/fruit-names.js'
+import {
+  chocolateMilk,
+  milk1,
+  milk2,
+  milk3,
+  rainbowMilk1,
+  rainbowMilk2,
+  rainbowMilk3,
+} from '../data/items.js'
+import { unlockableItems } from '../data/levels.js'
+import { cropItemIdToSeedItemMap, itemsMap } from '../data/maps.js'
+import cowShopInventory from '../data/shop-inventory-cow.js'
+import shopInventory from '../data/shop-inventory.js'
+import {
+  cowColors,
+  cropLifeStage,
+  fertilizerType,
+  genders,
+  itemType,
+  stageFocusType,
+  standardCowColors,
+} from '../enums.js'
+import { animals, items as itemImages, pixel } from '../img/index.js'
 
 import { farmProductsSold } from './farmProductsSold.js'
 import { getCropLifecycleDuration } from './getCropLifecycleDuration.js'
@@ -984,6 +984,40 @@ export const transformStateDataForImport = state => {
     sanitizedState.stageFocus === stageFocusType.HOME
   ) {
     sanitizedState = { ...sanitizedState, stageFocus: STANDARD_VIEW_LIST[0] }
+  }
+
+  // NOTE: This is a mitigation for
+  // https://github.com/jeremyckahn/farmhand/issues/546. There's no expected
+  // scenario where a cow would be present in cowBreedingPen but not
+  // cowInventory, but at least one player's game somehow got into that state.
+  // This block detects such an invalid state and corrects it.
+  {
+    const { cowId1, cowId2 } = sanitizedState.cowBreedingPen
+
+    const cowPenIdMap = sanitizedState.cowInventory.reduce(
+      /**
+       * @param acc {Record<string, farmhand.cow>}
+       * @param cow {farmhand.cow}
+       */
+      (acc, cow) => {
+        acc[cow.id] = cow
+
+        return acc
+      },
+      {}
+    )
+
+    ;[cowId1, cowId2].forEach(cowId => {
+      // If either cow is referenced in cowBreedingPen but not cowInventory,
+      // reset cowBreedingPen state
+      if (cowId && !(cowId in cowPenIdMap)) {
+        sanitizedState.cowBreedingPen = {
+          cowId1: null,
+          cowId2: null,
+          daysUntilBirth: -1,
+        }
+      }
+    })
   }
 
   return sanitizedState

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1086,8 +1086,6 @@ describe('transformStateDataForImport', () => {
   ])(
     'fixes corrupt cowBreedingPen if needed',
     ({ cowBreedingPen, cowInventory, expectedCowBreedingPen }) => {
-      state.cowBreedingPen = cowBreedingPen
-      state.cowInventory = cowInventory
       Object.assign(state, { cowBreedingPen, cowInventory })
 
       const sanitizedState = transformStateDataForImport(state)


### PR DESCRIPTION
### What this PR does

This is a speculative mitigation for #546. If a corrupt `cowBreedingPen` state is detected when loading a save file, it is automatically fixed.

### How this change can be validated

This fixes an error state that has no known steps to reproduce, so all we can really do is verify that the tests pass and that there are no regressions.

- [ ] Verify that cow breeding pen state works as expected across days (i.e. cows are not unexpectedly removed from the breeding pen when ending the day)

### Questions or concerns about this change

This may not be strictly needed as #547 is intended to fix the root cause of #546. However, since the issue could not be reproduced, #547 cannot be verified to effectively solve the problem. This PR is more of a fallback solution to enable users to fix their game state by reloading the page.