### PR TITLE
fix(ci): Prevent creation of `0.0.0` version during release process

### DIFF
--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Tag release
         run: npm version ${{ github.event.inputs.releaseType }}
 
-        # Sets new package version as ${{ env.PACKAGE_VERSION }}
-      - uses: jozsefsallai/node-package-version@v1.0.4
+        # Get new package version from package.json
+      - name: Get package version
+        id: package_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Check out main
         uses: actions/checkout@v3
@@ -67,7 +69,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Prepare Web Artifacts
-        run: zip farmhand-web-${{ env.PACKAGE_VERSION }}.zip -r dist/*
+        run: zip farmhand-web-${{ steps.package_version.outputs.version }}.zip -r dist/*
 
       - name: Create Release
         id: create_release
@@ -75,12 +77,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.PACKAGE_VERSION }}
-          name: ${{ env.PACKAGE_VERSION }}
+          tag_name: ${{ steps.package_version.outputs.version }}
+          name: ${{ steps.package_version.outputs.version }}
           draft: false
           prerelease: false
           files: |
-            ./farmhand-web-${{ env.PACKAGE_VERSION }}.zip
+            ./farmhand-web-${{ steps.package_version.outputs.version }}.zip
 
       - run: node -e "console.log(require('./package.json').version)" > dist/version.txt
       - name: Publish itch.io build


### PR DESCRIPTION
### What this PR does

This PR attempts to fix an issue where an extraneous `0.0.0` tag is created during the release process.

### How this change can be validated

Make a production release and see if the problem is resolved.

### Additional information

This is a Gemini-suggested fix and I have no idea if it will work. 🤷‍♂️