### PR TITLE
fix(e2e): Use consistent date for E2E tests

### DIFF
--- a/e2e/test-utils/open-page.js
+++ b/e2e/test-utils/open-page.js
@@ -3,8 +3,12 @@
  * @param {number=} seed
  * @returns {Promise<import('@playwright/test').Response | null>}
  */
-export const openPage = (page, seed = 0.5) => {
+export const openPage = async (page, seed = 0.5) => {
   const appUrl = process.env.APP_URL || 'http://localhost:3000'
+
+  // NOTE: A consistent date for the game is set so that time-based events
+  // don't interfere with the tests
+  await page.clock.install({ time: new Date('2025-01-01T09:00:00') })
 
   return page.goto(`${appUrl}?seed=${seed}`)
 }


### PR DESCRIPTION
### What this PR does

This PR prevents time-based events (such as for the months of October or December) from interfering with and breaking end-to-end tests.

### How this change can be validated

Verify that the E2E tests pass.