### PR TITLE
chore(playwright): Enable easier local end-to-end testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,40 +119,26 @@ It would be a good idea to perform a smoke test whenever there is a significant 
 
 ### End-to-end (E2E) testing
 
-E2E tests are performed in a GitHub Actions job called `e2e` under [the CI workflow](https://github.com/jeremyckahn/farmhand/actions/workflows/ci.yml) upon push to GitHub. You can run the E2E tests locally with the following additional tools installed and set up in your environment:
+Farmhand uses [Playwright](https://playwright.dev/) for end-to-end testing. E2E tests are performed in a GitHub Actions job called `e2e` under [the CI workflow](https://github.com/jeremyckahn/farmhand/actions/workflows/ci.yml) upon push to GitHub.
 
-- [Docker](https://docs.docker.com/engine/install/)
-- [GitHub CLI](https://cli.github.com/)
-  - You MUST [be authenticated](https://cli.github.com/manual/gh_auth_login)
-- [nektos/act](https://github.com/nektos/act)
-  - This MUST [be installed as a GitHub CLI extension](https://nektosact.com/installation/gh.html)
-- [jq](https://jqlang.org/download/)
+#### Quick Setup Guide
 
-Additionally, you MUST have a Vercel account and be logged into it locally. You can do that with:
+For detailed instructions on running E2E tests locally, including setup, available commands, and troubleshooting, please see the [`e2e/README.md`](e2e/README.md) file.
+
+**Quick start:**
 
 ```sh
-npx vercel login
-```
+# Navigate to the e2e directory
+cd e2e
 
-Once that's all set up, you can run the E2E tests with:
+# Run automated setup (first time only)
+npm run setup
 
-```sh
-npm run e2e
-```
+# Start the dev server (from project root)
+cd .. && npm run dev
 
-Note that running tests locally involves downloading Docker images to your system. These images can accrue and take up space over time, but you can clear them out with:
-
-```sh
-npm run e2e:cleanup
-```
-
-#### Authoring new E2E tests
-
-Run this script to launch the [Playwright codegen tools](https://playwright.dev/docs/codegen-intro):
-
-```sh
-# Assumes you already have `npm run dev` running
-npm run e2e:create
+# Run tests (from e2e directory)
+cd e2e && npm run test
 ```
 
 ### Releasing updates

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,53 @@
+# Test results
+test-results/
+test-results-*/
+reports/
+playwright-report/
+playwright/.cache/
+
+# Screenshots and videos
+screenshots/
+videos/
+traces/
+
+# HTML reports
+html-report/
+
+# Node modules
+node_modules/
+
+# Playwright cache
+.playwright/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Log files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Temporary files
+*.tmp
+*.temp

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,388 @@
+# Farmhand E2E Tests
+
+This directory contains end-to-end tests for Farmhand using [Playwright](https://playwright.dev/).
+
+## Overview
+
+The E2E tests verify that the game works correctly from a user's perspective by simulating real browser interactions. Tests cover core game functionality including:
+
+- New game initialization
+- Crop planting and harvesting
+- Save/load functionality
+- Price events and fluctuations
+- Multiplayer features
+- Game statistics
+
+## Running Tests
+
+### Prerequisites
+
+1. Install dependencies in the main project:
+
+   ```bash
+   cd .. && npm ci --legacy-peer-deps
+   ```
+
+2. Install Playwright browsers (only needed once):
+
+   ```bash
+   npm run test:install
+   ```
+
+### Quick Setup Guide
+
+**Option 1: Automated Setup (Recommended for first-time users)**
+
+```bash
+# 1. Run the automated setup (installs dependencies and browsers)
+npm run setup
+
+# 2. Start the dev server (in one terminal, from the project root)
+cd ..
+npm run dev
+
+# 3. Run the tests (in another terminal, from the e2e directory)
+cd e2e
+npm run test
+```
+
+**Option 2: Manual Setup**
+
+If you prefer to set things up manually:
+
+```bash
+# 1. Validate the setup (optional but recommended)
+npm run validate
+
+# 2. Start the dev server (in one terminal, from the project root)
+cd ..
+npm run dev
+
+# 3. Install Playwright browsers (in another terminal, from the e2e directory, only needed once)
+cd e2e
+npm run test:install
+
+# 4. Run the tests (from the e2e directory)
+npm run test
+```
+
+### Running Tests Locally with Playwright
+
+The recommended way to run E2E tests locally is using the Playwright test runner directly. This approach requires that the dev server is already running.
+
+**Prerequisites:**
+
+- Node.js and npm installed
+- The main Farmhand dependencies installed (`npm ci --legacy-peer-deps`)
+
+**Steps:**
+
+1. **Validate the setup** (optional but recommended):
+
+   ```bash
+   npm run validate
+   ```
+
+2. **Start the development server** (from the project root):
+
+   ```bash
+   cd ..
+   npm run dev
+   ```
+
+3. **Install Playwright browsers** (only needed the first time):
+
+   ```bash
+   npm run test:install
+   ```
+
+4. **Run the E2E tests**:
+   ```bash
+   npm run test
+   ```
+
+### Available Test Commands
+
+All commands should be run from the e2e directory:
+
+- `npm run setup` - Automated first-time setup (installs dependencies and browsers)
+- `npm run validate` - Validate the E2E test setup
+- `npm run test` - Run all tests in headless mode
+- `npm run test:headed` - Run tests with browser UI visible
+- `npm run test:debug` - Run tests in debug mode (step through tests)
+- `npm run test:ui` - Run tests with Playwright's interactive UI
+- `npm run test:report` - View the test report from the last run
+- `npm run test:install` - Install Playwright browsers
+
+## Directory Structure
+
+```
+e2e/
+├── tests/               # Test files
+│   ├── *.test.js        # Individual test files
+│   ├── combine-harvester/
+│   ├── multiplayer/
+│   ├── save-data/
+│   └── stats/
+├── test-utils/          # Shared test utilities
+│   └── open-page.js     # Helper for opening the game
+├── fixtures/            # Test data and assets
+├── test-results/        # Test output (generated)
+├── playwright.config.js # Playwright configuration
+└── package.json         # E2E-specific dependencies
+```
+
+## Writing New Tests
+
+### Basic Test Structure
+
+```javascript
+import { expect, test } from '@playwright/test'
+import { openPage } from '../test-utils/open-page.js'
+
+test('describe what the test does', async ({ page }) => {
+  await openPage(page)
+
+  // Your test code here
+  await expect(page.getByText('Expected text')).toBeVisible()
+})
+```
+
+### Test Utilities
+
+- `openPage(page, seed)` - Opens the game with an optional seed for deterministic testing
+- `loadFixture(page, fixtureName)` - Loads the game with a deterministic, predefined state to test against
+- The game URL is configurable via the `APP_URL` environment variable (defaults to `http://localhost:3000`)
+
+### Test Organization
+
+- Put related tests in subdirectories under `tests/`
+- Use descriptive file names ending in `.test.js`
+- Group related functionality together
+- Add shared utilities to `test-utils/`
+
+### Authoring New E2E Tests
+
+Run this script to launch the [Playwright codegen tools](https://playwright.dev/docs/codegen-intro):
+
+```bash
+# Assumes you already have `npm run dev` running (from the project root)
+# Run this from the e2e directory
+npx playwright codegen localhost:3000?seed=0.5
+```
+
+## Configuration
+
+The Playwright configuration is in `playwright.config.js` and includes:
+
+- **Browsers**: Chromium, Firefox, WebKit, Mobile Chrome, Mobile Safari
+- **Parallel execution**: Tests run in parallel for faster execution
+- **Retries**: Automatic retry on CI environments
+- **Screenshots**: Captured on test failure
+- **Video recording**: Retained on test failure
+- **Trace collection**: Available for debugging failed tests
+
+**Test Configuration:**
+
+- Tests run across multiple browsers: Chrome, Firefox, Safari, and mobile variants
+- Tests are configured to run in parallel for faster execution
+- Failed tests automatically capture screenshots and videos
+- Test results are saved in the `test-results/` directory
+
+### Environment Variables
+
+- `APP_URL` - The base URL for the application (default: `http://localhost:3000`)
+- `CI` - Enables CI-specific settings when set
+
+### Running E2E Tests with Docker (Advanced)
+
+For a more comprehensive testing setup that matches the CI environment, you can run the E2E tests locally with the following additional tools installed and set up in your environment:
+
+- [Docker](https://docs.docker.com/engine/install/)
+- [GitHub CLI](https://cli.github.com/)
+  - You MUST [be authenticated](https://cli.github.com/manual/gh_auth_login)
+- [nektos/act](https://github.com/nektos/act)
+  - This MUST [be installed as a GitHub CLI extension](https://nektosact.com/installation/gh.html)
+- [jq](https://jqlang.org/download/)
+
+Additionally, you MUST have a Vercel account and be logged into it locally. You can do that with:
+
+```bash
+npx vercel login
+```
+
+Once that's all set up, you can run the E2E tests with:
+
+```bash
+# From the project root
+npm run e2e
+```
+
+Note that running tests locally involves downloading Docker images to your system. These images can accrue and take up space over time, but you can clear them out with:
+
+```bash
+# From the project root
+npm run e2e:cleanup
+```
+
+## Debugging Tests
+
+### Debug Mode
+
+```bash
+npm run test:debug
+```
+
+This opens the Playwright Inspector where you can step through tests line by line.
+
+### Interactive UI
+
+```bash
+npm run test:ui
+```
+
+This opens Playwright's test runner UI where you can run tests interactively and see live results.
+
+### Screenshots and Videos
+
+Failed tests automatically capture screenshots and videos in the `test-results/` directory.
+
+### Trace Viewer
+
+If a test fails and retries, a trace is collected. You can view it using:
+
+```bash
+npx playwright show-trace test-results/path-to-trace.zip
+```
+
+## Common Issues
+
+### Port Already in Use
+
+If you get port errors, make sure the dev server is running on the correct port (3000 by default).
+
+### Browser Installation
+
+If browsers aren't installed, run:
+
+```bash
+npm run test:install
+```
+
+### Test Timeouts
+
+Tests have default timeouts. For slower operations, you can increase them:
+
+```javascript
+test('slow operation', async ({ page }) => {
+  test.setTimeout(60000) // 60 seconds
+  // test code
+})
+```
+
+## CI Integration
+
+Tests run automatically in GitHub Actions on every push. The CI environment:
+
+- Uses Docker containers for consistency
+- Runs tests with retries enabled
+- Generates test reports and artifacts
+- Runs against multiple browser engines
+
+For more details, see the main project's CI workflow configuration.
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### "Port 3000 is already in use"
+
+Make sure the development server is running on port 3000:
+
+```bash
+# In the main project directory
+npm run dev
+```
+
+If port 3000 is occupied by another process, you can change the port:
+
+```bash
+# Set a different port
+APP_URL=http://localhost:3001 npm run e2e:test
+```
+
+#### "Playwright browsers not found"
+
+Install the browsers:
+
+```bash
+npm run test:install
+# or from main project
+npm run e2e:install
+```
+
+#### "Cannot connect to <http://localhost:3000>"
+
+- Ensure the development server is running and accessible
+- Check that the server is listening on the correct port
+- Verify no firewall is blocking the connection
+- Try accessing the URL manually in your browser
+
+#### "Tests are failing unexpectedly"
+
+1. **Check the development server logs** for errors
+2. **Run tests with headed mode** to see what's happening:
+
+   ```bash
+   npm run test:headed
+   ```
+
+3. **Use debug mode** to step through the test:
+
+   ```bash
+   npm run test:debug
+   ```
+
+4. **Check for timing issues** - the game might need more time to load:
+
+   ```javascript
+   // In your test, add explicit waits
+   await page.waitForLoadState('networkidle')
+   ```
+
+5. **Ensure Vercel is set up properly** - at this time, you need to have the local Farmhand project properly linked to a Vercel project. This will be improved in a future iteration.
+
+#### "Permission denied" errors
+
+On Linux/Mac, ensure proper permissions:
+
+```bash
+chmod -R 755 test-results/
+chmod -R 755 playwright-report/
+```
+
+#### "Module not found" errors
+
+- Ensure you're in the correct directory (`e2e/`)
+- Reinstall dependencies:
+
+  ```bash
+  npm install
+  ```
+
+- Check that the main project dependencies are installed
+
+#### "Tests run but nothing happens"
+
+- Verify the game loads correctly at <http://localhost:3000>
+- Check browser console for JavaScript errors
+- Ensure the test selectors match the current UI
+
+### Getting Help
+
+If you encounter issues not covered here:
+
+1. Check the [Playwright documentation](https://playwright.dev/docs/intro)
+2. Look at existing test files for examples
+3. Run `npm run validate` to check your setup
+4. Open a GitHub issue with details about your problem

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@playwright/test": "^1.52.0"
+        "@playwright/test": "^1.52.0",
+        "@types/node": "^24.0.10"
       }
     },
     "node_modules/@playwright/test": {
@@ -25,6 +26,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/fsevents": {
@@ -70,6 +80,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -80,6 +96,15 @@
       "dev": true,
       "requires": {
         "playwright": "1.52.0"
+      }
+    },
+    "@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.8.0"
       }
     },
     "fsevents": {
@@ -103,6 +128,12 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
       "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true
     }
   }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,13 +3,24 @@
   "version": "0.0.0",
   "description": "End-to-end tests for Farmhand",
   "main": "index.js",
+  "type": "module",
   "directories": {
     "test": "tests"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "test:ui": "playwright test --ui",
+    "test:report": "playwright show-report",
+    "test:install": "playwright install",
+    "validate": "node validate-setup.js",
+    "setup": "node setup.js"
+  },
   "author": "jeremyckahn@gmail.com",
   "license": "GPL-2.0-or-later",
   "devDependencies": {
-    "@playwright/test": "^1.52.0"
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^24.0.10"
   }
 }

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,74 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if test.only was accidentally left in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['html'],
+    ['json', { outputFile: 'reports/results.json' }],
+    ['list'],
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.APP_URL || 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+
+    /* Screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Record video on failure */
+    video: 'retain-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    //
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+    //
+    // /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+})

--- a/e2e/setup.js
+++ b/e2e/setup.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+/**
+ * First-time setup script for Playwright E2E tests
+ * This script automates the initial setup process for running E2E tests
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function log(message, type = 'info') {
+  const colors = {
+    info: '\x1b[36m', // cyan
+    success: '\x1b[32m', // green
+    warning: '\x1b[33m', // yellow
+    error: '\x1b[31m', // red
+    reset: '\x1b[0m',
+  }
+
+  const prefix = {
+    info: 'ℹ️ ',
+    success: '✅ ',
+    warning: '⚠️ ',
+    error: '❌ ',
+  }
+
+  console.log(`${colors[type]}${prefix[type]}${message}${colors.reset}`)
+}
+
+function execute(command, description) {
+  try {
+    log(`${description}...`, 'info')
+    execSync(command, { stdio: 'inherit' })
+    log(`${description} completed successfully`, 'success')
+    return true
+  } catch (error) {
+    log(`${description} failed: ${error.message}`, 'error')
+    return false
+  }
+}
+
+async function checkPrerequisites() {
+  log('Checking prerequisites...', 'info')
+
+  // Check Node.js version
+  try {
+    const nodeVersion = execSync('node --version', { encoding: 'utf8' }).trim()
+    log(`Node.js version: ${nodeVersion}`, 'success')
+  } catch (error) {
+    log('Node.js is not installed or not accessible', 'error')
+    return false
+  }
+
+  // Check npm
+  try {
+    const npmVersion = execSync('npm --version', { encoding: 'utf8' }).trim()
+    log(`npm version: ${npmVersion}`, 'success')
+  } catch (error) {
+    log('npm is not installed or not accessible', 'error')
+    return false
+  }
+
+  // Check if main project dependencies are installed
+  try {
+    const mainPackageJsonPath = join(__dirname, '..', 'package.json')
+    const nodeModulesPath = join(__dirname, '..', 'node_modules')
+
+    try {
+      execSync(`test -d "${nodeModulesPath}"`, { stdio: 'ignore' })
+      log('Main project dependencies are installed', 'success')
+    } catch {
+      log('Main project dependencies are not installed', 'warning')
+      log(
+        'Please run "npm ci --legacy-peer-deps" in the main project directory first',
+        'warning'
+      )
+      return false
+    }
+  } catch (error) {
+    log('Could not check main project dependencies', 'error')
+    return false
+  }
+
+  return true
+}
+
+async function setupE2E() {
+  log('\n🚀 Setting up Playwright E2E tests for Farmhand\n', 'info')
+
+  // Check prerequisites
+  if (!(await checkPrerequisites())) {
+    log(
+      '\nPrerequisites check failed. Please fix the issues above and try again.',
+      'error'
+    )
+    process.exit(1)
+  }
+
+  // Install E2E dependencies
+  log('\nInstalling E2E dependencies...', 'info')
+  if (!execute('npm install', 'Installing E2E dependencies')) {
+    log('Failed to install E2E dependencies', 'error')
+    process.exit(1)
+  }
+
+  // Install Playwright browsers
+  log('\nInstalling Playwright browsers...', 'info')
+  if (!execute('npx playwright install', 'Installing Playwright browsers')) {
+    log('Failed to install Playwright browsers', 'error')
+    process.exit(1)
+  }
+
+  // Validate setup
+  log('\nValidating setup...', 'info')
+  if (!execute('npm run validate', 'Validating setup')) {
+    log('Setup validation failed', 'error')
+    process.exit(1)
+  }
+
+  // Success message
+  log('\n🎉 E2E test setup completed successfully!\n', 'success')
+
+  // Next steps
+  console.log('Next steps:')
+  console.log('1. Start the development server in the main project:')
+  console.log('   cd .. && npm run dev')
+  console.log('')
+  console.log('2. In a separate terminal, run the E2E tests:')
+  console.log('   npm test                    # Run all tests')
+  console.log('   npm run test:headed         # Run with browser UI')
+  console.log('   npm run test:debug          # Debug mode')
+  console.log('   npm run test:ui             # Interactive UI')
+  console.log('')
+  console.log('3. Or run from the main project directory:')
+  console.log('   npm run e2e:test            # Run all tests')
+  console.log('   npm run e2e:test:headed     # Run with browser UI')
+  console.log('   npm run e2e:test:debug      # Debug mode')
+  console.log('   npm run e2e:test:ui         # Interactive UI')
+  console.log('')
+  console.log('For more information, see the README.md file.')
+}
+
+// Run setup if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  setupE2E().catch(error => {
+    log(`Setup failed: ${error.message}`, 'error')
+    process.exit(1)
+  })
+}
+
+export { setupE2E }

--- a/e2e/test-utils/load-fixture.js
+++ b/e2e/test-utils/load-fixture.js
@@ -1,6 +1,14 @@
+import path from 'node:path'
+
 import { expect } from '@playwright/test'
 
 import { openPage } from './open-page.js'
+
+const isCiEnvironment = Boolean(process.env.CI)
+
+const projectDirectoryRoot = isCiEnvironment
+  ? '/home/pwuser'
+  : path.join(process.cwd(), '..')
 
 /**
  * @param {import('@playwright/test').Page} page
@@ -13,7 +21,7 @@ export async function loadFixture(page, fixtureName) {
   await page.getByRole('button', { name: 'Load game data that was' }).click()
   await page
     .locator('input[type=file]')
-    .setInputFiles(`/home/pwuser/e2e/fixtures/${fixtureName}.json`)
+    .setInputFiles(`${projectDirectoryRoot}/e2e/fixtures/${fixtureName}.json`)
 
   await expect(page.getByText('Data loaded!')).toBeVisible()
 }

--- a/e2e/validate-setup.js
+++ b/e2e/validate-setup.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * Validation script for Playwright E2E test setup
+ * This script verifies that the Playwright configuration is working correctly
+ */
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+async function validateSetup() {
+  console.log('🔍 Validating Playwright E2E setup...\n')
+
+  // Check if package.json exists and has playwright dependency
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(__dirname, 'package.json'), 'utf8')
+    )
+    if (packageJson.devDependencies?.['@playwright/test']) {
+      console.log('✅ Playwright dependency found')
+    } else {
+      console.log('❌ Playwright dependency missing')
+      return false
+    }
+  } catch (error) {
+    console.log('❌ Could not read package.json:', error.message)
+    return false
+  }
+
+  // Check if playwright.config.js exists
+  try {
+    const configPath = join(__dirname, 'playwright.config.js')
+    readFileSync(configPath, 'utf8')
+    console.log('✅ Playwright configuration file found')
+  } catch (error) {
+    console.log('❌ Playwright configuration file missing')
+    return false
+  }
+
+  // Check if test directory exists
+  try {
+    const testDir = join(__dirname, 'tests')
+    const testFiles = await import('fs').then(fs =>
+      fs.promises.readdir(testDir, { withFileTypes: true })
+    )
+    const testCount = testFiles.filter(
+      file => file.isFile() && file.name.endsWith('.test.js')
+    ).length
+
+    if (testCount > 0) {
+      console.log(`✅ Found ${testCount} test files`)
+    } else {
+      console.log('⚠️  No test files found in tests directory')
+    }
+  } catch (error) {
+    console.log('❌ Could not access tests directory:', error.message)
+    return false
+  }
+
+  // Check if test utilities exist
+  try {
+    const utilsPath = join(__dirname, 'test-utils', 'open-page.js')
+    readFileSync(utilsPath, 'utf8')
+    console.log('✅ Test utilities found')
+  } catch (error) {
+    console.log('❌ Test utilities missing:', error.message)
+    return false
+  }
+
+  // Try to load Playwright configuration
+  try {
+    const { devices } = await import('@playwright/test')
+    console.log('✅ Playwright modules load successfully')
+  } catch (error) {
+    console.log('❌ Could not load Playwright modules:', error.message)
+    return false
+  }
+
+  // Check environment configuration
+  const appUrl = process.env.APP_URL || 'http://localhost:3000'
+  console.log(`✅ App URL configured: ${appUrl}`)
+
+  console.log('\n🎉 Playwright E2E setup validation complete!')
+  console.log('\nNext steps:')
+  console.log('1. Start the development server: npm run dev')
+  console.log('2. Install browsers: npm run e2e:install')
+  console.log('3. Run tests: npm run e2e:test')
+
+  return true
+}
+
+// Run validation if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  validateSetup().catch(error => {
+    console.error('❌ Validation failed:', error.message)
+    process.exit(1)
+  })
+}
+
+export { validateSetup }


### PR DESCRIPTION
### What this PR does

As a followup to #548, this PR enables simpler and faster local running of E2E tests. It skips all the CI-centric Docker infrastructure and sets up a typical Playwright configuration to run against the local dev server.

### How this change can be validated

Follow the instructions and see that E2E tests that don't involve multiplayer pass.

### Questions or concerns about this change

**IMPORTANT NOTE**: The tests that involve online play will likely fail in every environment except for CI and my personal development machine. This is because those tests depend on Vercel which requires a personal Vercel project to be set up and linked. This is obviously pretty flawed and it can be worked around, but I'm going to break that out into a followup improvement once [the ongoing type error initiative](https://github.com/jeremyckahn/farmhand/compare/feature/fix-types?w=1) is complete (so as to avoid a nasty merge conflict).

### Additional information

This is mostly a boilerplate configuration and setup produced by Claude. This wasn't something I had a lot of time to invest into, but I needed it to unblock the type error fixes and it seems to work as expected. This PR isn't going for "perfect," it's going for "better." 😆