### PR TITLE
Convert JSDoc types to TypeScript

### DIFF
--- a/src/common/services/randomNumber.ts
+++ b/src/common/services/randomNumber.ts
@@ -17,17 +17,13 @@ export class RandomNumberService {
     }
   }
 
-  /**
-   * @param {string} seed
-   */
-  seedRandomNumber(seed) {
+
+  seedRandomNumber(seed: string) {
     this.seededRandom = seedrandom(seed)
   }
 
-  /**
-   * @returns {number}
-   */
-  generateRandomNumber() {
+
+  generateRandomNumber(): number {
     return this.seededRandom ? this.seededRandom() : Math.random()
   }
 
@@ -37,11 +33,11 @@ export class RandomNumberService {
 
   /**
    * Compares given number against a randomly generated number.
-   * @param {number} chance Float between 0-1 to compare dice roll against.
-   * @returns {boolean} True if the dice roll was equal to or lower than the
+   * @param chance Float between 0-1 to compare dice roll against.
+   * @returns True if the dice roll was equal to or lower than the
    * given chance, false otherwise.
    */
-  isRandomNumberLessThan(chance) {
+  isRandomNumberLessThan(chance: number): boolean {
     return this.generateRandomNumber() <= chance
   }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -6,12 +6,8 @@ export const random = () => {
   return randomNumberService.generateRandomNumber()
 }
 
-/**
- * @param {Partial<Record<string, farmhand.priceEvent>>} priceCrashes
- * @param {Partial<Record<string, farmhand.priceEvent>>} priceSurges
- * @returns {Record<string, number>}
- */
-export const generateValueAdjustments = (priceCrashes = {}, priceSurges = {}) =>
+
+export const generateValueAdjustments = (priceCrashes: Partial<Record<string, farmhand.priceEvent>> = {}, priceSurges: Partial<Record<string, farmhand.priceEvent>> = {}): Record<string, number> =>
   Object.keys(itemsMap).reduce((acc, key) => {
     if (itemsMap[key].doesPriceFluctuate) {
       if (priceCrashes[key]) {

--- a/src/components/AccountingView/AccountingView.tsx
+++ b/src/components/AccountingView/AccountingView.tsx
@@ -22,12 +22,12 @@ import './AccountingView.sass'
 
 const MoneyNumberFormat = forwardRef(
   /**
-   * @param {Object} props - Component properties
-   * @param {number} props.max - Maximum value allowed for the input
-   * @param {number} props.min - Minimum value allowed for the input
-   * @param {(value: number) => void} props.onChange - Callback function to handle changes in the input value
-   * @param {React.Dispatch<React.SetStateAction<number>>} props.setLoanInputValue - Function to set the loan input value
-   * @param {React.ForwardedRef<unknown>} [ref] - Forwarded ref for the component
+   * @param props - Component properties
+   * @param props.max - Maximum value allowed for the input
+   * @param props.min - Minimum value allowed for the input
+   * @param props.onChange - Callback function to handle changes in the input value
+   * @param props.setLoanInputValue - Function to set the loan input value
+   * @param [ref] - Forwarded ref for the component
    */
   (
     {

--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -8,12 +8,12 @@ const defaultFormatter = (/** @type {number} */ num) => `${num}`
 /**
  * AnimatedNumber component that displays a number with an animation effect.
  *
- * @param {Object} props - The component properties.
- * @param {number} props.number - The number to display.
- * @param {typeof defaultFormatter} [props.formatter=defaultFormatter] - A function to format the number before displaying it.
- * @returns {JSX.Element} - The JSX element representing the animated number.
+ * @param props - The component properties.
+ * @param props.number - The number to display.
+ * @param [props.formatter=defaultFormatter] - A function to format the number before displaying it.
+ * @returns - The JSX element representing the animated number.
  */
-const AnimatedNumber = ({ number, formatter = defaultFormatter }) => {
+const AnimatedNumber = ({ number, formatter = defaultFormatter }): JSX.Element => {
   const [displayedNumber, setDisplayedNumber] = useState(number)
   const [previousNumber, setPreviousNumber] = useState(number)
   const [currentTweenable, setCurrentTweenable] = useState<

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -15,8 +15,8 @@ import './AppBar.sass'
 /**
  * Displays formatted monetary value.
  *
- * @param {Object} props - The component props.
- * @param {number} props.money - The amount of money to display.
+ * @param props - The component props.
+ * @param props.money - The amount of money to display.
  */
 const MoneyDisplay = ({ money }) => {
   const idleColor = 'rgb(255, 255, 255)'

--- a/src/components/Cellar/CellarInventoryTabPanel.tsx
+++ b/src/components/Cellar/CellarInventoryTabPanel.tsx
@@ -23,9 +23,9 @@ import { TabPanel } from './TabPanel/index.js'
 import { Keg } from './Keg.js'
 
 /**
- * @param {Object} props
- * @param {number} props.index
- * @param {number} props.currentTab
+
+ * @param props.index
+ * @param props.currentTab
  */
 export const CellarInventoryTabPanel = ({ index, currentTab }) => {
   const [searchQuery, setSearchQuery] = useState('')

--- a/src/components/Cellar/Keg.tsx
+++ b/src/components/Cellar/Keg.tsx
@@ -22,8 +22,8 @@ import { wineService } from '../../services/wine.js'
 import { cellarService } from '../../services/cellar.js'
 
 /**
- * @param {Object} props
- * @param {keg} props.keg
+
+ * @param props.keg
  */
 export function Keg({ keg }) {
   /**

--- a/src/components/CowCard/CowCard.test.tsx
+++ b/src/components/CowCard/CowCard.test.tsx
@@ -18,9 +18,7 @@ describe('CowCard', () => {
     baseWeight: 100,
   })
 
-  /**
-   * @type {import("./CowCard.js").CowCardProps}
-   */
+
   const baseProps = {
     allowCustomPeerCowNames: false,
     cow,

--- a/src/components/CowCard/CowCard.tsx
+++ b/src/components/CowCard/CowCard.tsx
@@ -362,10 +362,8 @@ CowCard.propTypes = {
   purchasedCowPen: number.isRequired,
 }
 
-/**
- * @param {Pick<CowCardProps, 'cow' | 'isCowOfferedForTradeByPeer' | 'isSelected'>} props
- */
-export default function Consumer(props) {
+
+export default function Consumer(props: Pick<CowCardProps, 'cow' | 'isCowOfferedForTradeByPeer' | 'isSelected'>) {
   return (
     <FarmhandContext.Consumer>
       {({ gameState, handlers }) => (

--- a/src/components/CowCard/Subheader/Subheader.tsx
+++ b/src/components/CowCard/Subheader/Subheader.tsx
@@ -27,17 +27,12 @@ import './Subheader.sass'
 
 // The extra 0.5 is for rounding up to the next full heart. This allows a fully
 // happy cow to have full hearts on the beginning of a new day.
-/**
- * @param {number} heartIndex
- * @param {number} numberOfFullHearts
- */
-const isHeartFull = (heartIndex, numberOfFullHearts) =>
+
+const isHeartFull = (heartIndex: number, numberOfFullHearts: number) =>
   heartIndex + 0.5 < numberOfFullHearts
 
 const getCowMapById = memoize(
-  /**
-   * @param {farmhand.state['cowInventory']} cowInventory
-   */
+
   cowInventory =>
     cowInventory.reduce((acc, cow) => {
       acc[cow.id] = cow

--- a/src/components/CowPen/Tumbleweeds.tsx
+++ b/src/components/CowPen/Tumbleweeds.tsx
@@ -21,7 +21,7 @@ const tumbleweedSize = 48
 
 /**
  * A single tumbleweed that animates across the screen.
- * @type {React.FC<{onAnimationComplete: () => void}>}
+
  */
 const Tumbleweed = ({ onAnimationComplete }) => {
   // Randomize the vertical position of the tumbleweed.
@@ -61,7 +61,7 @@ const Tumbleweed = ({ onAnimationComplete }) => {
 
 /**
  * Manages the spawning of multiple Tumbleweed components.
- * @type {React.FC<{doSpawn: boolean}>}
+
  */
 export const Tumbleweeds = ({ doSpawn }) => {
   // A list of UUIDs, each representing a Tumbleweed component.
@@ -125,7 +125,7 @@ export const Tumbleweeds = ({ doSpawn }) => {
 
   /**
    * Removes a tumbleweed from the list after its animation is complete.
-   * @param {string} tumbleweedUuid
+
    */
   const handleTumbleweedAnimationComplete = useCallback(
     tumbleweedUuid => {

--- a/src/components/Farmhand/Farmhand.context.tsx
+++ b/src/components/Farmhand/Farmhand.context.tsx
@@ -196,9 +196,7 @@ export const createContextData = (): ContextData => {
   }
 }
 
-/**
- * @type {import('react').Context<ContextData>}
- */
-const FarmhandContext = createContext<ContextData>(createContextData())
+
+const FarmhandContext: import('react').Context<ContextData> = createContext<ContextData>(createContextData())
 
 export default FarmhandContext

--- a/src/components/Farmhand/Farmhand.tsx
+++ b/src/components/Farmhand/Farmhand.tsx
@@ -117,9 +117,9 @@ const emptyObject = Object.freeze({})
 
 export const computePlayerInventory = memoize(
   /**
-   * @param {{ id: globalThis.farmhand.item['id'], quantity: number }[]} inventory
-   * @param {Record<string, number>} valueAdjustments
-   * @returns {globalThis.farmhand.item[]}
+   * @param []} inventory
+
+
    */
   (inventory, valueAdjustments) =>
     inventory.map(({ quantity, id }) => ({
@@ -130,10 +130,7 @@ export const computePlayerInventory = memoize(
 )
 
 export const getFieldToolInventory = memoize(
-  /**
-   * @param {globalThis.farmhand.state['inventory']} inventory
-   * @returns {globalThis.farmhand.item[]}
-   */
+
   inventory =>
     inventory
       .filter(({ id }) => {
@@ -147,23 +144,15 @@ export const getFieldToolInventory = memoize(
 )
 
 export const getPlantableCropInventory = memoize(
-  /**
-   * @param {globalThis.farmhand.state['inventory']} inventory
-   * @returns {globalThis.farmhand.item[]}
-   */
+
   inventory =>
     inventory
       .filter(({ id }) => itemsMap[id].isPlantableCrop)
       .map(({ id, quantity }) => ({ ...itemsMap[id], quantity }))
 )
 
-/**
- * @param {Record<string, number>} valueAdjustments
- * @param {Partial<Record<string, globalThis.farmhand.priceEvent>>} priceCrashes
- * @param {Partial<Record<string, globalThis.farmhand.priceEvent>>} priceSurges
- * @returns {Record<string, number>}
- */
-const applyPriceEvents = (valueAdjustments, priceCrashes, priceSurges) => {
+
+const applyPriceEvents = (valueAdjustments: Record<string, number>, priceCrashes: Partial<Record<string, globalThis.farmhand.priceEvent>>, priceSurges: Partial<Record<string, globalThis.farmhand.priceEvent>>): Record<string, number> => {
   const patchedValueAdjustments = { ...valueAdjustments }
 
   Object.keys(priceCrashes).forEach(itemId => {
@@ -192,14 +181,10 @@ export default class Farmhand extends FarmhandReducers {
     debounced: BoundHandlers<typeof eventHandlers>
   }
 
-  /**
-   * @type {Record<string, string>}
-   */
+
   keyMap = {}
 
-  /**
-   * @type {Record<string, () => void>}
-   */
+
   keyHandlers = {}
 
   static defaultProps = {
@@ -211,9 +196,7 @@ export default class Farmhand extends FarmhandReducers {
     match: { path: '', params: {} },
   }
 
-  /**
-   * @param {typeof Farmhand.defaultProps} props
-   */
+
   constructor(props) {
     super(props)
 
@@ -298,9 +281,7 @@ export default class Farmhand extends FarmhandReducers {
     return this.levelEntitlements.stageFocusType[stageFocusType.FOREST]
   }
 
-  /**
-   * @returns {farmhand.state}
-   */
+
   createInitialState(): farmhand.state {
     return {
       activePlayers: null,
@@ -690,11 +671,11 @@ export default class Farmhand extends FarmhandReducers {
   }
 
   /**
-   * @param {Function} sendPeerMetadata Raw send action callback created by
+   * @param sendPeerMetadata Raw send action callback created by
    * Trystero's makeAction function.
-   * @return {Function}
+
    */
-  wrapSendPeerMetadata(sendPeerMetadata) {
+  wrapSendPeerMetadata(sendPeerMetadata: Function): Function {
     return throttle(
       (...args) => {
         sendPeerMetadata(...args)
@@ -710,10 +691,8 @@ export default class Farmhand extends FarmhandReducers {
     )
   }
 
-  /**
-   * @param {globalThis.farmhand.cow} peerPlayerCow
-   */
-  tradeForPeerCow(peerPlayerCow) {
+
+  tradeForPeerCow(peerPlayerCow: globalThis.farmhand.cow) {
     this.setState(state => {
       const {
         cowIdOfferedForTrade,
@@ -879,10 +858,8 @@ export default class Farmhand extends FarmhandReducers {
     }))
   }
 
-  /**
-   * @param {farmhand.state} prevState
-   */
-  showInventoryFullNotifications(prevState) {
+
+  showInventoryFullNotifications(prevState: any) {
     if (
       inventorySpaceRemaining(prevState) > 0 &&
       inventorySpaceRemaining(this.state) <= 0
@@ -928,16 +905,12 @@ export default class Farmhand extends FarmhandReducers {
     /** @type {globalThis.farmhand.notification[]} */
     const serverMessages: { message: string; severity: string }[] = []
 
-    /**
-     * @type {string | null}
-     */
+
     let broadcastedPositionMessage: string | null = null
 
     this.setState(() => ({ isAwaitingNetworkRequest: true }))
 
-    /**
-     * @type {Record<string, number> | undefined}
-     */
+
     let serverValueAdjustments
 
     if (this.state.isOnline) {
@@ -1013,10 +986,7 @@ export default class Farmhand extends FarmhandReducers {
     // experience. The persisted state is computed post-update and stored
     // asynchronously, thus avoiding state changes from being blocked.
     this.setState(
-      /**
-       * @param {farmhand.state} prev
-       * @return {Partial<farmhand.state>}
-       */
+
       prev => {
         const nextDayState = reducers.computeStateForNextDay(prev, isFirstDay)
 

--- a/src/components/Farmhand/FarmhandReducers.tsx
+++ b/src/components/Farmhand/FarmhandReducers.tsx
@@ -169,9 +169,7 @@ export class FarmhandReducers extends Component<FarmhandProps, FarmhandState> {
     throw new Error('Unimplemented')
   }
 
-  /**
-   * @param {Object} props
-   */
+
   constructor(props) {
     super(props)
 

--- a/src/components/Farmhand/helpers/getInventoryQuantities.ts
+++ b/src/components/Farmhand/helpers/getInventoryQuantities.ts
@@ -3,7 +3,7 @@ import { itemsMap } from '../../../data/maps.js'
 const itemIds = Object.keys(itemsMap)
 
 /**
- * @param {Array.<{ id: farmhand.item['id'], quantity: number }>} inventory
+ * @param >} inventory
  */
 export const getInventoryQuantities = inventory => {
   /** @type {Record<string, number>} */

--- a/src/components/FermentationRecipeList/FermentationRecipe.tsx
+++ b/src/components/FermentationRecipeList/FermentationRecipe.tsx
@@ -26,8 +26,8 @@ import AnimatedNumber from '../AnimatedNumber/index.js'
 import './FermentationRecipe.sass'
 
 /**
- * @param {Object} props
- * @param {item} props.item
+
+ * @param props.item
  */
 export const FermentationRecipe = ({ item }) => {
   const {

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -114,9 +114,7 @@ export const isInHoverRange = ({
 }
 
 export const MemoPlot = memo(
-  /**
-   * @param {MemoPlotProps} props
-   */
+
   (props: MemoPlotProps) => {
     const { hoveredPlot, plotContent, setHoveredPlot, x, y } = props
 

--- a/src/components/Inventory/Inventory.tsx
+++ b/src/components/Inventory/Inventory.tsx
@@ -50,10 +50,7 @@ export const separateItemsIntoCategories = (
   /** @type {farmhand.item[]} */ items
 ) =>
   sortItems(items).reduce(
-    /**
-     * @param {Map<string, farmhand.item[]>} categories
-     * @param {farmhand.item} item
-     */
+
     (categories, item) => {
       const { type } = itemsMap[item.id]
       const category = itemTypeCategoryMap.get(type)

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -105,9 +105,7 @@ const OnlineControls = ({
     handleRoomChange(displayedRoom)
   }
 
-  /**
-   * @param {boolean} checked
-   */
+
   const handleSwitchChange = checked => {
     submitRoomNameChange()
     handleOnlineToggleChange(checked)

--- a/src/components/Plot/Plot.tsx
+++ b/src/components/Plot/Plot.tsx
@@ -21,10 +21,7 @@ import { SHOVELED } from '../../strings.js'
 import './Plot.sass'
 import { SHOVELED_PLOT } from '../../templates.js'
 
-/**
- * @param {farmhand.plotContent?} plotContent
- * @returns {string | undefined}
- */
+
 export const getBackgroundStyles = plotContent => {
   if (!plotContent) {
     return undefined

--- a/src/components/QuantityInput/QuantityInput.tsx
+++ b/src/components/QuantityInput/QuantityInput.tsx
@@ -16,11 +16,11 @@ export const QUANTITY_INPUT_PLACEHOLDER_TEXT = '0'
 
 const QuantityNumberFormat = forwardRef(
   /**
-   * @param {Object} props
-   * @param {number} props.min
-   * @param {number} props.max
-   * @param {(value: number) => void} props.onChange
-   * @param {React.ForwardedRef<any>} ref
+
+   * @param props.min
+   * @param props.max
+   * @param props.onChange
+
    */
   (
     {

--- a/src/components/Recipe/Recipe.tsx
+++ b/src/components/Recipe/Recipe.tsx
@@ -27,12 +27,12 @@ import './Recipe.sass'
 import { INFINITE_STORAGE_LIMIT } from '../../constants.js'
 
 /**
- * @param {object} props
- * @param {Function} props.handleMakeRecipeClick
- * @param {farmhand.state['inventory']} props.inventory
- * @param {number} props.inventoryLimit
- * @param {Record<string, number>} props.playerInventoryQuantities
- * @param {farmhand.recipe} props.recipe
+
+ * @param props.handleMakeRecipeClick
+ * @param props.inventory
+ * @param props.inventoryLimit
+ * @param props.playerInventoryQuantities
+ * @param props.recipe
  */
 const Recipe = ({
   handleMakeRecipeClick,

--- a/src/components/SettingsView/RandomSeedInput.tsx
+++ b/src/components/SettingsView/RandomSeedInput.tsx
@@ -16,16 +16,12 @@ export const RandomSeedInput = ({ search = globalWindow.location.search }) => {
     new URLSearchParams(search).get('seed') ?? ''
   )
 
-  /**
-   * @param {React.ChangeEvent<HTMLInputElement>} e
-   */
+
   const handleChange = e => {
     setSeed(/** @type {HTMLInputElement} */ e.target.value)
   }
 
-  /**
-   * @param {React.SyntheticEvent<HTMLFormElement>} e
-   */
+
   const handleSubmit = e => {
     e.preventDefault()
 

--- a/src/components/Shop/Shop.tsx
+++ b/src/components/Shop/Shop.tsx
@@ -38,10 +38,7 @@ import { TabPanel, a11yProps } from './TabPanel/index.js'
 
 import './Shop.sass'
 
-/**
- * @param {Array.<farmhand.item>} shopInventory
- * @returns {Object.<'seeds' | 'fieldTools', Array.<farmhand.item>>}
- */
+
 const categorizeShopInventory = memoize(shopInventory =>
   shopInventory.reduce(
     (acc, inventoryItem) => {

--- a/src/components/WineRecipeList/WineRecipe.test.tsx
+++ b/src/components/WineRecipeList/WineRecipe.test.tsx
@@ -24,14 +24,14 @@ import { QUANTITY_INPUT_PLACEHOLDER_TEXT } from '../QuantityInput/QuantityInput.
 import { WineRecipe } from './WineRecipe.js'
 
 /** @type {Pick<farmhand.state, 'cellarInventory' | 'inventory' | 'purchasedCellar'>} */
-const stubGameState = {
+const stubGameState: Pick<farmhand.state, 'cellarInventory' | 'inventory' | 'purchasedCellar'> = {
   cellarInventory: [],
   inventory: [{ id: grapeChardonnay.id, quantity: 1 }],
   purchasedCellar: 1,
 }
 
 /** @type {Pick<uiHandlers, 'handleMakeWineClick'>} */
-const stubHandlers = {
+const stubHandlers: Pick<uiHandlers, 'handleMakeWineClick'> = {
   handleMakeWineClick: vitest.fn(),
 }
 

--- a/src/components/WineRecipeList/WineRecipe.tsx
+++ b/src/components/WineRecipeList/WineRecipe.tsx
@@ -31,9 +31,7 @@ import { yeast } from '../../data/recipes.js'
  * }} WineRecipeProps
  */
 
-/**
- * @param {WineRecipeProps} props
- */
+
 export const WineRecipe = ({
   wineVariety,
 }: {

--- a/src/components/Workshop/getUpgradesAvailable.ts
+++ b/src/components/Workshop/getUpgradesAvailable.ts
@@ -3,10 +3,10 @@ import { recipesMap } from '../../data/maps.js'
 
 /**
  * Get available upgrades based on current tool levels and unlocked recipes
- * @param {object} params - the parameters object
- * @param {array} params.learnedForgeRecipes - list of learned forge recipes from farmhand state
- * @param {object} params.toolLevels - the current level of each tool
- * @returns {array} a list of all applicable upgrades
+ * @param params - the parameters object
+ * @param params.learnedForgeRecipes - list of learned forge recipes from farmhand state
+ * @param params.toolLevels - the current level of each tool
+ * @returns a list of all applicable upgrades
  */
 interface GetUpgradesAvailableArgs {
   learnedForgeRecipes: string[]

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -39,10 +39,8 @@ const sumOfCropsHarvested = memoize(
 
 const cowFeed = itemsMap[COW_FEED_ITEM_ID]
 
-/**
- * @type {farmhand.achievement[]}
- */
-const achievements = [
+
+const achievements: any = [
   ((reward = 100) => ({
     id: 'plant-crop',
     name: 'Plant a Crop',

--- a/src/data/crop.ts
+++ b/src/data/crop.ts
@@ -3,18 +3,12 @@ import { getCropLifecycleDuration } from '../utils/getCropLifecycleDuration.js'
 
 const { freeze } = Object
 
-/**
- * @param {Partial<farmhand.item>} item
- * @returns {farmhand.item}
- */
+
 interface CropArgs extends Partial<farmhand.item> {
   cropTimeline?: number[]
 }
 
-/**
- * @param {CropArgs} item
- * @returns {farmhand.item}
- */
+
 export const crop = ({
   cropTimeline = [],
   growsInto,
@@ -46,11 +40,7 @@ interface FromSeedConfig {
   canBeFermented?: boolean
 }
 
-/**
- * @param {farmhand.item} item
- * @param {FromSeedConfig} [config]
- * @returns {Partial<farmhand.item>}
- */
+
 export const fromSeed = (
   { cropTimeline, cropType, growsInto, tier = 1 }: farmhand.item,
   { variantIdx = 0, canBeFermented = false }: FromSeedConfig = {}
@@ -71,10 +61,7 @@ export const fromSeed = (
   }
 }
 
-/**
- * @param {farmhand.cropVariety} cropVarietyArgs
- * @returns {farmhand.cropVariety}
- */
+
 export const cropVariety = ({
   imageId,
   cropFamily,

--- a/src/data/crops/asparagus.ts
+++ b/src/data/crops/asparagus.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.asparagusSeed
- * @type {farmhand.item}
+
  */
-export const asparagusSeed = crop({
+export const asparagusSeed: any = crop({
   cropType: cropType.ASPARAGUS,
   cropTimeline: [4, 2, 2, 1],
   growsInto: 'asparagus',
@@ -16,9 +16,9 @@ export const asparagusSeed = crop({
 
 /**
  * @property farmhand.module:items.asparagus
- * @type {farmhand.item}
+
  */
-export const asparagus = crop({
+export const asparagus: any = crop({
   ...fromSeed(asparagusSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/carrot.ts
+++ b/src/data/crops/carrot.ts
@@ -1,10 +1,8 @@
 import { crop, fromSeed } from '../crop.js'
 import { cropType } from '../../enums.js'
 
-/**
- * @type {farmhand.item}
- */
-export const carrotSeed = crop({
+
+export const carrotSeed: any = crop({
   cropType: cropType.CARROT,
   cropTimeline: [2, 1, 1, 1],
   growsInto: 'carrot',
@@ -13,10 +11,8 @@ export const carrotSeed = crop({
   tier: 1,
 })
 
-/**
- * @type {farmhand.item}
- */
-export const carrot = crop({
+
+export const carrot: any = crop({
   ...fromSeed(carrotSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/corn.ts
+++ b/src/data/crops/corn.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.cornSeed
- * @type {farmhand.item}
+
  */
-export const cornSeed = crop({
+export const cornSeed: any = crop({
   cropType: cropType.CORN,
   cropTimeline: [3, 1, 1, 1, 2, 2],
   growsInto: 'corn',
@@ -16,9 +16,9 @@ export const cornSeed = crop({
 
 /**
  * @property farmhand.module:items.corn
- * @type {farmhand.item}
+
  */
-export const corn = crop({
+export const corn: any = crop({
   ...fromSeed(cornSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/garlic.ts
+++ b/src/data/crops/garlic.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.garlicSeed
- * @type {farmhand.item}
+
  */
-export const garlicSeed = crop({
+export const garlicSeed: any = crop({
   cropType: cropType.GARLIC,
   cropTimeline: [2, 1, 1, 1],
   growsInto: 'garlic',
@@ -16,9 +16,9 @@ export const garlicSeed = crop({
 
 /**
  * @property farmhand.module:items.garlic
- * @type {farmhand.item}
+
  */
-export const garlic = crop({
+export const garlic: any = crop({
   ...fromSeed(garlicSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/grape.ts
+++ b/src/data/crops/grape.ts
@@ -1,17 +1,14 @@
 import { cropFamily, cropType, grapeVariety } from '../../enums.js'
 import { crop, cropVariety, fromSeed } from '../crop.js'
 
-/**
- * @param {farmhand.item | farmhand.cropVariety} item
- * @returns {item is farmhand.grape}
- */
+
 export const isGrape = item => {
   return 'cropFamily' in item && item.cropFamily === cropFamily.GRAPE
 }
 
 /**
- * @param {Partial<farmhand.grape> & { imageId: string; variety: farmhand.grapeVariety; wineId: string }} grapeProps
- * @returns {farmhand.grape}
+ * @param } grapeProps
+
  */
 const grape = (
   grapeProps: Partial<farmhand.grape> & {
@@ -31,9 +28,9 @@ const grape = (
 
 /**
  * @property farmhand.module:items.grapeSeed
- * @type {farmhand.item}
+
  */
-export const grapeSeed = crop({
+export const grapeSeed: any = crop({
   cropType: cropType.GRAPE,
   cropTimeline: [3, 4],
   growsInto: [
@@ -53,10 +50,8 @@ export const grapeSeed = crop({
   tier: 7,
 })
 
-/**
- * @type {Record<grapeVariety, string>}
- */
-export const grapeVarietyNameMap = {
+
+export const grapeVarietyNameMap: Record<grapeVariety, string> = {
   [grapeVariety.CHARDONNAY]: 'Chardonnay',
   [grapeVariety.SAUVIGNON_BLANC]: 'Sauvignon Blanc',
   //[grapeVariety.PINOT_BLANC]: 'Pinot Blanc',
@@ -73,7 +68,7 @@ export const grapeVarietyNameMap = {
  * @type {Record<grapeVariety, number>} The number value represents a wine's
  * value relative to a baseline of 1. Must be an integer.
  */
-export const wineVarietyValueMap = {
+export const wineVarietyValueMap: Record<grapeVariety, number> = {
   [grapeVariety.CHARDONNAY]: 1,
   [grapeVariety.SAUVIGNON_BLANC]: 8,
   //[grapeVariety.PINOT_BLANC]: 2,
@@ -88,9 +83,9 @@ export const wineVarietyValueMap = {
 
 /**
  * @property farmhand.module:items.grapeChardonnay
- * @type {farmhand.grape}
+
  */
-export const grapeChardonnay = grape({
+export const grapeChardonnay: any = grape({
   ...fromSeed(grapeSeed, {
     variantIdx: grapeSeed.growsInto?.indexOf('grape-chardonnay'),
   }),
@@ -102,9 +97,9 @@ export const grapeChardonnay = grape({
 
 /**
  * @property farmhand.module:items.grapeSauvignonBlanc
- * @type {farmhand.grape}
+
  */
-export const grapeSauvignonBlanc = grape({
+export const grapeSauvignonBlanc: any = grape({
   ...fromSeed(grapeSeed, {
     variantIdx: grapeSeed.growsInto?.indexOf('grape-sauvignon-blanc'),
   }),
@@ -116,7 +111,7 @@ export const grapeSauvignonBlanc = grape({
 
 /**
  * @property farmhand.module:items.grapePinotBlanc
- * @type {farmhand.grape}
+
  */
 // export const grapePinotBlanc = grape({
 // ...fromSeed(grapeSeed, { variantIdx: grapeSeed.growsInto?.indexOf('grape-pinot-blanc') }),
@@ -128,7 +123,7 @@ export const grapeSauvignonBlanc = grape({
 
 /**
  * @property farmhand.module:items.grapeMuscat
- * @type {farmhand.grape}
+
  */
 // export const grapeMuscat = grape({
 // ...fromSeed(grapeSeed, { variantIdx: grapeSeed.growsInto?.indexOf('grape-muscat') }),
@@ -140,7 +135,7 @@ export const grapeSauvignonBlanc = grape({
 
 /**
  * @property farmhand.module:items.grapeRiesling
- * @type {farmhand.grape}
+
  */
 // export const grapeRiesling = grape({
 // ...fromSeed(grapeSeed, { variantIdx: grapeSeed.growsInto?.indexOf('grape-riesling') }),
@@ -152,7 +147,7 @@ export const grapeSauvignonBlanc = grape({
 
 /**
  * @property farmhand.module:items.grapeMerlot
- * @type {farmhand.grape}
+
  */
 // export const grapeMerlot = grape({
 // ...fromSeed(grapeSeed, { variantIdx: grapeSeed.growsInto?.indexOf('grape-merlot') }),
@@ -164,9 +159,9 @@ export const grapeSauvignonBlanc = grape({
 
 /**
  * @property farmhand.module:items.grapeCabernetSauvignon
- * @type {farmhand.grape}
+
  */
-export const grapeCabernetSauvignon = grape({
+export const grapeCabernetSauvignon: any = grape({
   ...fromSeed(grapeSeed, {
     variantIdx: grapeSeed.growsInto?.indexOf('grape-cabernet-sauvignon'),
   }),
@@ -178,7 +173,7 @@ export const grapeCabernetSauvignon = grape({
 
 /**
  * @property farmhand.module:items.grapeSyrah
- * @type {farmhand.grape}
+
  */
 // export const grapeSyrah = grape({
 // ...fromSeed(grapeSeed, { variantIdx: grapeSeed.growsInto?.indexOf('grape-syrah') }),
@@ -190,9 +185,9 @@ export const grapeCabernetSauvignon = grape({
 
 /**
  * @property farmhand.module:items.grapeTempranillo
- * @type {farmhand.grape}
+
  */
-export const grapeTempranillo = grape({
+export const grapeTempranillo: any = grape({
   ...fromSeed(grapeSeed, {
     variantIdx: grapeSeed.growsInto?.indexOf('grape-tempranillo'),
   }),
@@ -204,9 +199,9 @@ export const grapeTempranillo = grape({
 
 /**
  * @property farmhand.module:items.grapeNebbiolo
- * @type {farmhand.grape}
+
  */
-export const grapeNebbiolo = grape({
+export const grapeNebbiolo: any = grape({
   ...fromSeed(grapeSeed, {
     variantIdx: grapeSeed.growsInto?.indexOf('grape-nebbiolo'),
   }),
@@ -216,10 +211,8 @@ export const grapeNebbiolo = grape({
   wineId: 'wine-nebbiolo',
 })
 
-/**
- * @type {Record<grapeVariety, farmhand.grape>}
- */
-export const grapeVarietyToGrapeItemMap = {
+
+export const grapeVarietyToGrapeItemMap: Record<grapeVariety, farmhand.grape> = {
   [grapeVariety.CHARDONNAY]: grapeChardonnay,
   [grapeVariety.SAUVIGNON_BLANC]: grapeSauvignonBlanc,
   //[grapeVariety.PINOT_BLANC]: grapePinotBlanc,

--- a/src/data/crops/jalapeno.ts
+++ b/src/data/crops/jalapeno.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.jalapenoSeed
- * @type {farmhand.item}
+
  */
-export const jalapenoSeed = crop({
+export const jalapenoSeed: any = crop({
   cropType: cropType.JALAPENO,
   cropTimeline: [2, 1, 1, 1],
   growsInto: 'jalapeno',
@@ -16,9 +16,9 @@ export const jalapenoSeed = crop({
 
 /**
  * @property farmhand.module:items.jalapeno
- * @type {farmhand.item}
+
  */
-export const jalapeno = crop({
+export const jalapeno: any = crop({
   ...fromSeed(jalapenoSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/olive.ts
+++ b/src/data/crops/olive.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.oliveSeed
- * @type {farmhand.item}
+
  */
-export const oliveSeed = crop({
+export const oliveSeed: any = crop({
   cropType: cropType.OLIVE,
   cropTimeline: [3, 6],
   growsInto: 'olive',
@@ -16,9 +16,9 @@ export const oliveSeed = crop({
 
 /**
  * @property farmhand.module:items.olive
- * @type {farmhand.item}
+
  */
-export const olive = crop({
+export const olive: any = crop({
   ...fromSeed(oliveSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/onion.ts
+++ b/src/data/crops/onion.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.onionSeed
- * @type {farmhand.item}
+
  */
-export const onionSeed = crop({
+export const onionSeed: any = crop({
   cropType: cropType.ONION,
   cropTimeline: [3, 1, 2, 1],
   growsInto: 'onion',
@@ -16,9 +16,9 @@ export const onionSeed = crop({
 
 /**
  * @property farmhand.module:items.onion
- * @type {farmhand.item}
+
  */
-export const onion = crop({
+export const onion: any = crop({
   ...fromSeed(onionSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/pea.ts
+++ b/src/data/crops/pea.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.peaSeed
- * @type {farmhand.item}
+
  */
-export const peaSeed = crop({
+export const peaSeed: any = crop({
   cropType: cropType.PEA,
   cropTimeline: [2, 3],
   growsInto: 'pea',
@@ -16,9 +16,9 @@ export const peaSeed = crop({
 
 /**
  * @property farmhand.module:items.pea
- * @type {farmhand.item}
+
  */
-export const pea = crop({
+export const pea: any = crop({
   ...fromSeed(peaSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/potato.ts
+++ b/src/data/crops/potato.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.potatoSeed
- * @type {farmhand.item}
+
  */
-export const potatoSeed = crop({
+export const potatoSeed: any = crop({
   cropType: cropType.POTATO,
   cropTimeline: [2, 1, 1, 1],
   growsInto: 'potato',
@@ -16,9 +16,9 @@ export const potatoSeed = crop({
 
 /**
  * @property farmhand.module:items.potato
- * @type {farmhand.item}
+
  */
-export const potato = crop({
+export const potato: any = crop({
   ...fromSeed(potatoSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/pumpkin.ts
+++ b/src/data/crops/pumpkin.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.pumpkinSeed
- * @type {farmhand.item}
+
  */
-export const pumpkinSeed = crop({
+export const pumpkinSeed: any = crop({
   cropType: cropType.PUMPKIN,
   cropTimeline: [3, 1, 1, 1, 1, 1],
   growsInto: 'pumpkin',
@@ -16,9 +16,9 @@ export const pumpkinSeed = crop({
 
 /**
  * @property farmhand.module:items.pumpkin
- * @type {farmhand.item}
+
  */
-export const pumpkin = crop({
+export const pumpkin: any = crop({
   ...fromSeed(pumpkinSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/soybean.ts
+++ b/src/data/crops/soybean.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.soybeanSeed
- * @type {farmhand.item}
+
  */
-export const soybeanSeed = crop({
+export const soybeanSeed: any = crop({
   cropType: cropType.SOYBEAN,
   cropTimeline: [2, 2],
   growsInto: 'soybean',
@@ -16,9 +16,9 @@ export const soybeanSeed = crop({
 
 /**
  * @property farmhand.module:items.soybean
- * @type {farmhand.item}
+
  */
-export const soybean = crop({
+export const soybean: any = crop({
   ...fromSeed(soybeanSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/spinach.ts
+++ b/src/data/crops/spinach.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.spinachSeed
- * @type {farmhand.item}
+
  */
-export const spinachSeed = crop({
+export const spinachSeed: any = crop({
   cropType: cropType.SPINACH,
   cropTimeline: [2, 4],
   growsInto: 'spinach',
@@ -16,9 +16,9 @@ export const spinachSeed = crop({
 
 /**
  * @property farmhand.module:items.spinach
- * @type {farmhand.item}
+
  */
-export const spinach = crop({
+export const spinach: any = crop({
   ...fromSeed(spinachSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/strawberry.ts
+++ b/src/data/crops/strawberry.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.strawberrySeed
- * @type {farmhand.item}
+
  */
-export const strawberrySeed = crop({
+export const strawberrySeed: any = crop({
   cropType: cropType.STRAWBERRY,
   cropTimeline: [6, 2],
   growsInto: 'strawberry',
@@ -16,9 +16,9 @@ export const strawberrySeed = crop({
 
 /**
  * @property farmhand.module:items.strawberry
- * @type {farmhand.item}
+
  */
-export const strawberry = crop({
+export const strawberry: any = crop({
   ...fromSeed(strawberrySeed),
   name: 'Strawberry',
 })

--- a/src/data/crops/sunflower.ts
+++ b/src/data/crops/sunflower.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.sunflowerSeed
- * @type {farmhand.item}
+
  */
-export const sunflowerSeed = crop({
+export const sunflowerSeed: any = crop({
   cropType: cropType.SUNFLOWER,
   cropTimeline: [1, 1, 1, 1, 1, 1],
   growsInto: 'sunflower',
@@ -16,9 +16,9 @@ export const sunflowerSeed = crop({
 
 /**
  * @property farmhand.module:items.sunflower
- * @type {farmhand.item}
+
  */
-export const sunflower = crop({
+export const sunflower: any = crop({
   ...fromSeed(sunflowerSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/sweet-potato.ts
+++ b/src/data/crops/sweet-potato.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.sweetPotatoSeed
- * @type {farmhand.item}
+
  */
-export const sweetPotatoSeed = crop({
+export const sweetPotatoSeed: any = crop({
   cropType: cropType.SWEET_POTATO,
   cropTimeline: [2, 1, 1, 2, 2],
   growsInto: 'sweet-potato',
@@ -16,9 +16,9 @@ export const sweetPotatoSeed = crop({
 
 /**
  * @property farmhand.module:items.sweetPotato
- * @type {farmhand.item}
+
  */
-export const sweetPotato = crop({
+export const sweetPotato: any = crop({
   ...fromSeed(sweetPotatoSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/tomato.ts
+++ b/src/data/crops/tomato.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.tomatoSeed
- * @type {farmhand.item}
+
  */
-export const tomatoSeed = crop({
+export const tomatoSeed: any = crop({
   cropType: cropType.TOMATO,
   cropTimeline: [2, 1, 1, 1, 2, 2, 2],
   growsInto: 'tomato',
@@ -16,9 +16,9 @@ export const tomatoSeed = crop({
 
 /**
  * @property farmhand.module:items.tomato
- * @type {farmhand.item}
+
  */
-export const tomato = crop({
+export const tomato: any = crop({
   ...fromSeed(tomatoSeed, {
     canBeFermented: true,
   }),

--- a/src/data/crops/watermelon.ts
+++ b/src/data/crops/watermelon.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.watermelonSeed
- * @type {farmhand.item}
+
  */
-export const watermelonSeed = crop({
+export const watermelonSeed: any = crop({
   cropType: cropType.WATERMELON,
   cropTimeline: [2, 10],
   growsInto: 'watermelon',
@@ -16,9 +16,9 @@ export const watermelonSeed = crop({
 
 /**
  * @property farmhand.module:items.watermelon
- * @type {farmhand.item}
+
  */
-export const watermelon = crop({
+export const watermelon: any = crop({
   ...fromSeed(watermelonSeed),
   name: 'Watermelon',
 })

--- a/src/data/crops/wheat.ts
+++ b/src/data/crops/wheat.ts
@@ -3,9 +3,9 @@ import { cropType } from '../../enums.js'
 
 /**
  * @property farmhand.module:items.wheatSeed
- * @type {farmhand.item}
+
  */
-export const wheatSeed = crop({
+export const wheatSeed: any = crop({
   cropType: cropType.WHEAT,
   cropTimeline: [1, 1],
   growsInto: 'wheat',
@@ -16,9 +16,9 @@ export const wheatSeed = crop({
 
 /**
  * @property farmhand.module:items.wheat
- * @type {farmhand.item}
+
  */
-export const wheat = crop({
+export const wheat: any = crop({
   ...fromSeed(wheatSeed),
   name: 'Wheat',
 })

--- a/src/data/items-map.ts
+++ b/src/data/items-map.ts
@@ -3,12 +3,12 @@ import * as items from '../data/items.js'
 /**
  * ⚠️⚠️⚠️ This is a low-level object that is UNSAFE to use directly outside of
  * initial bootup. Use itemsMap in src/data/maps.js instead.
- * @type {Object.<string, farmhand.item>}
+
  * @deprecated This is not actually deprecated. It's just marked as such to
  * make it more obvious during development that this should generally not be
  * used directly.
  */
-const itemsMap = {
+const itemsMap: Record<string, farmhand.item> = {
   ...Object.keys(items).reduce((acc, itemName) => {
     const item = items[itemName]
     acc[item.id] = item

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -100,9 +100,9 @@ export {
 
 /**
  * @property farmhand.module:items.rainbowFertilizer
- * @type {farmhand.item}
+
  */
-export const rainbowFertilizer = freeze({
+export const rainbowFertilizer: any = freeze({
   description:
     'Helps crops grow a little faster and automatically replants them upon harvesting. Consumes seeds upon replanting and disappears if none are available. Also works for Scarecrows.',
   enablesFieldMode: fieldMode.FERTILIZE,
@@ -118,9 +118,9 @@ export const rainbowFertilizer = freeze({
 
 /**
  * @property farmhand.module:items.sprinkler
- * @type {farmhand.item}
+
  */
-export const sprinkler = freeze({
+export const sprinkler: any = freeze({
   description: 'Automatically waters adjacent plants every day.',
   enablesFieldMode: fieldMode.SET_SPRINKLER,
   // Note: The actual hoveredPlotRangeSize of sprinklers grows with the
@@ -135,9 +135,9 @@ export const sprinkler = freeze({
 
 /**
  * @property farmhand.module:items.scarecrow
- * @type {farmhand.item}
+
  */
-export const scarecrow = freeze({
+export const scarecrow: any = freeze({
   description:
     'Prevents crows from eating your crops. One scarecrow covers an entire field, but they are afraid of storms.',
   enablesFieldMode: fieldMode.SET_SCARECROW,
@@ -160,9 +160,9 @@ export const scarecrow = freeze({
 
 /**
  * @property farmhand.module:items.cowFeed
- * @type {farmhand.item}
+
  */
-export const cowFeed = freeze({
+export const cowFeed: any = freeze({
   id: COW_FEED_ITEM_ID,
   description:
     'Each cow automatically consumes one unit of Cow Feed per day. Fed cows gain and maintain weight.',
@@ -173,9 +173,9 @@ export const cowFeed = freeze({
 
 /**
  * @property farmhand.module:items.huggingMachine
- * @type {farmhand.item}
+
  */
-export const huggingMachine = freeze({
+export const huggingMachine: any = freeze({
   id: HUGGING_MACHINE_ITEM_ID,
   description: 'Automatically hugs one cow three times every day.',
   name: 'Hugging Machine',
@@ -185,9 +185,9 @@ export const huggingMachine = freeze({
 
 /**
  * @property farmhand.module:items.milk1
- * @type {farmhand.item}
+
  */
-export const milk1 = freeze({
+export const milk1: any = freeze({
   id: 'milk-1',
   name: 'Grade C Milk',
   type: /** @type {farmhand.itemType} */ MILK,
@@ -196,9 +196,9 @@ export const milk1 = freeze({
 
 /**
  * @property farmhand.module:items.milk2
- * @type {farmhand.item}
+
  */
-export const milk2 = freeze({
+export const milk2: any = freeze({
   id: 'milk-2',
   name: 'Grade B Milk',
   type: /** @type {farmhand.itemType} */ MILK,
@@ -207,9 +207,9 @@ export const milk2 = freeze({
 
 /**
  * @property farmhand.module:items.milk3
- * @type {farmhand.item}
+
  */
-export const milk3 = freeze({
+export const milk3: any = freeze({
   id: 'milk-3',
   name: 'Grade A Milk',
   type: /** @type {farmhand.itemType} */ MILK,
@@ -218,9 +218,9 @@ export const milk3 = freeze({
 
 /**
  * @property farmhand.module:items.rainbowMilk1
- * @type {farmhand.item}
+
  */
-export const rainbowMilk1 = freeze({
+export const rainbowMilk1: any = freeze({
   id: 'rainbow-milk-1',
   name: 'Grade C Rainbow Milk',
   type: /** @type {farmhand.itemType} */ MILK,
@@ -229,9 +229,9 @@ export const rainbowMilk1 = freeze({
 
 /**
  * @property farmhand.module:items.rainbowMilk2
- * @type {farmhand.item}
+
  */
-export const rainbowMilk2 = freeze({
+export const rainbowMilk2: any = freeze({
   id: 'rainbow-milk-2',
   name: 'Grade B Rainbow Milk',
   type: /** @type {farmhand.itemType} */ MILK,
@@ -240,9 +240,9 @@ export const rainbowMilk2 = freeze({
 
 /**
  * @property farmhand.module:items.rainbowMilk3
- * @type {farmhand.item}
+
  */
-export const rainbowMilk3 = freeze({
+export const rainbowMilk3: any = freeze({
   id: 'rainbow-milk-3',
   name: 'Grade A Rainbow Milk',
   type: /** @type {farmhand.itemType} */ MILK,
@@ -251,9 +251,9 @@ export const rainbowMilk3 = freeze({
 
 /**
  * @property farmhand.module:items.chocolateMilk
- * @type {farmhand.item}
+
  */
-export const chocolateMilk = freeze({
+export const chocolateMilk: any = freeze({
   id: 'chocolate-milk',
   name: 'Chocolate Milk',
   type: /** @type {farmhand.itemType} */ MILK,

--- a/src/data/maps.ts
+++ b/src/data/maps.ts
@@ -62,19 +62,15 @@ for (let toolType of Object.keys(upgrades)) {
   }
 }
 
-/**
- * @type {Object.<string, farmhand.item>}
- */
-export const itemsMap = {
+
+export const itemsMap: Record<string, farmhand.item> = {
   ...baseItemsMap,
   ...recipesMap,
   ...upgradesMap,
 }
 
-/**
- * @type {Object.<string, farmhand.item>}
- */
-export const fermentableItemsMap = Object.fromEntries(
+
+export const fermentableItemsMap: Record<string, farmhand.item> = Object.fromEntries(
   Object.entries(itemsMap).filter(([itemId]) => {
     const item = itemsMap[itemId]
 
@@ -82,10 +78,8 @@ export const fermentableItemsMap = Object.fromEntries(
   })
 )
 
-/**
- * @type {Object.<string, farmhand.seedItem>}
- */
-export const cropItemIdToSeedItemMap = Object.entries(baseItemsMap).reduce(
+
+export const cropItemIdToSeedItemMap: Record<string, farmhand.seedItem> = Object.entries(baseItemsMap).reduce(
   (acc, [itemId, item]) => {
     const { growsInto } = item as { growsInto?: string | string[] }
     if (growsInto) {
@@ -101,10 +95,8 @@ export const cropItemIdToSeedItemMap = Object.entries(baseItemsMap).reduce(
   {}
 )
 
-/**
- * @type {Object.<string, string|Array.<string>>}
- */
-export const cropTypeToIdMap = {
+
+export const cropTypeToIdMap: Record<string, string|string[]> = {
   [ASPARAGUS]: 'asparagus',
   [CARROT]: 'carrot',
   [CORN]: 'corn',

--- a/src/data/ores/bronzeOre.ts
+++ b/src/data/ores/bronzeOre.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.bronzeOre
- * @type {farmhand.item}
+
  */
-export const bronzeOre = freeze({
+export const bronzeOre: any = freeze({
   description: 'A piece of bronze ore.',
   doesPriceFluctuate: true,
   id: 'bronze-ore',

--- a/src/data/ores/coal.ts
+++ b/src/data/ores/coal.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.coal
- * @type {farmhand.item}
+
  */
-export const coal = freeze({
+export const coal: any = freeze({
   description: 'A piece of coal.',
   doesPriceFluctuate: false,
   id: 'coal',

--- a/src/data/ores/goldOre.ts
+++ b/src/data/ores/goldOre.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.goldOre
- * @type {farmhand.item}
+
  */
-export const goldOre = freeze({
+export const goldOre: any = freeze({
   description: 'A piece of gold ore.',
   doesPriceFluctuate: true,
   id: 'gold-ore',

--- a/src/data/ores/ironOre.ts
+++ b/src/data/ores/ironOre.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.ironOre
- * @type {farmhand.item}
+
  */
-export const ironOre = freeze({
+export const ironOre: any = freeze({
   description: 'A piece of iron ore.',
   doesPriceFluctuate: true,
   id: 'iron-ore',

--- a/src/data/ores/saltRock.ts
+++ b/src/data/ores/saltRock.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.saltRock
- * @type {farmhand.item}
+
  */
-export const saltRock = freeze({
+export const saltRock: any = freeze({
   description: 'A large chunk of salt.',
   doesPriceFluctuate: true,
   id: 'salt-rock',

--- a/src/data/ores/silverOre.ts
+++ b/src/data/ores/silverOre.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.silverOre
- * @type {farmhand.item}
+
  */
-export const silverOre = freeze({
+export const silverOre: any = freeze({
   description: 'A piece of silver ore.',
   doesPriceFluctuate: true,
   id: 'silver-ore',

--- a/src/data/ores/stone.ts
+++ b/src/data/ores/stone.ts
@@ -5,9 +5,9 @@ const { freeze } = Object
 
 /**
  * @property farmhand.module:items.stone
- * @type {farmhand.item}
+
  */
-export const stone = freeze({
+export const stone: any = freeze({
   description: 'A piece of rock.',
   doesPriceFluctuate: false,
   id: 'stone',

--- a/src/data/recipes.ts
+++ b/src/data/recipes.ts
@@ -15,8 +15,8 @@ import { grapeVarietyNameMap } from './crops/grape.js'
 const itemsMap = { ...baseItemsMap }
 
 /**
- * @param {Omit<farmhand.recipe, 'type' | 'value'> & { type?: string, value?: number }} partialRecipe
- * @returns {farmhand.recipe}
+ * @param } partialRecipe
+
  */
 const convertToRecipe = partialRecipe => {
   const recipe = Object.freeze({
@@ -39,9 +39,9 @@ const convertToRecipe = partialRecipe => {
 
 /**
  * @property farmhand.module:recipes.salt
- * @type {farmhand.recipe}
+
  */
-export const salt = convertToRecipe({
+export const salt: any = convertToRecipe({
   id: 'salt',
   name: 'Salt',
   ingredients: {
@@ -54,9 +54,9 @@ export const salt = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.flour
- * @type {farmhand.recipe}
+
  */
-export const flour = convertToRecipe({
+export const flour: any = convertToRecipe({
   id: 'flour',
   name: 'Flour',
   ingredients: {
@@ -68,9 +68,9 @@ export const flour = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.yeast
- * @type {farmhand.recipe}
+
  */
-export const yeast = convertToRecipe({
+export const yeast: any = convertToRecipe({
   id: 'yeast',
   name: 'Yeast',
   ingredients: {
@@ -80,10 +80,7 @@ export const yeast = convertToRecipe({
   recipeType: /** @type {farmhand.recipeType} */ recipeType.KITCHEN,
 })
 
-/**
- * @param {farmhand.grape} grape
- * @returns {farmhand.wine}
- */
+
 const getWineRecipeFromGrape = grape => {
   return {
     ...convertToRecipe({
@@ -104,9 +101,9 @@ const getWineRecipeFromGrape = grape => {
 
 /**
  * @property farmhand.module:recipes.bread
- * @type {farmhand.recipe}
+
  */
-export const bread = convertToRecipe({
+export const bread: any = convertToRecipe({
   id: 'bread',
   name: 'Bread',
   ingredients: {
@@ -121,9 +118,9 @@ export const bread = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.butter
- * @type {farmhand.recipe}
+
  */
-export const butter = convertToRecipe({
+export const butter: any = convertToRecipe({
   id: 'butter',
   name: 'Butter',
   ingredients: {
@@ -135,9 +132,9 @@ export const butter = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.sunButter
- * @type {farmhand.recipe}
+
  */
-export const sunButter = convertToRecipe({
+export const sunButter: any = convertToRecipe({
   id: 'sun-butter',
   name: 'Sun Butter',
   ingredients: {
@@ -163,9 +160,9 @@ export const oliveOil = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.cheese
- * @type {farmhand.recipe}
+
  */
-export const cheese = convertToRecipe({
+export const cheese: any = convertToRecipe({
   id: 'cheese',
   name: 'Cheese',
   ingredients: {
@@ -177,9 +174,9 @@ export const cheese = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.rainbowCheese
- * @type {farmhand.recipe}
+
  */
-export const rainbowCheese = convertToRecipe({
+export const rainbowCheese: any = convertToRecipe({
   id: 'rainbowCheese',
   name: 'Rainbow Cheese',
   ingredients: {
@@ -191,9 +188,9 @@ export const rainbowCheese = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.chocolate
- * @type {farmhand.recipe}
+
  */
-export const chocolate = convertToRecipe({
+export const chocolate: any = convertToRecipe({
   id: 'chocolate',
   name: 'Chocolate',
   ingredients: {
@@ -205,9 +202,9 @@ export const chocolate = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.carrotSoup
- * @type {farmhand.recipe}
+
  */
-export const carrotSoup = convertToRecipe({
+export const carrotSoup: any = convertToRecipe({
   id: 'carrot-soup',
   name: 'Carrot Soup',
   ingredients: {
@@ -219,9 +216,9 @@ export const carrotSoup = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.jackolantern
- * @type {farmhand.recipe}
+
  */
-export const jackolantern = convertToRecipe({
+export const jackolantern: any = convertToRecipe({
   id: 'jackolantern',
   name: "Jack-o'-lantern",
   ingredients: {
@@ -233,9 +230,9 @@ export const jackolantern = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.spaghetti
- * @type {farmhand.recipe}
+
  */
-export const spaghetti = convertToRecipe({
+export const spaghetti: any = convertToRecipe({
   id: 'spaghetti',
   name: 'Spaghetti',
   ingredients: {
@@ -250,9 +247,9 @@ export const spaghetti = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.frenchOnionSoup
- * @type {farmhand.recipe}
+
  */
-export const frenchOnionSoup = convertToRecipe({
+export const frenchOnionSoup: any = convertToRecipe({
   id: 'french-onion-soup',
   name: 'French Onion Soup',
   ingredients: {
@@ -268,9 +265,9 @@ export const frenchOnionSoup = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.burger
- * @type {farmhand.recipe}
+
  */
-export const burger = convertToRecipe({
+export const burger: any = convertToRecipe({
   id: 'burger',
   name: 'Burger',
   ingredients: {
@@ -293,9 +290,9 @@ export const burger = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.summerSalad
- * @type {farmhand.recipe}
+
  */
-export const summerSalad = convertToRecipe({
+export const summerSalad: any = convertToRecipe({
   id: 'summer-salad',
   name: 'Summer Salad',
   ingredients: {
@@ -312,9 +309,9 @@ export const summerSalad = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.soyMilk
- * @type {farmhand.recipe}
+
  */
-export const soyMilk = convertToRecipe({
+export const soyMilk: any = convertToRecipe({
   id: 'soy-milk',
   name: 'Soy Milk',
   ingredients: {
@@ -326,9 +323,9 @@ export const soyMilk = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.chocolateSoyMilk
- * @type {farmhand.recipe}
+
  */
-export const chocolateSoyMilk = convertToRecipe({
+export const chocolateSoyMilk: any = convertToRecipe({
   id: 'chocolate-soy-milk',
   name: 'Chocolate Soy Milk',
   ingredients: {
@@ -343,9 +340,9 @@ export const chocolateSoyMilk = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.tofu
- * @type {farmhand.recipe}
+
  */
-export const tofu = convertToRecipe({
+export const tofu: any = convertToRecipe({
   id: 'tofu',
   name: 'Tofu',
   ingredients: {
@@ -357,9 +354,9 @@ export const tofu = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.chicknPotPie
- * @type {farmhand.recipe}
+
  */
-export const chicknPotPie = convertToRecipe({
+export const chicknPotPie: any = convertToRecipe({
   id: 'chickn-pot-pie',
   name: "Chick'n Pot Pie",
   ingredients: {
@@ -380,9 +377,9 @@ export const chicknPotPie = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.hotSauce
- * @type {farmhand.recipe}
+
  */
-export const hotSauce = convertToRecipe({
+export const hotSauce: any = convertToRecipe({
   id: 'hot-sauce',
   name: 'Hot Sauce',
   ingredients: {
@@ -395,9 +392,9 @@ export const hotSauce = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.salsa
- * @type {farmhand.recipe}
+
  */
-export const salsa = convertToRecipe({
+export const salsa: any = convertToRecipe({
   id: 'salsa',
   name: 'Salsa',
   ingredients: {
@@ -416,9 +413,9 @@ export const salsa = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.spicyCheese
- * @type {farmhand.recipe}
+
  */
-export const spicyCheese = convertToRecipe({
+export const spicyCheese: any = convertToRecipe({
   id: 'spicy-cheese',
   name: 'Spicy Cheese',
   ingredients: {
@@ -433,9 +430,9 @@ export const spicyCheese = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.vegetableOil
- * @type {farmhand.recipe}
+
  */
-export const vegetableOil = convertToRecipe({
+export const vegetableOil: any = convertToRecipe({
   id: 'vegetable-oil',
   name: 'Vegetable Oil',
   ingredients: {
@@ -447,9 +444,9 @@ export const vegetableOil = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.friedTofu
- * @type {farmhand.recipe}
+
  */
-export const friedTofu = convertToRecipe({
+export const friedTofu: any = convertToRecipe({
   id: 'fried-tofu',
   name: 'Deep Fried Tofu',
   ingredients: {
@@ -464,9 +461,9 @@ export const friedTofu = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.spicyPickledGarlic
- * @type {farmhand.recipe}
+
  */
-export const spicyPickledGarlic = convertToRecipe({
+export const spicyPickledGarlic: any = convertToRecipe({
   id: 'spicy-pickled-garlic',
   name: 'Spicy Pickled Garlic',
   ingredients: {
@@ -481,9 +478,9 @@ export const spicyPickledGarlic = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.garlicFries
- * @type {farmhand.recipe}
+
  */
-export const garlicFries = convertToRecipe({
+export const garlicFries: any = convertToRecipe({
   id: 'garlic-fries',
   name: 'Garlic Fries',
   ingredients: {
@@ -500,9 +497,9 @@ export const garlicFries = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.garlicBread
- * @type {farmhand.recipe}
+
  */
-export const garlicBread = convertToRecipe({
+export const garlicBread: any = convertToRecipe({
   id: 'garlic-bread',
   name: 'Garlic Bread',
   ingredients: {
@@ -519,9 +516,9 @@ export const garlicBread = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.strawberryJam
- * @type {farmhand.recipe}
+
  */
-export const strawberryJam = convertToRecipe({
+export const strawberryJam: any = convertToRecipe({
   id: 'strawberry-jam',
   name: 'Strawberry Jam',
   ingredients: {
@@ -533,9 +530,9 @@ export const strawberryJam = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.popcorn
- * @type {farmhand.recipe}
+
  */
-export const popcorn = convertToRecipe({
+export const popcorn: any = convertToRecipe({
   id: 'popcorn',
   name: 'Popcorn',
   ingredients: {
@@ -550,9 +547,9 @@ export const popcorn = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.pumpkinPie
- * @type {farmhand.recipe}
+
  */
-export const pumpkinPie = convertToRecipe({
+export const pumpkinPie: any = convertToRecipe({
   id: 'pumpkin-pie',
   name: 'Pumpkin Pie',
   ingredients: {
@@ -569,9 +566,9 @@ export const pumpkinPie = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.sweetPotatoPie
- * @type {farmhand.recipe}
+
  */
-export const sweetPotatoPie = convertToRecipe({
+export const sweetPotatoPie: any = convertToRecipe({
   id: 'sweet-potato-pie',
   name: 'Sweet Potato Pie',
   ingredients: {
@@ -588,9 +585,9 @@ export const sweetPotatoPie = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.sweetPotatoFries
- * @type {farmhand.recipe}
+
  */
-export const sweetPotatoFries = convertToRecipe({
+export const sweetPotatoFries: any = convertToRecipe({
   id: 'sweet-potato-fries',
   name: 'Sweet Potato Fries',
   ingredients: {
@@ -604,9 +601,9 @@ export const sweetPotatoFries = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.onionRings
- * @type {farmhand.recipe}
+
  */
-export const onionRings = convertToRecipe({
+export const onionRings: any = convertToRecipe({
   id: 'onion-rings',
   name: 'Onion Rings',
   ingredients: {
@@ -626,9 +623,9 @@ export const onionRings = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.bronzeIngot
- * @type {farmhand.recipe}
+
  */
-export const bronzeIngot = convertToRecipe({
+export const bronzeIngot: any = convertToRecipe({
   id: 'bronze-ingot',
   name: 'Bronze Ingot',
   ingredients: {
@@ -643,9 +640,9 @@ export const bronzeIngot = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.ironIngot
- * @type {farmhand.recipe}
+
  */
-export const ironIngot = convertToRecipe({
+export const ironIngot: any = convertToRecipe({
   id: 'iron-ingot',
   name: 'Iron Ingot',
   ingredients: {
@@ -660,9 +657,9 @@ export const ironIngot = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.silverIngot
- * @type {farmhand.recipe}
+
  */
-export const silverIngot = convertToRecipe({
+export const silverIngot: any = convertToRecipe({
   id: 'silver-ingot',
   name: 'Silver Ingot',
   ingredients: {
@@ -677,9 +674,9 @@ export const silverIngot = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.goldIngot
- * @type {farmhand.recipe}
+
  */
-export const goldIngot = convertToRecipe({
+export const goldIngot: any = convertToRecipe({
   id: 'gold-ingot',
   name: 'Gold Ingot',
   ingredients: {
@@ -708,9 +705,9 @@ export const compost = convertToRecipe({
 
 /**
  * @property farmhand.module:recipes.fertilizer
- * @type {farmhand.item}
+
  */
-export const fertilizer = convertToRecipe({
+export const fertilizer: any = convertToRecipe({
   id: 'fertilizer',
   name: 'Fertilizer',
   ingredients: {

--- a/src/data/shop-inventory.ts
+++ b/src/data/shop-inventory.ts
@@ -1,5 +1,4 @@
-/**
- */
+
 
 import {
   // Plantable crops
@@ -31,7 +30,7 @@ import {
 import { fertilizer } from './recipes.js'
 
 /** @type {farmhand.item[]} */
-const inventory = [
+const inventory: any = [
   // Plantable crops
   asparagusSeed,
   carrotSeed,

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -25,10 +25,8 @@ const coalNeededForIngots = (ingotId, amount = 1) => {
 const { bronzeIngot, ironIngot, silverIngot, goldIngot } = recipes
 const { coal } = items
 
-/**
- * @type {farmhand.upgradesMetadata}
- */
-const upgrades = {
+
+const upgrades: any = {
   [toolType.HOE]: {
     [toolLevel.DEFAULT]: {
       id: 'hoe-default',

--- a/src/factories/CoalFactory.ts
+++ b/src/factories/CoalFactory.ts
@@ -9,7 +9,7 @@ import { chooseRandom } from '../utils/index.js'
 export default class CoalFactory extends Factory {
   /**
    * Generate resources
-   * @returns {Array.<farmhand.item>} an array of coal and stone resources
+   * @returns an array of coal and stone resources
    */
   generate(): farmhand.item[] {
     const spawns: farmhand.item[] = []
@@ -27,19 +27,19 @@ export default class CoalFactory extends Factory {
 
   /**
    * Spawn a piece of coal
-   * @returns {Object} coal item
+   * @returns coal item
    * @private
    */
-  spawnCoal() {
+  spawnCoal(): Object {
     return coal
   }
 
   /**
    * Spawn a piece of stone
-   * @returns {Object} stone item
+   * @returns stone item
    * @private
    */
-  spawnStone() {
+  spawnStone(): Object {
     return stone
   }
 }

--- a/src/factories/OreFactory.ts
+++ b/src/factories/OreFactory.ts
@@ -24,18 +24,18 @@ export default class OreFactory extends Factory {
 
   /**
    * Generate resources
-   * @returns {Array.<farmhand.item>} an array of ore resources
+   * @returns an array of ore resources
    */
-  generate() {
+  generate(): any {
     return [this.spawn()]
   }
 
   /**
    * Spawn a random ore
-   * @returns {Object} an object representing an ore
+   * @returns an object representing an ore
    * @private
    **/
-  spawn() {
+  spawn(): Object {
     const spawnedOption = randomChoice(this.oreOptions)
     return spawnedOption.ore
   }

--- a/src/factories/ResourceFactory.ts
+++ b/src/factories/ResourceFactory.ts
@@ -47,10 +47,10 @@ export default class ResourceFactory {
 
   /**
    * Retrieve a reusable instance of ResourceFactory
-   * @returns {ResourceFactory}
+
    * @static
    */
-  static instance() {
+  static instance(): ResourceFactory {
     if (!instance) {
       instance = new ResourceFactory()
     }
@@ -60,10 +60,10 @@ export default class ResourceFactory {
 
   /**
    * Generate an instance for specific factory
-   * @param {farmhand.itemType} type
-   * @returns {?Factory} A factory if one exists for type, default return is null
+
+   * @returns A factory if one exists for type, default return is null
    */
-  static generateFactoryInstance(type) {
+  static generateFactoryInstance(type: any): Factory {
     switch (type) {
       case itemType.STONE:
         return new StoneFactory()
@@ -82,7 +82,7 @@ export default class ResourceFactory {
   /**
    * Retrieve a specific factory for generating resources. Will create and cache
    * a factory instance for reuse.
-   * @returns {?Factory}
+
    */
   static getFactoryForItemType = type => {
     if (!factoryInstances[type]) {
@@ -94,9 +94,9 @@ export default class ResourceFactory {
 
   /**
    * Use dice roll and resource factories to generate resources at random
-   * @returns {Array.<farmhand.item>} array of resource objects
+   * @returns array of resource objects
    */
-  generateResources(shovelLevel) {
+  generateResources(shovelLevel): any {
     let resources: farmhand.item[] = []
 
     let spawnChance = RESOURCE_SPAWN_CHANCE

--- a/src/factories/StoneFactory.ts
+++ b/src/factories/StoneFactory.ts
@@ -20,9 +20,9 @@ const spawnableResources = [
 export default class StoneFactory extends Factory {
   /**
    * Generate resources
-   * @returns {Array.<farmhand.item>} an array of stone and coal resources
+   * @returns an array of stone and coal resources
    */
-  generate() {
+  generate(): any {
     const resources: farmhand.item[] = []
 
     for (const { resource, spawnChance } of spawnableResources) {

--- a/src/game-logic/reducers/addCowToInventory.ts
+++ b/src/game-logic/reducers/addCowToInventory.ts
@@ -1,10 +1,6 @@
 // TODO: Add tests for this reducer
-/**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @returns {farmhand.state}
- */
-export const addCowToInventory = (state, cow) => {
+
+export const addCowToInventory = (state: any, cow: any): any => {
   const { cowInventory } = state
 
   return {

--- a/src/game-logic/reducers/addExperience.ts
+++ b/src/game-logic/reducers/addExperience.ts
@@ -2,12 +2,8 @@ import { levelAchieved } from '../../utils/levelAchieved.js'
 
 import { processLevelUp } from './processLevelUp.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} amount
- * @returns {farmhand.state}
- */
-export const addExperience = (state, amount) => {
+
+export const addExperience = (state: any, amount: number): any => {
   const { experience } = state
   const oldLevel = levelAchieved(experience)
 

--- a/src/game-logic/reducers/addItemToInventory.ts
+++ b/src/game-logic/reducers/addItemToInventory.ts
@@ -3,18 +3,18 @@ import { inventorySpaceRemaining } from '../../utils/index.js'
 /**
  * Only adds as many items as there is room in the inventory for unless
  * allowInventoryOverage is true.
- * @param {farmhand.state} state
- * @param {farmhand.item} item
- * @param {number} [howMany=1]
- * @param {boolean} [allowInventoryOverage=false]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+ * @param [allowInventoryOverage=false]
+
  */
 export const addItemToInventory = (
-  state,
-  item,
-  howMany = 1,
-  allowInventoryOverage = false
-) => {
+  state: any,
+  item: any,
+  howMany?: number = 1,
+  allowInventoryOverage?: boolean = false
+): any => {
   const { id } = item
   const inventory = [...state.inventory]
 

--- a/src/game-logic/reducers/addKegToCellarInventory.ts
+++ b/src/game-logic/reducers/addKegToCellarInventory.ts
@@ -4,9 +4,9 @@
 /**
  * ⚠️ It is the responsibility of the consumer of this reducer to ensure that
  * there is sufficient space in cellarInventory.
- * @param {state} state
- * @param {keg} keg
- * @returns {state}
+
+
+
  */
 export const addKegToCellarInventory = (state, keg) => {
   const { cellarInventory } = state

--- a/src/game-logic/reducers/addPeer.ts
+++ b/src/game-logic/reducers/addPeer.ts
@@ -1,10 +1,10 @@
 // TODO: Add tests for this reducer
 /**
- * @param {farmhand.state} state
- * @param {string} peerId The peer to add
- * @returns {farmhand.state}
+
+ * @param peerId The peer to add
+
  */
-export const addPeer = (state, peerId) => {
+export const addPeer = (state: any, peerId: string): any => {
   const peers = { ...state.peers }
   peers[peerId] = null
 

--- a/src/game-logic/reducers/addRevenue.ts
+++ b/src/game-logic/reducers/addRevenue.ts
@@ -1,12 +1,8 @@
 import { moneyTotal } from '../../utils/index.js'
 
 // TODO: Add tests for this reducer
-/**
- * @param {farmhand.state} state
- * @param {number} revenueToAdd
- * @returns {farmhand.state}
- */
-export const addRevenue = (state, revenueToAdd) => {
+
+export const addRevenue = (state: any, revenueToAdd: number): any => {
   const { money, revenue, todaysRevenue } = state
 
   return {

--- a/src/game-logic/reducers/adjustLoan.ts
+++ b/src/game-logic/reducers/adjustLoan.ts
@@ -4,12 +4,12 @@ import { LOAN_INCREASED, LOAN_PAYOFF } from '../../templates.js'
 import { showNotification } from './showNotification.js'
 
 /**
- * @param {farmhand.state} state
- * @param {number} adjustmentAmount This should be a negative number if the
+
+ * @param adjustmentAmount This should be a negative number if the
  * loan is being paid down, positive if a loan is being taken out.
- * @returns {farmhand.state}
+
  */
-export const adjustLoan = (state, adjustmentAmount) => {
+export const adjustLoan = (state: any, adjustmentAmount: number): any => {
   const loanBalance = moneyTotal(state.loanBalance, adjustmentAmount)
   const newMoney = moneyTotal(state.money, adjustmentAmount)
 

--- a/src/game-logic/reducers/applyCrows.ts
+++ b/src/game-logic/reducers/applyCrows.ts
@@ -9,10 +9,10 @@ import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 import { fieldHasScarecrow } from './helpers.js'
 
 /**
- * @param {farmhand.state} state
+
  * @callback {forEachPlotCallback} callback
  */
-export function forEachPlot(state, callback) {
+export function forEachPlot(state: any, callback) {
   state.field.forEach((row, y) =>
     row.forEach((plotContents, x) => callback(plotContents, x, y))
   )
@@ -20,15 +20,12 @@ export function forEachPlot(state, callback) {
 
 /**
  * @callback forEachPlotCallback
- * @param {object} plotContents - the contents of the plot
- * @param {number} x - the X coordinate for the plot
- * @param {number} y - the Y coordinate for the plot
+ * @param plotContents - the contents of the plot
+ * @param x - the X coordinate for the plot
+ * @param y - the Y coordinate for the plot
  */
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const applyCrows = state => {
   const { field, purchasedField } = state
 

--- a/src/game-logic/reducers/applyLoanInterest.ts
+++ b/src/game-logic/reducers/applyLoanInterest.ts
@@ -2,10 +2,7 @@ import { castToMoney, moneyTotal } from '../../utils/index.js'
 import { LOAN_INTEREST_RATE } from '../../constants.js'
 import { LOAN_BALANCE_NOTIFICATION } from '../../templates.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const applyLoanInterest = state => {
   const newLoanBalance = moneyTotal(
     state.loanBalance,

--- a/src/game-logic/reducers/applyPrecipitation.ts
+++ b/src/game-logic/reducers/applyPrecipitation.ts
@@ -15,10 +15,7 @@ import {
 import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 import { waterField } from './waterField.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const applyPrecipitation = state => {
   let { field } = state
   let scarecrowsConsumedByReplanting = 0

--- a/src/game-logic/reducers/changeCowAutomaticHugState.ts
+++ b/src/game-logic/reducers/changeCowAutomaticHugState.ts
@@ -6,13 +6,8 @@ import { addItemToInventory } from './addItemToInventory.js'
 import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 import { modifyCow } from './modifyCow.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @param {boolean} doUseHuggingMachine
- * @returns {farmhand.state}
- */
-export const changeCowAutomaticHugState = (state, cow, doUseHuggingMachine) => {
+
+export const changeCowAutomaticHugState = (state: any, cow: any, doUseHuggingMachine: boolean): any => {
   if (doUseHuggingMachine) {
     if (
       cow.isUsingHuggingMachine ||

--- a/src/game-logic/reducers/changeCowBreedingPenResident.ts
+++ b/src/game-logic/reducers/changeCowBreedingPenResident.ts
@@ -1,12 +1,7 @@
 import { COW_GESTATION_PERIOD_DAYS } from '../../constants.js'
 
-/**
- * @param {farmhand.cow} cow
- * @param {farmhand.cowBreedingPen} cowBreedingPen
- * @param {Array.<farmhand.cow>} cowInventory
- * @return {boolean}
- */
-const cowCanBeAdded = (cow, cowBreedingPen, cowInventory) => {
+
+const cowCanBeAdded = (cow: any, cowBreedingPen: any, cowInventory: any): boolean => {
   const { cowId1, cowId2 } = cowBreedingPen
   const isBreedingPenFull = cowId1 !== null && cowId2 !== null
   const isCowInBreedingPen = cowId1 === cow.id || cowId2 === cow.id
@@ -19,13 +14,13 @@ const cowCanBeAdded = (cow, cowBreedingPen, cowInventory) => {
 }
 
 /**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @param {boolean} isAdding If true, cow will be added to the breeding pen. If
+
+
+ * @param isAdding If true, cow will be added to the breeding pen. If
  * false, they will be removed.
- * @returns {farmhand.state}
+
  */
-export const changeCowBreedingPenResident = (state, cow, isAdding) => {
+export const changeCowBreedingPenResident = (state: any, cow: any, isAdding: boolean): any => {
   const { cowBreedingPen, cowInventory } = state
   const { cowId1, cowId2 } = cowBreedingPen
   const isCowInBreedingPen = cowId1 === cow.id || cowId2 === cow.id

--- a/src/game-logic/reducers/changeCowName.ts
+++ b/src/game-logic/reducers/changeCowName.ts
@@ -2,13 +2,8 @@ import { MAX_ANIMAL_NAME_LENGTH } from '../../constants.js'
 
 import { modifyCow } from './modifyCow.js'
 
-/**
- * @param {farmhand.state} state
- * @param {string} newName
- * @param {string} cowId
- * @returns {farmhand.state}
- */
-export const changeCowName = (state, cowId, newName) =>
+
+export const changeCowName = (state: any, cowId: string, newName: string): any =>
   modifyCow(state, cowId, () => ({
     name: newName.slice(0, MAX_ANIMAL_NAME_LENGTH),
   }))

--- a/src/game-logic/reducers/clearPlot.ts
+++ b/src/game-logic/reducers/clearPlot.ts
@@ -14,13 +14,8 @@ import { removeFieldPlotAt } from './removeFieldPlotAt.js'
 
 const { GROWN } = cropLifeStage
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const clearPlot = (state, x, y) => {
+
+export const clearPlot = (state: any, x: number, y: number): any => {
   const plotContent = state.field[y][x]
   const hoeLevel = state.toolLevels[toolType.HOE]
 

--- a/src/game-logic/reducers/computeCowInventoryForNextDay.ts
+++ b/src/game-logic/reducers/computeCowInventoryForNextDay.ts
@@ -1,9 +1,6 @@
 import { COW_HUG_BENEFIT, MAX_DAILY_COW_HUG_BENEFITS } from '../../constants.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const computeCowInventoryForNextDay = state => ({
   ...state,
   cowInventory: state.cowInventory.map(cow => ({

--- a/src/game-logic/reducers/computeStateForNextDay.ts
+++ b/src/game-logic/reducers/computeStateForNextDay.ts
@@ -21,10 +21,7 @@ import { updateFinancialRecords } from './updateFinancialRecords.js'
 import { updateInventoryRecordsForNextDay } from './updateInventoryRecordsForNextDay.js'
 import { updatePriceEvents } from './updatePriceEvents.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 const adjustItemValues = state => ({
   ...state,
   historicalValueAdjustments: [state.valueAdjustments],
@@ -34,11 +31,8 @@ const adjustItemValues = state => ({
   ),
 })
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
-export const computeStateForNextDay = (state, isFirstDay = false) => {
+
+export const computeStateForNextDay = (state: any, isFirstDay = false): any => {
   const reducers = isFirstDay
     ? [processField]
     : [

--- a/src/game-logic/reducers/consumeIngredients.ts
+++ b/src/game-logic/reducers/consumeIngredients.ts
@@ -5,19 +5,19 @@ import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 
 /**
  * Consume ingredients - validate, add experience, and decrement ingredients
- * @param {farmhand.state} state
- * @param {object} recipe - Recipe or upgrade object with ingredients
- * @param {number} [recipeYield=1] - How many units of the recipe to consume ingredients for
- * @param {number} [experiencePoints=0] - Experience points to award
- * @returns {farmhand.state}
+
+ * @param recipe - Recipe or upgrade object with ingredients
+ * @param [recipeYield=1] - How many units of the recipe to consume ingredients for
+ * @param [experiencePoints=0] - Experience points to award
+
  */
 
 export const consumeIngredients = (
-  state,
-  recipe,
-  recipeYield = 1,
-  experiencePoints = 0
-) => {
+  state: any,
+  recipe: object,
+  recipeYield?: number = 1,
+  experiencePoints?: number = 0
+): any => {
   if (
     recipe.ingredients &&
     !canMakeRecipe(recipe, state.inventory, recipeYield)

--- a/src/game-logic/reducers/createPriceEvent.ts
+++ b/src/game-logic/reducers/createPriceEvent.ts
@@ -1,10 +1,10 @@
 /**
- * @param {farmhand.state} state
- * @param {farmhand.priceEvent} priceEvent
- * @param {string} priceEventKey Either 'priceCrashes' or 'priceSurges'
- * @returns {farmhand.state}
+
+
+ * @param priceEventKey Either 'priceCrashes' or 'priceSurges'
+
  */
-export const createPriceEvent = (state, priceEvent, priceEventKey) => ({
+export const createPriceEvent = (state: any, priceEvent: any, priceEventKey: string): any => ({
   ...state,
   [priceEventKey]: {
     ...state[priceEventKey],

--- a/src/game-logic/reducers/decrementItemFromInventory.ts
+++ b/src/game-logic/reducers/decrementItemFromInventory.ts
@@ -1,10 +1,10 @@
 /**
- * @param {farmhand.state} state
- * @param {string} itemId
- * @param {number} [howMany=1]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+
  */
-export const decrementItemFromInventory = (state, itemId, howMany = 1) => {
+export const decrementItemFromInventory = (state: any, itemId: string, howMany?: number = 1): any => {
   const inventory = [...state.inventory]
   const itemInventoryIndex = inventory.findIndex(({ id }) => id === itemId)
 

--- a/src/game-logic/reducers/fertilizePlot.ts
+++ b/src/game-logic/reducers/fertilizePlot.ts
@@ -15,12 +15,12 @@ const fertilizerItemIdToTypeMap = {
 /**
  * Assumes that state.selectedItemId references an item with type ===
  * itemType.FERTILIZER.
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
+
+
+
+
  */
-export const fertilizePlot = (state, x, y) => {
+export const fertilizePlot = (state: any, x: number, y: number): any => {
   const { field, selectedItemId } = state
   const row = field[y]
   const plotContent = row[x]

--- a/src/game-logic/reducers/forRange.ts
+++ b/src/game-logic/reducers/forRange.ts
@@ -1,20 +1,20 @@
 /**
- * @param {farmhand.state} state
- * @param {function(farmhand.state, number, number, ...any): farmhand.state} fieldFn Performs an operation on each plot within the range.
- * @param {number} rangeRadius
- * @param {number} plotX
- * @param {number} plotY
- * @param {...any} args Passed as arguments to fieldFn.
- * @returns {farmhand.state}
+
+ * @param fieldFn Performs an operation on each plot within the range.
+
+
+
+ * @param args Passed as arguments to fieldFn.
+
  */
 export const forRange = (
-  state,
-  fieldFn,
-  rangeRadius,
-  plotX,
-  plotY,
+  state: any,
+  fieldFn: function(farmhand.state, number, number, ...any): farmhand.state,
+  rangeRadius: number,
+  plotX: number,
+  plotY: number,
   ...args
-) => {
+): any => {
   const startX = Math.max(plotX - rangeRadius, 0)
   const endX = Math.min(plotX + rangeRadius, state.field[0].length - 1)
   const startY = Math.max(plotY - rangeRadius, 0)

--- a/src/game-logic/reducers/generatePriceEvents.ts
+++ b/src/game-logic/reducers/generatePriceEvents.ts
@@ -14,10 +14,7 @@ import { createPriceEvent } from './createPriceEvent.js'
 const TYPE_CRASH = 'priceCrashes'
 const TYPE_SURGE = 'priceSurges'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const generatePriceEvents = state => {
   const priceCrashes = { ...state.priceCrashes }
   const priceSurges = { ...state.priceSurges }

--- a/src/game-logic/reducers/harvestPlot.ts
+++ b/src/game-logic/reducers/harvestPlot.ts
@@ -21,11 +21,8 @@ import { plantInPlot } from './plantInPlot.js'
 
 const { GROWN } = cropLifeStage
 
-/**
- * @param {farmhand.state} state
- * @returns {number}
- */
-function getHarvestedQuantity(state) {
+
+function getHarvestedQuantity(state: any): number {
   let amount = 1
 
   switch (state.toolLevels[toolType.SCYTHE]) {
@@ -52,13 +49,8 @@ function getHarvestedQuantity(state) {
   return amount
 }
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-function harvestCrops(state, x, y) {
+
+function harvestCrops(state: any, x: number, y: number): any {
   const row = state.field[y]
   const crop = row[x]
 
@@ -111,13 +103,8 @@ function harvestCrops(state, x, y) {
   }
 }
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-function harvestWeed(state, x, y) {
+
+function harvestWeed(state: any, x: number, y: number): any {
   const row = state.field[y]
   const crop = row[x]
 
@@ -132,13 +119,8 @@ function harvestWeed(state, x, y) {
   return state
 }
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const harvestPlot = (state, x, y) => {
+
+export const harvestPlot = (state: any, x: number, y: number): any => {
   const row = state.field[y]
   const crop = row[x]
 

--- a/src/game-logic/reducers/helpers.tsx
+++ b/src/game-logic/reducers/helpers.tsx
@@ -7,12 +7,8 @@ import { findInField } from '../../utils/findInField.js'
 // This file is designed to contain common logic that is needed across multiple
 // reducers.
 
-/**
- * @param {?farmhand.plotContent} plotContent
- * @param {boolean} wasWateredToday
- * @returns {?farmhand.plotContent}
- */
-export const setWasWateredProperty = (plotContent, wasWateredToday) => {
+
+export const setWasWateredProperty = (plotContent: any, wasWateredToday: boolean): any => {
   if (plotContent === null) {
     return null
   }
@@ -22,44 +18,35 @@ export const setWasWateredProperty = (plotContent, wasWateredToday) => {
     : { ...plotContent }
 }
 
-/**
- * @param {?farmhand.plotContent} plotContent
- * @returns {?farmhand.plotContent}
- */
+
 export const setWasWatered = plotContent =>
   setWasWateredProperty(plotContent, true)
 
-/**
- * @param {Array.<Array.<?farmhand.plotContent>>} field
- * @returns {boolean}
- */
+
 export const fieldHasScarecrow = field =>
   !!findInField(field, plotContainsScarecrow)
 
 /**
- * @param {Array.<Array.<function>>} chancesAndEvents An array of arrays in which the
+ * @param chancesAndEvents An array of arrays in which the
  * first element is a function that determines whether to trigger an event, and
  * the second function which is a reducer that implements the event.
- * @param {farmhand.state} state
- * @returns {farmhand.state}
+
+
  */
-export const applyChanceEvent = (chancesAndEvents, state) =>
+export const applyChanceEvent = (chancesAndEvents: Array.<function[]>, state: any): any =>
   chancesAndEvents.reduce((acc, [chanceCalculator, fn]) => {
     return chanceCalculator() ? fn(acc) : acc
   }, state)
 
-/**
- * @param {?farmhand.plotContent} plot
- * @returns {boolean}
- */
+
 export const plotContainsScarecrow = plot =>
   !!(plot && plot.itemId === SCARECROW_ITEM_ID)
 
 /**
  * Invokes a function on every plot in a field.
- * @param {Array.<Array.<?farmhand.plotContent>>} field
- * @param {function(?farmhand.plotContent, number, number): *} modifierFn
- * @returns {Array.<Array.<?farmhand.plotContent>>}
+
+
+
  */
-export const updateField = (field, modifierFn) =>
+export const updateField = (field: Array.<?farmhand.plotContent[]>, modifierFn: function(?farmhand.plotContent, number, number): *): Array.<?farmhand.plotContent[]> =>
   field.map((row, y) => row.map((plot, x) => modifierFn(plot, x, y)))

--- a/src/game-logic/reducers/hugCow.ts
+++ b/src/game-logic/reducers/hugCow.ts
@@ -2,12 +2,8 @@ import { COW_HUG_BENEFIT, MAX_DAILY_COW_HUG_BENEFITS } from '../../constants.js'
 
 import { modifyCow } from './modifyCow.js'
 
-/**
- * @param {farmhand.state} state
- * @param {string} cowId
- * @returns {farmhand.state}
- */
-export const hugCow = (state, cowId) =>
+
+export const hugCow = (state: any, cowId: string): any =>
   modifyCow(state, cowId, cow =>
     cow.happinessBoostsToday >= MAX_DAILY_COW_HUG_BENEFITS
       ? cow

--- a/src/game-logic/reducers/incrementPlotContentAge.ts
+++ b/src/game-logic/reducers/incrementPlotContentAge.ts
@@ -2,10 +2,7 @@ import { fertilizerType, itemType } from '../../enums.js'
 import { getPlotContentType } from '../../utils/index.js'
 import { FERTILIZER_BONUS } from '../../constants.js'
 
-/**
- * @param {?farmhand.crop} crop
- * @returns {?farmhand.crop}
- */
+
 export const incrementPlotContentAge = crop =>
   crop && getPlotContentType(crop) === itemType.CROP
     ? {

--- a/src/game-logic/reducers/makeFermentationRecipe.ts
+++ b/src/game-logic/reducers/makeFermentationRecipe.ts
@@ -8,16 +8,16 @@ import { addKegToCellarInventory } from './addKegToCellarInventory.js'
 import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 
 /**
- * @param {farmhand.state} state
- * @param {farmhand.item} fermentationRecipe
- * @param {number} [howMany=1]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+
  */
 export const makeFermentationRecipe = (
-  state,
-  fermentationRecipe,
-  howMany = 1
-) => {
+  state: any,
+  fermentationRecipe: any,
+  howMany?: number = 1
+): any => {
   const { inventory, cellarInventory, purchasedCellar } = state
 
   const { space: cellarSize } = PURCHASEABLE_CELLARS.get(purchasedCellar) ?? {

--- a/src/game-logic/reducers/makeRecipe.ts
+++ b/src/game-logic/reducers/makeRecipe.ts
@@ -12,12 +12,12 @@ const EXPERIENCE_FOR_RECIPE = {
 }
 
 /**
- * @param {farmhand.state} state
- * @param {farmhand.recipe} recipe
- * @param {number} [howMany=1]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+
  */
-export const makeRecipe = (state, recipe, howMany = 1) => {
+export const makeRecipe = (state: any, recipe: any, howMany?: number = 1): any => {
   const originalState = state
   state = consumeIngredients(
     state,

--- a/src/game-logic/reducers/makeWine.ts
+++ b/src/game-logic/reducers/makeWine.ts
@@ -11,12 +11,12 @@ import { addKegToCellarInventory } from './addKegToCellarInventory.js'
 import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 
 /**
- * @param {farmhand.state} state
- * @param {farmhand.grape} grape
- * @param {number} [howMany=1]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+
  */
-export const makeWine = (state, grape, howMany = 1) => {
+export const makeWine = (state: any, grape: any, howMany?: number = 1): any => {
   const { inventory, cellarInventory, purchasedCellar } = state
 
   const { space: cellarSize } = PURCHASEABLE_CELLARS.get(purchasedCellar) ?? {

--- a/src/game-logic/reducers/minePlot.ts
+++ b/src/game-logic/reducers/minePlot.ts
@@ -10,13 +10,8 @@ import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
 const daysUntilClearPeriods = [1, 2, 2, 3]
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const minePlot = (state, x, y) => {
+
+export const minePlot = (state: any, x: number, y: number): any => {
   const { field } = state
   const row = field[y]
 

--- a/src/game-logic/reducers/modifyCow.ts
+++ b/src/game-logic/reducers/modifyCow.ts
@@ -1,11 +1,11 @@
 // TODO: Add tests for this reducer
 /**
- * @param {farmhand.state} state
- * @param {string} cowId
- * @param {Function} fn Function that takes a cow and returns the modified cow or undefined.
- * @returns {farmhand.state}
+
+
+ * @param fn Function that takes a cow and returns the modified cow or undefined.
+
  */
-export const modifyCow = (state, cowId, fn) => {
+export const modifyCow = (state: any, cowId: string, fn: Function): any => {
   const cowInventory = [...state.cowInventory]
 
   // TODO: Use the findCowById util here.

--- a/src/game-logic/reducers/modifyFieldPlotAt.ts
+++ b/src/game-logic/reducers/modifyFieldPlotAt.ts
@@ -1,12 +1,6 @@
 // TODO: Add tests for this reducer.
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @param {function(?farmhand.plotContent): ?farmhand.plotContent} modifierFn
- * @returns {farmhand.state}
- */
-export const modifyFieldPlotAt = (state, x, y, modifierFn) => {
+
+export const modifyFieldPlotAt = (state: any, x: number, y: number, modifierFn: function(?farmhand.plotContent): ?farmhand.plotContent): any => {
   const { field } = state
   const row = [...field[y]]
   const plotContent = modifierFn(row[x])

--- a/src/game-logic/reducers/offerCow.ts
+++ b/src/game-logic/reducers/offerCow.ts
@@ -1,9 +1,5 @@
-/**
- * @param {farmhand.state} state
- * @param {string} cowId
- * @returns {farmhand.state}
- */
-export const offerCow = (state, cowId) => {
+
+export const offerCow = (state: any, cowId: string): any => {
   state = { ...state, cowIdOfferedForTrade: cowId }
 
   return state

--- a/src/game-logic/reducers/plantInPlot.ts
+++ b/src/game-logic/reducers/plantInPlot.ts
@@ -9,14 +9,8 @@ import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 import { processSprinklers } from './processSprinklers.js'
 import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @param {string} plantableItemId
- * @returns {farmhand.state}
- */
-export const plantInPlot = (state, x, y, plantableItemId) => {
+
+export const plantInPlot = (state: any, x: number, y: number, plantableItemId: string): any => {
   if (
     !plantableItemId ||
     !state.inventory.some(({ id }) => id === plantableItemId)

--- a/src/game-logic/reducers/prependPendingPeerMessage.ts
+++ b/src/game-logic/reducers/prependPendingPeerMessage.ts
@@ -1,16 +1,16 @@
 import { MAX_PENDING_PEER_MESSAGES } from '../../constants.js'
 
 /**
- * @param {farmhand.state} state
- * @param {string} message
- * @param {farmhand.notificationSeverity} [severity='info']
- * @returns {farmhand.state}
+
+
+ * @param [severity='info']
+
  */
 export const prependPendingPeerMessage = (
-  state,
-  message,
-  severity = 'info'
-) => {
+  state: any,
+  message: string,
+  severity?: any = 'info'
+): any => {
   return {
     ...state,
     pendingPeerMessages: [

--- a/src/game-logic/reducers/processCellar.ts
+++ b/src/game-logic/reducers/processCellar.ts
@@ -3,7 +3,7 @@
 import { processCellarSpoilage } from './processCellarSpoilage.js'
 
 /**
- * @param {state} state
+
  * @returns state
  */
 export const processCellar = state => {

--- a/src/game-logic/reducers/processCellarSpoilage.ts
+++ b/src/game-logic/reducers/processCellarSpoilage.ts
@@ -8,10 +8,7 @@ import { getKegSpoilageRate } from '../../utils/getKegSpoilageRate.js'
 
 import { removeKegFromCellar } from './removeKegFromCellar.js'
 
-/**
- * @param {state} state
- * @returns {state}
- */
+
 export const processCellarSpoilage = state => {
   const { cellarInventory } = state
 

--- a/src/game-logic/reducers/processCowAttrition.ts
+++ b/src/game-logic/reducers/processCowAttrition.ts
@@ -3,10 +3,7 @@ import { COW_ATTRITION_MESSAGE } from '../../templates.js'
 
 import { removeCowFromInventory } from './removeCowFromInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processCowAttrition = state => {
   const newDayNotifications = [...state.newDayNotifications]
   const oldCowInventory = [...state.cowInventory]

--- a/src/game-logic/reducers/processCowBreeding.ts
+++ b/src/game-logic/reducers/processCowBreeding.ts
@@ -10,10 +10,7 @@ import { COW_BORN_MESSAGE } from '../../templates.js'
 
 import { addExperience } from './addExperience.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processCowBreeding = state => {
   const {
     cowBreedingPen,

--- a/src/game-logic/reducers/processCowFertilizerProduction.ts
+++ b/src/game-logic/reducers/processCowFertilizerProduction.ts
@@ -7,10 +7,7 @@ import { FERTILIZERS_PRODUCED } from '../../templates.js'
 
 import { addItemToInventory } from './addItemToInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processCowFertilizerProduction = state => {
   const cowInventory = [...state.cowInventory]
   const newDayNotifications = [...state.newDayNotifications]

--- a/src/game-logic/reducers/processFeedingCows.ts
+++ b/src/game-logic/reducers/processFeedingCows.ts
@@ -9,10 +9,7 @@ import { OUT_OF_COW_FEED_NOTIFICATION } from '../../strings.js'
 
 import { decrementItemFromInventory } from './decrementItemFromInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processFeedingCows = state => {
   const cowInventory = [...state.cowInventory]
   const { length: cowInventoryLength } = cowInventory

--- a/src/game-logic/reducers/processField.ts
+++ b/src/game-logic/reducers/processField.ts
@@ -6,10 +6,7 @@ import { spawnWeeds } from './spawnWeeds.js'
 const fieldReducer = (acc, fn) => fn(acc)
 
 // TODO: Add tests for this reducer.
-/**
- * @param {?farmhand.plotContent} plotContent
- * @returns {?farmhand.plotContent}
- */
+
 const resetWasWatered = plotContent => setWasWateredProperty(plotContent, false)
 
 const fieldUpdaters = [
@@ -19,10 +16,7 @@ const fieldUpdaters = [
   updatePlotShoveledState,
 ]
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processField = state => ({
   ...state,
   field: updateField(state.field, plotContent =>

--- a/src/game-logic/reducers/processLevelUp.ts
+++ b/src/game-logic/reducers/processLevelUp.ts
@@ -12,12 +12,8 @@ import { addItemToInventory } from './addItemToInventory.js'
 import { showNotification } from './showNotification.js'
 import { unlockTool } from './unlockTool.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} oldLevel
- * @returns {farmhand.state}
- */
-export const processLevelUp = (state, oldLevel) => {
+
+export const processLevelUp = (state: any, oldLevel: number): any => {
   const { experience, selectedItemId } = state
   const newLevel = levelAchieved(experience)
 

--- a/src/game-logic/reducers/processMilkingCows.ts
+++ b/src/game-logic/reducers/processMilkingCows.ts
@@ -7,10 +7,7 @@ import { MILKS_PRODUCED } from '../../templates.js'
 
 import { addItemToInventory } from './addItemToInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processMilkingCows = state => {
   const cowInventory = [...state.cowInventory]
   const newDayNotifications = [...state.newDayNotifications]

--- a/src/game-logic/reducers/processNerfs.ts
+++ b/src/game-logic/reducers/processNerfs.ts
@@ -1,9 +1,6 @@
 import { applyChanceEvent } from './helpers.js'
 import { applyCrows } from './applyCrows.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processNerfs = state =>
   applyChanceEvent([[() => true, applyCrows]], state)

--- a/src/game-logic/reducers/processSprinklers.ts
+++ b/src/game-logic/reducers/processSprinklers.ts
@@ -6,10 +6,7 @@ import { getLevelEntitlements } from '../../utils/getLevelEntitlements.js'
 import { setWasWatered } from './helpers.js'
 import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processSprinklers = state => {
   const { field, experience } = state
   const crops = new Map()

--- a/src/game-logic/reducers/processWeather.ts
+++ b/src/game-logic/reducers/processWeather.ts
@@ -3,9 +3,6 @@ import { shouldPrecipitateToday } from '../../utils/index.js'
 import { applyChanceEvent } from './helpers.js'
 import { applyPrecipitation } from './applyPrecipitation.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const processWeather = state =>
   applyChanceEvent([[shouldPrecipitateToday, applyPrecipitation]], state)

--- a/src/game-logic/reducers/purchaseCellar.ts
+++ b/src/game-logic/reducers/purchaseCellar.ts
@@ -6,12 +6,8 @@ import { CELLAR_PURCHASED } from '../../templates.js'
 import { addExperience } from './addExperience.js'
 import { showNotification } from './showNotification.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} cellarId
- * @returns {farmhand.state}
- */
-export const purchaseCellar = (state, cellarId) => {
+
+export const purchaseCellar = (state: any, cellarId: number): any => {
   const { money, purchasedCellar } = state
 
   if (purchasedCellar >= cellarId) {

--- a/src/game-logic/reducers/purchaseCombine.ts
+++ b/src/game-logic/reducers/purchaseCombine.ts
@@ -1,12 +1,8 @@
 import { moneyTotal } from '../../utils/index.js'
 import { PURCHASEABLE_COMBINES } from '../../constants.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} combineId
- * @returns {farmhand.state}
- */
-export const purchaseCombine = (state, combineId) => {
+
+export const purchaseCombine = (state: any, combineId: number): any => {
   const { money, purchasedCombine } = state
 
   if (purchasedCombine >= combineId) {

--- a/src/game-logic/reducers/purchaseComposter.ts
+++ b/src/game-logic/reducers/purchaseComposter.ts
@@ -6,12 +6,8 @@ import { addExperience } from './addExperience.js'
 import { showNotification } from './showNotification.js'
 import { updateLearnedRecipes } from './updateLearnedRecipes.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} composterId
- * @returns {farmhand.state}
- */
-export const purchaseComposter = (state, composterId) => {
+
+export const purchaseComposter = (state: any, composterId: number): any => {
   const { money, purchasedComposter } = state
 
   if (purchasedComposter >= composterId) return state

--- a/src/game-logic/reducers/purchaseCow.ts
+++ b/src/game-logic/reducers/purchaseCow.ts
@@ -3,12 +3,8 @@ import { PURCHASEABLE_COW_PENS } from '../../constants.js'
 
 import { addCowToInventory } from './addCowToInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @returns {farmhand.state}
- */
-export const purchaseCow = (state, cow) => {
+
+export const purchaseCow = (state: any, cow: any): any => {
   const {
     cowInventory,
     cowColorsPurchased,

--- a/src/game-logic/reducers/purchaseCowPen.ts
+++ b/src/game-logic/reducers/purchaseCowPen.ts
@@ -5,12 +5,8 @@ import { COW_PEN_PURCHASED } from '../../templates.js'
 import { addExperience } from './addExperience.js'
 import { showNotification } from './showNotification.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} cowPenId
- * @returns {farmhand.state}
- */
-export const purchaseCowPen = (state, cowPenId) => {
+
+export const purchaseCowPen = (state: any, cowPenId: number): any => {
   const { money, purchasedCowPen } = state
 
   if (purchasedCowPen >= cowPenId) {

--- a/src/game-logic/reducers/purchaseField.ts
+++ b/src/game-logic/reducers/purchaseField.ts
@@ -3,12 +3,8 @@ import { EXPERIENCE_VALUES, PURCHASEABLE_FIELD_SIZES } from '../../constants.js'
 
 import { addExperience } from './addExperience.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} fieldId
- * @returns {farmhand.state}
- */
-export const purchaseField = (state, fieldId) => {
+
+export const purchaseField = (state: any, fieldId: number): any => {
   const { field, money, purchasedField } = state
   if (purchasedField >= fieldId) {
     return state

--- a/src/game-logic/reducers/purchaseForest.ts
+++ b/src/game-logic/reducers/purchaseForest.ts
@@ -6,12 +6,8 @@ import { FOREST_AVAILABLE_NOTIFICATION } from '../../strings.js'
 import { addExperience } from './addExperience.js'
 import { showNotification } from './showNotification.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} forestId
- * @returns {farmhand.state}
- */
-export const purchaseForest = (state, forestId) => {
+
+export const purchaseForest = (state: any, forestId: number): any => {
   const { forest, money, purchasedForest } = state
   if (purchasedForest >= forestId) {
     return state

--- a/src/game-logic/reducers/purchaseItem.ts
+++ b/src/game-logic/reducers/purchaseItem.ts
@@ -10,12 +10,12 @@ import { addItemToInventory } from './addItemToInventory.js'
 import { prependPendingPeerMessage } from './index.js'
 
 /**
- * @param {farmhand.state} state
- * @param {farmhand.item} item
- * @param {number} [howMany=1]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+
  */
-export const purchaseItem = (state, item, howMany = 1) => {
+export const purchaseItem = (state: any, item: any, howMany?: number = 1): any => {
   const { money, todaysPurchases, valueAdjustments } = state
   const numberOfItemsToAdd = Math.min(howMany, inventorySpaceRemaining(state))
 

--- a/src/game-logic/reducers/purchaseSmelter.ts
+++ b/src/game-logic/reducers/purchaseSmelter.ts
@@ -6,12 +6,8 @@ import { addExperience } from './addExperience.js'
 import { showNotification } from './showNotification.js'
 import { updateLearnedRecipes } from './updateLearnedRecipes.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} smelterId
- * @returns {farmhand.state}
- */
-export const purchaseSmelter = (state, smelterId) => {
+
+export const purchaseSmelter = (state: any, smelterId: number): any => {
   const { money, purchasedSmelter } = state
 
   if (purchasedSmelter >= smelterId) return state

--- a/src/game-logic/reducers/purchaseStorageExpansion.ts
+++ b/src/game-logic/reducers/purchaseStorageExpansion.ts
@@ -4,10 +4,7 @@ import {
   STORAGE_EXPANSION_AMOUNT,
 } from '../../constants.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const purchaseStorageExpansion = state => {
   const { money, inventoryLimit } = state
   const storageUpgradeCost = getCostOfNextStorageExpansion(inventoryLimit)

--- a/src/game-logic/reducers/removeCowFromInventory.ts
+++ b/src/game-logic/reducers/removeCowFromInventory.ts
@@ -6,12 +6,8 @@ import { addItemToInventory } from './addItemToInventory.js'
 import { changeCowBreedingPenResident } from './changeCowBreedingPenResident.js'
 
 // TODO: Add tests for this reducer
-/**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @returns {farmhand.state}
- */
-export const removeCowFromInventory = (state, cow) => {
+
+export const removeCowFromInventory = (state: any, cow: any): any => {
   const cowInventory = [...state.cowInventory]
   const { isUsingHuggingMachine } = cow
 

--- a/src/game-logic/reducers/removeFieldPlotAt.ts
+++ b/src/game-logic/reducers/removeFieldPlotAt.ts
@@ -1,10 +1,5 @@
 import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const removeFieldPlotAt = (state, x, y) =>
+
+export const removeFieldPlotAt = (state: any, x: number, y: number): any =>
   modifyFieldPlotAt(state, x, y, () => null)

--- a/src/game-logic/reducers/removeKegFromCellar.ts
+++ b/src/game-logic/reducers/removeKegFromCellar.ts
@@ -1,8 +1,5 @@
-/**
- * @param {farmhand.state} state
- * @param {string} kegId
- */
-export const removeKegFromCellar = (state, kegId) => {
+
+export const removeKegFromCellar = (state: any, kegId: string) => {
   const { cellarInventory } = state
 
   const kegIdx = cellarInventory.findIndex(({ id }) => {

--- a/src/game-logic/reducers/removePeer.ts
+++ b/src/game-logic/reducers/removePeer.ts
@@ -1,11 +1,10 @@
-/**
- */
+
 
 // TODO: Add tests for this reducer
 /**
- * @param {farmhand.state} state
- * @param {string} peerId The peer to remove
- * @returns {farmhand.state}
+
+ * @param peerId The peer to remove
+
  */
 export const removePeer = (state, peerId) => {
   const peers = { ...state.peers }

--- a/src/game-logic/reducers/rotateNotificationLogs.ts
+++ b/src/game-logic/reducers/rotateNotificationLogs.ts
@@ -1,9 +1,6 @@
 import { NOTIFICATION_LOG_SIZE } from '../../constants.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const rotateNotificationLogs = state => {
   const notificationLog = [...state.notificationLog]
 

--- a/src/game-logic/reducers/selectCow.ts
+++ b/src/game-logic/reducers/selectCow.ts
@@ -1,6 +1,2 @@
-/**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @returns {farmhand.state}
- */
-export const selectCow = (state, { id }) => ({ ...state, selectedCowId: id })
+
+export const selectCow = (state: any, { id }): any => ({ ...state, selectedCowId: id })

--- a/src/game-logic/reducers/sellCow.ts
+++ b/src/game-logic/reducers/sellCow.ts
@@ -4,12 +4,8 @@ import { addRevenue } from './addRevenue.js'
 
 import { removeCowFromInventory } from './removeCowFromInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.cow} cow
- * @returns {farmhand.state}
- */
-export const sellCow = (state, cow) => {
+
+export const sellCow = (state: any, cow: any): any => {
   const { cowsSold } = state
   const cowColorId = getCowColorId(cow)
   const cowValue = getCowValue(cow, true)

--- a/src/game-logic/reducers/sellItem.ts
+++ b/src/game-logic/reducers/sellItem.ts
@@ -20,12 +20,12 @@ import { adjustLoan } from './adjustLoan.js'
 import { prependPendingPeerMessage } from './index.js'
 
 /**
- * @param {farmhand.state} state
- * @param {farmhand.item} item
- * @param {number} [howMany=1]
- * @returns {farmhand.state}
+
+
+ * @param [howMany=1]
+
  */
-export const sellItem = (state, { id }, howMany = 1) => {
+export const sellItem = (state: any, { id }, howMany?: number = 1): any => {
   if (howMany === 0) {
     return state
   }

--- a/src/game-logic/reducers/sellKeg.ts
+++ b/src/game-logic/reducers/sellKeg.ts
@@ -16,12 +16,8 @@ import { updateLearnedRecipes } from './updateLearnedRecipes.js'
 
 import { prependPendingPeerMessage } from './index.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.keg} keg
- * @returns {farmhand.state}
- */
-export const sellKeg = (state, keg) => {
+
+export const sellKeg = (state: any, keg: any): any => {
   const { itemId } = keg
   const item = itemsMap[itemId]
   const {

--- a/src/game-logic/reducers/setScarecrow.ts
+++ b/src/game-logic/reducers/setScarecrow.ts
@@ -7,13 +7,8 @@ import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
 const { OBSERVE, SET_SCARECROW } = fieldMode
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const setScarecrow = (state, x, y) => {
+
+export const setScarecrow = (state: any, x: number, y: number): any => {
   const plot = state.field[y][x]
 
   // Only set scarecrows in empty plots

--- a/src/game-logic/reducers/setSprinkler.ts
+++ b/src/game-logic/reducers/setSprinkler.ts
@@ -8,13 +8,8 @@ import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
 const { OBSERVE, SET_SPRINKLER } = fieldMode
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const setSprinkler = (state, x, y) => {
+
+export const setSprinkler = (state: any, x: number, y: number): any => {
   const { field } = state
   const plot = field[y][x]
 

--- a/src/game-logic/reducers/showNotification.ts
+++ b/src/game-logic/reducers/showNotification.ts
@@ -6,12 +6,12 @@
 // TODO: Change showNotification to accept a configuration object instead of so
 // many formal parameters.
 /**
- * @param {state} state
- * @param {string} message
- * @param {alertSeverity} [severity] Corresponds to the `severity` prop here:
+
+
+ * @param [severity] Corresponds to the `severity` prop here:
  * https://material-ui.com/api/alert/
- * @param {import('@mui/material/Alert').AlertProps['onClick']} onClick
- * @returns {state}
+
+
  * @see https://material-ui.com/api/alert/
  */
 export const showNotification = (

--- a/src/game-logic/reducers/spawnWeeds.ts
+++ b/src/game-logic/reducers/spawnWeeds.ts
@@ -4,11 +4,8 @@ import { randomNumberService } from '../../common/services/randomNumber.js'
 import { weed } from '../../data/items.js'
 import { getPlotContentFromItemId } from '../../utils/index.js'
 
-/**
- * @param {?farmhand.plotContent} plotContents
- * @returns {?farmhand.plotContent}
- */
-export function spawnWeeds(plotContents) {
+
+export function spawnWeeds(plotContents: any): any {
   if (plotContents) return plotContents
 
   let contents: farmhand.plotContent | null = null

--- a/src/game-logic/reducers/unlockTool.ts
+++ b/src/game-logic/reducers/unlockTool.ts
@@ -1,11 +1,7 @@
 import { toolLevel } from '../../enums.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.toolType} toolType
- * @returns {farmhand.state}
- */
-export const unlockTool = (state, toolType) => {
+
+export const unlockTool = (state: any, toolType: any): any => {
   const { toolLevels } = state
 
   if (toolLevels[toolType] === toolLevel.UNAVAILABLE) {

--- a/src/game-logic/reducers/updateAchievements.ts
+++ b/src/game-logic/reducers/updateAchievements.ts
@@ -3,12 +3,8 @@ import { ACHIEVEMENT_COMPLETED } from '../../templates.js'
 
 import { showNotification } from './showNotification.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.state} prevState
- * @returns {farmhand.state}
- */
-export const updateAchievements = (state, prevState) =>
+
+export const updateAchievements = (state: any, prevState: any): any =>
   achievements.reduce(
     (
       reducerState: farmhand.state,

--- a/src/game-logic/reducers/updateFinancialRecords.ts
+++ b/src/game-logic/reducers/updateFinancialRecords.ts
@@ -1,10 +1,7 @@
 import { get7DayAverage, getProfit, moneyTotal } from '../../utils/index.js'
 import { DAILY_FINANCIAL_HISTORY_RECORD_LENGTH } from '../../constants.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const updateFinancialRecords = state => {
   const {
     profitabilityStreak,

--- a/src/game-logic/reducers/updateInventoryRecordsForNextDay.ts
+++ b/src/game-logic/reducers/updateInventoryRecordsForNextDay.ts
@@ -1,7 +1,4 @@
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const updateInventoryRecordsForNextDay = state => ({
   ...state,
   todaysPurchases: {},

--- a/src/game-logic/reducers/updateLearnedRecipes.ts
+++ b/src/game-logic/reducers/updateLearnedRecipes.ts
@@ -1,9 +1,6 @@
 import { recipesMap } from '../../data/maps.js'
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const updateLearnedRecipes = state => ({
   ...state,
   learnedRecipes: Object.keys(recipesMap).reduce((acc, recipeId) => {

--- a/src/game-logic/reducers/updatePeer.ts
+++ b/src/game-logic/reducers/updatePeer.ts
@@ -6,13 +6,13 @@ import { dialogView } from '../../enums.js'
 import { showNotification } from './showNotification.js'
 
 /**
- * @param {farmhand.state} state
- * @param {Farmhand} farmhand
- * @param {farmhand.peerMetadata} peerMetadata
- * @param {string} peerId The peer to update
- * @returns {farmhand.state}
+
+
+
+ * @param peerId The peer to update
+
  */
-export const updatePeer = (state, farmhand, peerMetadata, peerId) => {
+export const updatePeer = (state: any, farmhand: Farmhand, peerMetadata: any, peerId: string): any => {
   const peers = { ...state.peers }
 
   const previousPeerMetadata = peers[peerId]

--- a/src/game-logic/reducers/updatePlotShoveledState.ts
+++ b/src/game-logic/reducers/updatePlotShoveledState.ts
@@ -1,7 +1,4 @@
-/**
- * @param {?farmhand.plotContent} plotContent
- * @returns {?farmhand.plotContent}
- */
+
 export const updatePlotShoveledState = plotContent => {
   if (
     plotContent &&

--- a/src/game-logic/reducers/updatePriceEvents.tsx
+++ b/src/game-logic/reducers/updatePriceEvents.tsx
@@ -1,7 +1,4 @@
-/**
- * @param {Partial<Record<string, farmhand.priceEvent>>} priceEvents
- * @returns {Partial<Record<string, farmhand.priceEvent>>}
- */
+
 const decrementPriceEventDays = priceEvents =>
   Object.keys(priceEvents).reduce((acc, key) => {
     const priceEvent = priceEvents[key]
@@ -16,10 +13,7 @@ const decrementPriceEventDays = priceEvents =>
     return acc
   }, {})
 
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 
 export const updatePriceEvents = state => {
   const { priceCrashes, priceSurges } = state

--- a/src/game-logic/reducers/upgradeTool.ts
+++ b/src/game-logic/reducers/upgradeTool.ts
@@ -6,11 +6,8 @@ import { showNotification } from './showNotification.js'
 import { consumeIngredients } from './consumeIngredients.js'
 import { addItemToInventory } from './addItemToInventory.js'
 
-/**
- * @param {farmhand.state} state
- * @param {farmhand.upgradesMetadatum} upgrade
- */
-export const upgradeTool = (state, upgrade) => {
+
+export const upgradeTool = (state: any, upgrade: any) => {
   // Validate required properties
   if (!upgrade.toolType || !upgrade.level) {
     return state

--- a/src/game-logic/reducers/waterAllPlots.ts
+++ b/src/game-logic/reducers/waterAllPlots.ts
@@ -1,8 +1,5 @@
 import { waterField } from './waterField.js'
 
 // TODO: Remove this and just use waterField directly.
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const waterAllPlots = state => waterField(state)

--- a/src/game-logic/reducers/waterField.ts
+++ b/src/game-logic/reducers/waterField.ts
@@ -1,10 +1,7 @@
 import { setWasWatered, updateField } from './helpers.js'
 
 // TODO: Add tests for this reducer
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.state}
- */
+
 export const waterField = state => ({
   ...state,
   field: updateField(state.field, setWasWatered),

--- a/src/game-logic/reducers/waterPlot.ts
+++ b/src/game-logic/reducers/waterPlot.ts
@@ -3,13 +3,8 @@ import { itemType } from '../../enums.js'
 
 import { modifyFieldPlotAt } from './modifyFieldPlotAt.js'
 
-/**
- * @param {farmhand.state} state
- * @param {number} x
- * @param {number} y
- * @returns {farmhand.state}
- */
-export const waterPlot = (state, x, y) => {
+
+export const waterPlot = (state: any, x: number, y: number): any => {
   const plotContent = state.field[y][x]
 
   const canBeWatered =

--- a/src/game-logic/reducers/withdrawCow.ts
+++ b/src/game-logic/reducers/withdrawCow.ts
@@ -1,9 +1,5 @@
-/**
- * @param {farmhand.state} state
- * @param {string} cowId
- * @returns {farmhand.state}
- */
-export const withdrawCow = (state, cowId) => {
+
+export const withdrawCow = (state: any, cowId: string): any => {
   const { cowIdOfferedForTrade } = state
 
   if (cowId === cowIdOfferedForTrade) {

--- a/src/handlers/peer-events.ts
+++ b/src/handlers/peer-events.ts
@@ -18,27 +18,23 @@ import {
 
 import { addExperience } from '../game-logic/reducers/addExperience.js'
 
-/**
- * @param {import('../components/Farmhand/Farmhand.js').default} farmhand
- * @param {farmhand.peerMetadata} peerMetadata
- * @param {string} peerId
- */
-export const handlePeerMetadataRequest = (farmhand, peerMetadata, peerId) => {
+
+export const handlePeerMetadataRequest = (farmhand: import('../components/Farmhand/Farmhand.js').default, peerMetadata: any, peerId: string) => {
   farmhand.updatePeer(farmhand, peerMetadata, peerId)
 }
 
 /**
  * Handles another player's initiation of a cow trade request.
- * @param {Farmhand} farmhand
- * @param {Object} cowTradeRequestPayload
- * @param {farmhand.cow} cowTradeRequestPayload.cowOffered
- * @param {farmhand.cow} cowTradeRequestPayload.cowRequested
- * @param {string} peerId
+
+
+ * @param cowTradeRequestPayload.cowOffered
+ * @param cowTradeRequestPayload.cowRequested
+
  */
 export const handleCowTradeRequest = async (
-  farmhand,
+  farmhand: Farmhand,
   { cowOffered, cowRequested },
-  peerId
+  peerId: string
 ) => {
   let wasTradeSuccessful = false
 
@@ -158,12 +154,8 @@ export const handleCowTradeRequest = async (
   )
 }
 
-/**
- * @param {Farmhand} farmhand
- * @param {farmhand.cow} cowReceived
- * @param {string} peerId
- */
-export const handleCowTradeRequestAccept = (farmhand, cowReceived, peerId) => {
+
+export const handleCowTradeRequestAccept = (farmhand: Farmhand, cowReceived: any, peerId: string) => {
   let wasTradeSuccessful = false
 
   farmhand.setState(
@@ -269,11 +261,11 @@ export const handleCowTradeRequestAccept = (farmhand, cowReceived, peerId) => {
 }
 
 /**
- * @param {Farmhand} farmhand
- * @param {Object} cowTradeRejectionPayload
- * @param {string} cowTradeRejectionPayload.reason
+
+
+ * @param cowTradeRejectionPayload.reason
  */
-export const handleCowTradeRequestReject = (farmhand, { reason }) => {
+export const handleCowTradeRequestReject = (farmhand: Farmhand, { reason }) => {
   const { cowTradeTimeoutId } = farmhand.state
 
   if (typeof cowTradeTimeoutId === 'number') {

--- a/src/img/index.ts
+++ b/src/img/index.ts
@@ -431,10 +431,8 @@ export const items = {
   ...craftedItems,
 }
 
-/**
- * @type {Record<grapeVariety, string>}
- */
-export const wines = {
+
+export const wines: Record<grapeVariety, string> = {
   [grapeVariety.CHARDONNAY]: wineGreen,
   [grapeVariety.SAUVIGNON_BLANC]: wineGreen,
   //[grapeVariety.PINOT_BLANC]: wineGreen,

--- a/src/interfaces/Factory.ts
+++ b/src/interfaces/Factory.ts
@@ -3,7 +3,7 @@
  */
 export class Factory {
   /**
-   * @returns {farmhand.item | farmhand.item[]}
+
    * @abstract
    */
   generate(): farmhand.item | farmhand.item[] {

--- a/src/scripts/generate-crop-table.ts
+++ b/src/scripts/generate-crop-table.ts
@@ -9,11 +9,8 @@ const getDaysToMature = seedItem => {
   return seedItem.cropTimeline.reduce((days, acc) => days + acc)
 }
 
-/**
- * @param {farmhand.item} seedItem
- * @param {(farmhand.item|farmhand.cropVariety)} cropItem
- */
-function getCropImage(seedItem, cropItem) {
+
+function getCropImage(seedItem: any, cropItem: (farmhand.item|farmhand.cropVariety)) {
   if (Array.isArray(seedItem.growsInto)) {
     return `![${
       cropItem.name
@@ -24,10 +21,8 @@ function getCropImage(seedItem, cropItem) {
   }
 }
 
-/**
- * @param {farmhand.item} seedItem
- */
-function getSeedImage(seedItem) {
+
+function getSeedImage(seedItem: any) {
   return `![${seedItem.name}](https://raw.githubusercontent.com/jeremyckahn/farmhand/main/src/img/items/${seedItem.id}.png)`
 }
 
@@ -42,12 +37,8 @@ const headers = [
 
 const rows: (string | number)[][] = []
 
-/**
- * @param {number} level
- * @param {farmhand.item} seedItem
- * @param {farmhand.item} cropItem
- */
-const getCropRow = (level, seedItem, cropItem) => {
+
+const getCropRow = (level: number, seedItem: any, cropItem: any) => {
   return [
     `${getCropImage(seedItem, cropItem)} ${cropItem.name}`,
     `${getSeedImage(seedItem)} ${seedItem.name}`,

--- a/src/services/cellar.ts
+++ b/src/services/cellar.ts
@@ -20,19 +20,14 @@ export class CellarService {
   _uuid = uuid
 
   getItemInstancesInCellar = memoize(
-    /**
-     * @param {keg[]} cellarInventory
-     * @param {item} item
-     */
+
     (cellarInventory, item) => {
       return cellarInventory.filter(keg => keg.itemId === item.id).length
     },
     { cacheSize: Object.keys(fermentableItemsMap).length }
   )
 
-  /**
-   * @param {item} item
-   */
+
   generateKeg = item => {
     /** @type {keg} */
     const keg = {
@@ -48,10 +43,7 @@ export class CellarService {
     return keg
   }
 
-  /**
-   * @param {keg[]} cellarInventory
-   * @param {number} purchasedCellar
-   */
+
   doesCellarSpaceRemain = (cellarInventory, purchasedCellar) => {
     return (
       cellarInventory.length <
@@ -59,9 +51,7 @@ export class CellarService {
     )
   }
 
-  /**
-   * @param {keg} keg
-   */
+
   doesKegSpoil = keg => {
     const item = itemsMap[keg.itemId]
     const doesKegSpoil = !wineService.isWineRecipe(item)

--- a/src/services/wine.ts
+++ b/src/services/wine.ts
@@ -20,27 +20,22 @@ export class WineService {
    */
   maturityDayMultiplier = 3
 
-  /**
-   * @param {grapeVarietyEnum} grapeVariety
-   */
+
   getDaysToMature = grapeVariety => {
     return wineVarietyValueMap[grapeVariety] * this.maturityDayMultiplier
   }
 
-  /**
-   * @param {item} recipe
-   * @returns {recipe is wine}
-   */
+
   isWineRecipe = recipe => {
     return 'recipeType' in recipe && recipe.recipeType === recipeType.WINE
   }
 
   /**
-   * @param {Object} props
-   * @param {grape} props.grape
-   * @param {{ id: string, quantity: number }[]} props.inventory
-   * @param {keg[]} props.cellarInventory
-   * @param {number} props.cellarSize
+
+   * @param props.grape
+   * @param []} props.inventory
+   * @param props.cellarInventory
+   * @param props.cellarSize
    */
   getMaxWineYield = ({ grape, inventory, cellarInventory, cellarSize }) => {
     const {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,5 +1,4 @@
-/**
- */
+
 
 /**
  * @module farmhand.templates
@@ -18,38 +17,22 @@ import {
   integerString,
 } from './utils/index.js'
 
-/**
- * @param {string} _
- * @param {number} numCropsDestroyed
- * @returns {string}
- */
-export const CROWS_DESTROYED = (_, numCropsDestroyed) =>
+
+export const CROWS_DESTROYED = (_: string, numCropsDestroyed: number): string =>
   `Oh no! Crows destroyed ${numCropsDestroyed} crop${
     numCropsDestroyed > 1 ? 's' : ''
   }!`
 
-/**
- * @param {string} _
- * @param {number} cows
- * @returns {string}
- */
-export const COW_PEN_PURCHASED = (_, cows) =>
+
+export const COW_PEN_PURCHASED = (_: string, cows: number): string =>
   `Purchased a cow pen with capacity for ${cows} cows! You can visit your cow pen by going to the "Cows" page.`
 
-/**
- * @param {string} _
- * @param {number} kegCapacity
- * @returns {string}
- */
-export const CELLAR_PURCHASED = (_, kegCapacity) =>
+
+export const CELLAR_PURCHASED = (_: string, kegCapacity: number): string =>
   `Purchased a cellar with capacity for ${kegCapacity} kegs! View your keg inventory by going to the "Cellar" page.`
 
-/**
- * @param {string} _
- * @param {Object.<string, number>} milksProduced
- * @returns {string}
- */
-export const MILKS_PRODUCED = (_, milksProduced) => {
+
+export const MILKS_PRODUCED = (_: string, milksProduced: Record<string, number>): string => {
   let message = `Your cows produced milk:
 `
 
@@ -66,12 +49,8 @@ export const MILKS_PRODUCED = (_, milksProduced) => {
   return message
 }
 
-/**
- * @param {string} _
- * @param {Object.<string, number>} fertilizersProduced
- * @returns {string}
- */
-export const FERTILIZERS_PRODUCED = (_, fertilizersProduced) => {
+
+export const FERTILIZERS_PRODUCED = (_: string, fertilizersProduced: Record<string, number>): string => {
   let message = `Your cows produced fertilizer:
 `
 
@@ -88,30 +67,16 @@ export const FERTILIZERS_PRODUCED = (_, fertilizersProduced) => {
   return message
 }
 
-/**
- * @param {string} _
- * @param {farmhand.cow} cow
- * @returns {string}
- */
-export const COW_ATTRITION_MESSAGE = (_, cow) =>
+
+export const COW_ATTRITION_MESSAGE = (_: string, cow: any): string =>
   `${cow.name} got hungry from being underfed and ran away!`
 
-/**
- * @param {string} _
- * @param {farmhand.cow} parentCow1
- * @param {farmhand.cow} parentCow2
- * @param {farmhand.cow} offspringCow
- * @returns {string}
- */
-export const COW_BORN_MESSAGE = (_, parentCow1, parentCow2, offspringCow) =>
+
+export const COW_BORN_MESSAGE = (_: string, parentCow1: any, parentCow2: any, offspringCow: any): string =>
   `${parentCow1.name} and ${parentCow2.name} had a baby: ${offspringCow.name}! Welcome to the world, ${offspringCow.name}!`
 
-/**
- * @param {string} _
- * @param {farmhand.recipe} recipe
- * @returns {string}
- */
-export const RECIPE_LEARNED = (_, recipe) =>
+
+export const RECIPE_LEARNED = (_: string, recipe: any): string =>
   `You learned a new recipe: **${recipe.name}**!`
 
 export const RECIPES_LEARNED = (_, learnedRecipes) => {
@@ -129,63 +94,44 @@ export const RECIPES_LEARNED = (_, learnedRecipes) => {
   return `You learned the recipes for ${recipesString}!`
 }
 
-/**
- * @param {string} _
- * @param {farmhand.item} item
- * @returns {string}
- */
-export const PRICE_CRASH = (_, { name }) =>
+
+export const PRICE_CRASH = (_: string, { name }): string =>
   `${name} prices have bottomed out! Avoid selling them until prices return to normal.`
 
 /**
- * @param {string} _
- * @param {{ name: string }} item
- * @returns {string}
+
+ * @param } item
+
  */
-export const PRICE_SURGE = (_, { name }) =>
+export const PRICE_SURGE = (_: string, { name }): string =>
   `${name} prices are at their peak! Now is the time to sell!`
 
 /**
- * @param {string} _
- * @param {{ name: string, rewardDescription: string }} achievement
- * @returns {string}
+
+ * @param } achievement
+
  */
-export const ACHIEVEMENT_COMPLETED = (_, { name, rewardDescription }) =>
+export const ACHIEVEMENT_COMPLETED = (_: string, { name, rewardDescription }): string =>
   `You achieved "${name}!" Way to go!
 
 You earned: ${rewardDescription}`
 
-/**
- * @returns {string}
- */
-export const LOAN_PAYOFF = () =>
+
+export const LOAN_PAYOFF = (): string =>
   `You paid off your loan to the bank! You're finally free!`
 
-/**
- * @param {string} _
- * @param {number} loanBalance
- * @returns {string}
- */
-export const LOAN_INCREASED = (_, loanBalance) =>
+
+export const LOAN_INCREASED = (_: string, loanBalance: number): string =>
   `You took out a new loan. Your current balance is ${moneyString(
     loanBalance
   )}.`
 
-/**
- * @param {string} _
- * @param {number} loanBalance
- * @returns {string}
- */
-export const LOAN_BALANCE_NOTIFICATION = (_, loanBalance) =>
+
+export const LOAN_BALANCE_NOTIFICATION = (_: string, loanBalance: number): string =>
   `Your loan balance has grown to ${moneyString(loanBalance)}.`
 
-/**
- * @param {string} _
- * @param {number} newLevel
- * @param {farmhand.item} [randomCropSeed]
- * @returns {string}
- */
-export const LEVEL_GAINED_NOTIFICATION = (_, newLevel, randomCropSeed) => {
+
+export const LEVEL_GAINED_NOTIFICATION = (_: string, newLevel: number, randomCropSeed?: any): string => {
   let chunks = [
     `You reached **level ${newLevel}!** Way to go!
 
@@ -225,20 +171,11 @@ export const LEVEL_GAINED_NOTIFICATION = (_, newLevel, randomCropSeed) => {
   return chunks.join(' ')
 }
 
-/**
- * @param {string} _
- * @param {string} room
- * @returns {string}
- */
-export const CONNECTED_TO_ROOM = (_, room) => `Connected to room **${room}**!`
 
-/**
- * @param {string} _
- * @param {string} who
- * @param {Object} positions
- * @returns {string}
- */
-export const POSITIONS_POSTED_NOTIFICATION = (_, who, positions) => {
+export const CONNECTED_TO_ROOM = (_: string, room: string): string => `Connected to room **${room}**!`
+
+
+export const POSITIONS_POSTED_NOTIFICATION = (_: string, who: string, positions: Object): string => {
   const positivePositions: string[] = []
   const negativePositions: string[] = []
   const positionKeys = Object.keys(positions)
@@ -273,49 +210,30 @@ export const POSITIONS_POSTED_NOTIFICATION = (_, who, positions) => {
   return chunks.join('\n')
 }
 
-/**
- * @param {string} _
- * @param {string} room
- * @param {string} nextRoom
- * @returns {string}
- */
-export const ROOM_FULL_NOTIFICATION = (_, room, nextRoom) =>
+
+export const ROOM_FULL_NOTIFICATION = (_: string, room: string, nextRoom: string): string =>
   `Room **${room}** is full! Trying room **${nextRoom}**...`
 
-/**
- * @param {string} _
- * @param {number} quantity
- * @param {farmhand.item} item
- * @returns {string}
- */
-export const PURCHASED_ITEM_PEER_NOTIFICATION = (_, quantity, { name }) =>
+
+export const PURCHASED_ITEM_PEER_NOTIFICATION = (_: string, quantity: number, { name }): string =>
   `purchased ${integerString(quantity)} unit${
     quantity > 1 ? 's' : ''
   } of ${name}.`
 
-/**
- * @param {string} _
- * @param {number} quantity
- * @param {farmhand.item} item
- * @returns {string}
- */
-export const SOLD_ITEM_PEER_NOTIFICATION = (_, quantity, { name }) =>
+
+export const SOLD_ITEM_PEER_NOTIFICATION = (_: string, quantity: number, { name }): string =>
   `sold ${integerString(quantity)} unit${quantity > 1 ? 's' : ''} of ${name}.`
 
-/**
- * @param {string} _
- * @param {farmhand.item} item
- * @returns {string}
- */
-export const SOLD_FERMENTED_ITEM_PEER_NOTIFICATION = (_, item) =>
+
+export const SOLD_FERMENTED_ITEM_PEER_NOTIFICATION = (_: string, item: any): string =>
   `sold one unit of ${FERMENTED_CROP_NAME(_, item)}.`
 
 /**
- * @param {string} _
- * @param {string} toolName - the name of the tool being replaced
- * @param {string} upgradedName - the new name of the tool
+
+ * @param toolName - the name of the tool being replaced
+ * @param upgradedName - the new name of the tool
  */
-export const TOOL_UPGRADED_NOTIFICATION = (_, toolName, upgradedName) =>
+export const TOOL_UPGRADED_NOTIFICATION = (_: string, toolName: string, upgradedName: string) =>
   `Your ${toolName} has been upgraded to a **${upgradedName}**!`
 
 export const INGREDIENTS_LIST_ITEM = (
@@ -325,94 +243,54 @@ export const INGREDIENTS_LIST_ITEM = (
   quantityAvailable
 ) => `${ingredientName} x ${quantityNeeded} (On hand: ${quantityAvailable})`
 
-/**
- * @param {string} _
- * @param {string} cowDisplayName
- * @returns {string}
- */
-export const OFFER_COW_FOR_TRADE = (_, cowDisplayName) =>
+
+export const OFFER_COW_FOR_TRADE = (_: string, cowDisplayName: string): string =>
   `Offer ${cowDisplayName} for trade with online players`
 
-/**
- * @param {string} _
- * @param {string} cowDisplayName
- * @returns {string}
- */
-export const WITHDRAW_COW_FROM_TRADE = (_, cowDisplayName) =>
+
+export const WITHDRAW_COW_FROM_TRADE = (_: string, cowDisplayName: string): string =>
   `Keep ${cowDisplayName} from being traded`
 
-/**
- * @param {string} _
- * @param {farmhand.cow} cowTradedAway
- * @param {farmhand.cow} cowReceived
- * @param {string} playerId
- * @param {boolean} allowCustomPeerCowNames
- * @returns {string}
- */
+
 export const COW_TRADED_NOTIFICATION = (
-  _,
-  cowTradedAway,
-  cowReceived,
-  playerId,
-  allowCustomPeerCowNames
-) =>
+  _: string,
+  cowTradedAway: any,
+  cowReceived: any,
+  playerId: string,
+  allowCustomPeerCowNames: boolean
+): string =>
   `You traded ${getCowDisplayName(
     cowTradedAway,
     playerId,
     allowCustomPeerCowNames
   )} for ${getCowDisplayName(cowReceived, playerId, allowCustomPeerCowNames)}!`
 
-/**
- * @param {string} _
- * @param {farmhand.item} item
- * @returns {string}
- */
-export const SHOVELED_PLOT = (_, item) => `Shoveled plot of ${item.name}`
 
-/**
- * @param {string} _
- * @param {farmhand.item} item
- * @returns {string}
- */
-export const FERMENTED_CROP_NAME = (_, item) => `Fermented ${item.name}`
+export const SHOVELED_PLOT = (_: string, item: any): string => `Shoveled plot of ${item.name}`
 
-/**
- * @param {string} _
- * @param {farmhand.keg} keg
- * @returns {string}
- */
-export const KEG_SPOILED_MESSAGE = (_, keg) =>
+
+export const FERMENTED_CROP_NAME = (_: string, item: any): string => `Fermented ${item.name}`
+
+
+export const KEG_SPOILED_MESSAGE = (_: string, keg: any): string =>
   `Oh no! Your ${FERMENTED_CROP_NAME(_, itemsMap[keg.itemId])} has spoiled!`
 
-/**
- * @param {TemplateStringsArray} _
- * @param {farmhand.peerMetadata} peerMetadata
- * @returns {string}
- */
-export const NEW_COW_OFFERED_FOR_TRADE = (_, peerMetadata) =>
+
+export const NEW_COW_OFFERED_FOR_TRADE = (_: TemplateStringsArray, peerMetadata: any): string =>
   `A new cow is being offered for trade by ${getPlayerName(
     peerMetadata.playerId
   )}!`
 
-/**
- * @param {TemplateStringsArray} _
- * @param {number} numTrees
- * @returns {string}
- */
-export const FOREST_EXPANDED = (_, numTrees) =>
+
+export const FOREST_EXPANDED = (_: TemplateStringsArray, numTrees: number): string =>
   `The Forest has expanded! You can now plant up to ${numTrees} trees.`
 
-/**
- * @param {TemplateStringsArray} _
- * @param {number} experiencePointsToNextLevel
- * @param {number} nextLevel
- * @returns {string}
- */
+
 export const EXPERIENCE_GAUGE_TOOLTIP_LABEL = (
-  _,
-  experiencePointsToNextLevel,
-  nextLevel
-) => {
+  _: TemplateStringsArray,
+  experiencePointsToNextLevel: number,
+  nextLevel: number
+): string => {
   if (experiencePointsToNextLevel === 1) {
     return `Just 1 more experience point needed to reach level ${integerString(
       nextLevel

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -28,9 +28,7 @@ export const testTree = (item = {}) => ({
   ...item,
 })
 
-/**
- * @param {Partial<farmhand.shoveledPlot>} plotProps
- */
+
 export const testShoveledPlot = plotProps => ({
   isShoveled: true,
   daysUntilClear: 5,
@@ -51,10 +49,10 @@ export const testItem = (item = {}) => ({
 
 /**
  * Creates a minimal but complete farmhand.recipe object for testing
- * @param {Partial<farmhand.recipe>} overrides - Properties to override in the test recipe
- * @returns {farmhand.recipe}
+ * @param overrides - Properties to override in the test recipe
+
  */
-export const testRecipe = (overrides = {}) => ({
+export const testRecipe = (overrides: Partial<farmhand.recipe> = {}): any => ({
   id: 'sample-recipe-1',
   name: 'Test Recipe',
   description: 'A test recipe',
@@ -70,8 +68,8 @@ export const testRecipe = (overrides = {}) => ({
 
 /**
  * Creates a minimal but complete farmhand.state object for testing
- * @param {Partial<farmhand.state>} overrides - Properties to override in the test state
- * @returns {farmhand.state}
+ * @param overrides - Properties to override in the test state
+
  */
 export const testState = (
   overrides: Partial<farmhand.state> = {}

--- a/src/test-utils/stubs/cowStub.ts
+++ b/src/test-utils/stubs/cowStub.ts
@@ -1,9 +1,7 @@
 import { generateCow } from '../../utils/index.js'
 
-/**
- * @param {Partial<farmhand.cow>?} overrides
- */
-export const getCowStub = (overrides = {}) => {
+
+export const getCowStub = (overrides: Partial<farmhand.cow>? = {}) => {
   const cow = generateCow({
     baseWeight: 1000,
     ...overrides,

--- a/src/test-utils/stubs/farmhandStub.tsx
+++ b/src/test-utils/stubs/farmhandStub.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route } from 'react-router-dom'
 import Farmhand from '../../components/Farmhand/index.js'
 
 /**
- * @param {Object} [props] props to start the Farmhand instance with for
+ * @param [props] props to start the Farmhand instance with for
  * testing.
  */
 export const farmhandStub = async (props = {}) => {

--- a/src/test-utils/stubs/getKegStub.ts
+++ b/src/test-utils/stubs/getKegStub.ts
@@ -4,11 +4,8 @@ import { v4 as uuid } from 'uuid'
 
 import { carrot } from '../../data/crops/index.js'
 
-/**
- * @param {Partial<keg>} overrides
- * @returns {keg}
- */
-export const getKegStub = (overrides = {}) => {
+
+export const getKegStub = (overrides: Partial<keg> = {}): keg => {
   const carrotItem = carrot as farmhand.item
   return {
     id: uuid(),

--- a/src/test-utils/stubs/itemStub.ts
+++ b/src/test-utils/stubs/itemStub.ts
@@ -1,9 +1,6 @@
 import { itemType } from '../../enums.js'
 
-/**
- * @param {Partial<farmhand.item>} overrides
- * @returns {farmhand.item}
- */
+
 export const itemStub = overrides => ({
   id: 'sample-item',
   name: 'Sample Item',

--- a/src/test-utils/stubs/saveDataStubFactory.ts
+++ b/src/test-utils/stubs/saveDataStubFactory.ts
@@ -1,9 +1,7 @@
 import { computeStateForNextDay } from '../../game-logic/reducers/index.js'
 import { testState } from '../index.js'
 
-/**
- * @param {Partial<farmhand.state>} state
- */
+
 export const saveDataStubFactory = ({ dayCount = 1, ...restOverrides }) =>
   computeStateForNextDay(
     // dayCount is offset by 1 here to account for the fact that

--- a/src/utils/farmProductsSold.tsx
+++ b/src/utils/farmProductsSold.tsx
@@ -4,10 +4,7 @@ import { memoize } from './memoize.js'
 import { isItemAFarmProduct } from './isItemAFarmProduct.js'
 
 export const farmProductsSold = memoize(
-  /**
-   * @param {Partial<Record<string, number>>} itemsSold
-   * @returns {number}
-   */
+
   (itemsSold: Partial<Record<string, number>>) =>
     Object.entries(itemsSold).reduce(
       (sum, [itemId, numberSold]) =>

--- a/src/utils/findInField.ts
+++ b/src/utils/findInField.ts
@@ -3,11 +3,7 @@ import { memoize } from './memoize.js'
 import { memoizationSerializer } from './index.js'
 
 export const findInField = memoize(
-  /**
-   * @param {(?farmhand.plotContent)[][]} field
-   * @param {function(?farmhand.plotContent): boolean} condition
-   * @returns {?farmhand.plotContent}
-   */
+
   (field, condition) => {
     for (const row of field) {
       for (const plot of row) {

--- a/src/utils/getCropLifecycleDuration.ts
+++ b/src/utils/getCropLifecycleDuration.ts
@@ -1,8 +1,8 @@
 import { memoize } from './memoize.js'
 
 /**
- * @param {{ cropTimeline: number[] }} crop
- * @returns {number}
+ * @param } crop
+
  */
 export const getCropLifecycleDuration = memoize(
   ({ cropTimeline }: { cropTimeline: number[] }) => {

--- a/src/utils/getCropsAvailableToFerment.ts
+++ b/src/utils/getCropsAvailableToFerment.ts
@@ -6,16 +6,10 @@ import { itemsMap } from '../data/maps.js'
 
 import { getFinalCropItemFromSeedItem } from './index.js'
 
-/**
- * @param {levelEntitlements} levelEntitlements
- * @returns {item[]}
- */
-export function getCropsAvailableToFerment(levelEntitlements) {
+
+export function getCropsAvailableToFerment(levelEntitlements: levelEntitlements): item[] {
   const cropsAvailableToFerment = Object.keys(levelEntitlements.items).reduce(
-    /**
-     * @param {farmhand.item[]} acc
-     * @param {string} itemId
-     */
+
     (acc, itemId) => {
       const finalCropItemFromSeedItem = getFinalCropItemFromSeedItem(
         itemsMap[itemId]

--- a/src/utils/getInventoryQuantityMap.ts
+++ b/src/utils/getInventoryQuantityMap.ts
@@ -5,8 +5,8 @@ import { memoize } from './memoize.js'
 
 export const getInventoryQuantityMap = memoize(
   /**
-   * @param {{ id: item['id'], quantity: number }[]} inventory
-   * @returns {Record<item['id'], number>}
+   * @param []} inventory
+
    */
   (inventory: { id: string; quantity: number }[]) =>
     inventory.reduce((acc: Record<string, number>, { id, quantity }) => {

--- a/src/utils/getItemBaseValue.ts
+++ b/src/utils/getItemBaseValue.ts
@@ -1,7 +1,4 @@
 import { itemsMap } from '../data/maps.js'
 
-/**
- * @param {string} itemId
- * @returns {number}
- */
+
 export const getItemBaseValue = itemId => itemsMap[itemId].value

--- a/src/utils/getKegSpoilageRate.ts
+++ b/src/utils/getKegSpoilageRate.ts
@@ -4,7 +4,7 @@ import { KEG_SPOILAGE_RATE_MULTIPLIER } from '../constants.js'
 import { cellarService } from '../services/cellar.js'
 
 /**
- * @param {keg} keg
+
  * @returns number
  */
 export const getKegSpoilageRate = keg => {

--- a/src/utils/getKegValue.ts
+++ b/src/utils/getKegValue.ts
@@ -10,9 +10,7 @@ import { wineService } from '../services/wine.js'
 
 import { getItemBaseValue } from './getItemBaseValue.js'
 
-/**
- * @param {keg} keg
- */
+
 export const getKegValue = keg => {
   const { itemId, daysUntilMature } = keg
   const kegItem = itemsMap[itemId]

--- a/src/utils/getLevelEntitlements.ts
+++ b/src/utils/getLevelEntitlements.ts
@@ -5,15 +5,12 @@ import { INITIAL_SPRINKLER_RANGE } from '../constants.js'
 import { memoize } from './memoize.js'
 
 /**
- * @param {number} levelNumber
- * @returns {levelEntitlements} Contains `sprinklerRange` and keys that correspond to
+
+ * @returns Contains `sprinklerRange` and keys that correspond to
  * unlocked items.
  */
 export const getLevelEntitlements = memoize(
-  /**
-   * @param {number} levelNumber
-   * @returns {levelEntitlements}
-   */
+
   levelNumber => {
     const acc: farmhand.levelEntitlements = {
       sprinklerRange: INITIAL_SPRINKLER_RANGE,

--- a/src/utils/getMaxYieldOfFermentationRecipe.ts
+++ b/src/utils/getMaxYieldOfFermentationRecipe.ts
@@ -8,18 +8,18 @@ import { getInventoryQuantityMap } from './getInventoryQuantityMap.js'
 import { getSaltRequirementsForFermentationRecipe } from './getSaltRequirementsForFermentationRecipe.js'
 
 /**
- * @param {item} fermentationRecipe
- * @param {{ id: string, quantity: number }[]} inventory
- * @param {Array.<keg>} cellarInventory
- * @param {number} cellarSize
- * @returns {number}
+
+ * @param []} inventory
+
+
+
  */
 export const getMaxYieldOfFermentationRecipe = (
-  fermentationRecipe,
+  fermentationRecipe: item,
   inventory,
-  cellarInventory,
-  cellarSize
-) => {
+  cellarInventory: keg[],
+  cellarSize: number
+): number => {
   const {
     [fermentationRecipe.id]: itemQuantityInInventory = 0,
     [(itemsMap as Record<string, farmhand.item>).salt

--- a/src/utils/getSaltRequirementsForFermentationRecipe.ts
+++ b/src/utils/getSaltRequirementsForFermentationRecipe.ts
@@ -1,9 +1,6 @@
 const saltRequirementMultiplier = 2 / 3
 
-/**
- * @param {farmhand.item} fermentationRecipe
- * @returns {number}
- */
+
 export const getSaltRequirementsForFermentationRecipe = fermentationRecipe => {
   const { daysToFerment = 0, tier = 1 } = fermentationRecipe
 

--- a/src/utils/getWineVarietiesAvailableToMake.ts
+++ b/src/utils/getWineVarietiesAvailableToMake.ts
@@ -7,11 +7,8 @@
 import { isGrape } from '../data/crops/grape.js'
 import { itemsMap } from '../data/maps.js'
 
-/**
- * @param {itemsSold} itemsSold
- * @returns {grape[]}
- */
-const getGrapesSold = (itemsSold: farmhand.state['itemsSold']) => {
+
+const getGrapesSold = (itemsSold: farmhand.state['itemsSold']): grape[] => {
   const grapesSold = Object.entries(itemsSold).reduce(
     (acc: farmhand.grape[], [itemId, quantity]) => {
       const item = itemsMap[itemId]
@@ -28,13 +25,10 @@ const getGrapesSold = (itemsSold: farmhand.state['itemsSold']) => {
   return grapesSold
 }
 
-/**
- * @param {itemsSold} itemsSold
- * @returns {farmhand.grapeVariety[]}
- */
+
 export function getWineVarietiesAvailableToMake(
   itemsSold: farmhand.state['itemsSold']
-) {
+): any {
   const grapesSold = getGrapesSold(itemsSold)
 
   const winesVarietiesAvailableToMake = grapesSold.map(({ variety }) => variety)

--- a/src/utils/getYeastRequiredForWine.ts
+++ b/src/utils/getYeastRequiredForWine.ts
@@ -3,9 +3,7 @@ import { YEAST_REQUIREMENT_FOR_WINE_MULTIPLIER } from '../constants.js'
 // eslint-disable-next-line no-unused-vars
 import { grapeVariety as grapeVarietyEnum } from '../enums.js'
 
-/**
- * @param {grapeVarietyEnum} grapeVariety
- */
+
 export const getYeastRequiredForWine = grapeVariety => {
   return (
     wineVarietyValueMap[grapeVariety] * YEAST_REQUIREMENT_FOR_WINE_MULTIPLIER

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -86,18 +86,12 @@ const Jimp = configureJimp({
 
 const { SEED, GROWING, GROWN } = cropLifeStage
 
-/**
- * @param {unknown} obj
- * @returns {obj is farmhand.plotContent}
- */
-const isPlotContent = (obj = {}) =>
+
+const isPlotContent = (obj: unknown = {}): obj is farmhand.plotContent =>
   Boolean(obj && obj['itemId'] && obj['fertilizerType'])
 
-/**
- * @param {unknown} obj
- * @returns {obj is farmhand.shoveledPlot}
- */
-const isShoveledPlot = (obj = {}) =>
+
+const isShoveledPlot = (obj: unknown = {}): obj is farmhand.shoveledPlot =>
   Boolean(obj && obj['isShoveled'] && obj['daysUntilClear'])
 
 const purchasableItemMap = [...cowShopInventory, ...shopInventory].reduce(
@@ -108,17 +102,11 @@ const purchasableItemMap = [...cowShopInventory, ...shopInventory].reduce(
   {}
 )
 
-/**
- * @param {Array.<*>} list
- * @return {number}
- */
+
 export const chooseRandomIndex = list =>
   Math.round(random() * (list.length - 1))
 
-/**
- * @param {Array.<*>} list
- * @return {*}
- */
+
 export const chooseRandom = list => list[chooseRandomIndex(list)]
 
 /**
@@ -127,51 +115,42 @@ export const chooseRandom = list => list[chooseRandomIndex(list)]
  *
  * Pass this is the `serializer` option to any memoize()-ed functions that
  * accept function arguments.
- * @param {any[]} args
+
  */
 export const memoizationSerializer = args =>
   JSON.stringify(
     [...args].map(arg => (typeof arg === 'function' ? arg.toString() : arg))
   )
 
-/**
- * @param {number} num
- * @param {number} min
- * @param {number} max
- */
-export const clampNumber = (num, min, max) =>
+
+export const clampNumber = (num: number, min: number, max: number) =>
   num <= min ? min : num >= max ? max : num
 
-/**
- * @param {number} num
- */
+
 export const castToMoney = num => Math.round(num * 100) / 100
 
 /**
  * Safely adds dollar figures to avoid IEEE 754 rounding errors.
- * @param {...number} args Numbers that represent money values.
- * @returns {number}
+ * @param args Numbers that represent money values.
+
  * @see http://adripofjavascript.com/blog/drips/avoiding-problems-with-decimal-math-in-javascript.html
  */
-export const moneyTotal = (...args) =>
+export const moneyTotal = (...args): number =>
   args.reduce((sum, num) => (sum += Math.round(num * 100)), 0) / 100
 
 /**
  * Based on https://stackoverflow.com/a/14224813/470685
- * @param {number} value Number to scale
- * @param {number} min Non-standard minimum
- * @param {number} max Non-standard maximum
- * @param {number} baseMin Standard minimum
- * @param {number} baseMax Standard maximum
- * @returns {number}
+ * @param value Number to scale
+ * @param min Non-standard minimum
+ * @param max Non-standard maximum
+ * @param baseMin Standard minimum
+ * @param baseMax Standard maximum
+
  */
-export const scaleNumber = (value, min, max, baseMin, baseMax) =>
+export const scaleNumber = (value: number, min: number, max: number, baseMin: number, baseMax: number): number =>
   ((value - min) * (baseMax - baseMin)) / (max - min) + baseMin
 
-/**
- * @param {string} string
- * @returns {number}
- */
+
 const convertStringToInteger = string =>
   string.split('').reduce((acc, char, i) => acc + char.charCodeAt(0) * i, 0)
 
@@ -187,8 +166,8 @@ export const createNewForest = () => {
 }
 
 /**
- * @param {number} number
- * @returns {string} Include dollar sign and other formatting. Cents are
+
+ * @returns Include dollar sign and other formatting. Cents are
  * rounded off.
  */
 export const dollarString = number =>
@@ -204,8 +183,8 @@ export const dollarString = number =>
   )
 
 /**
- * @param {number} number
- * @returns {string} Number string with commas.
+
+ * @returns Number string with commas.
  */
 export const integerString = number =>
   toDecimal(
@@ -214,17 +193,13 @@ export const integerString = number =>
   )
 
 /**
- * @param {number} number A float
- * @returns {string} the float converted to a full number with a % added
+ * @param number A float
+ * @returns the float converted to a full number with a % added
  */
 export const percentageString = number => `${Math.round(number * 100)}%`
 
-/**
- * @param {farmhand.item} item
- * @param {Record<string, number>} valueAdjustments
- * @returns {number}
- */
-export const getItemCurrentValue = ({ id }, valueAdjustments) => {
+
+export const getItemCurrentValue = ({ id }, valueAdjustments: Record<string, number>): number => {
   const amount = Math.round(
     (valueAdjustments[id]
       ? getItemBaseValue(id) *
@@ -236,38 +211,26 @@ export const getItemCurrentValue = ({ id }, valueAdjustments) => {
 }
 
 /**
- * @param {Record<string, number>} valueAdjustments
- * @param {string} itemId
- * @returns {number} Rounded to a money value.
+
+
+ * @returns Rounded to a money value.
  */
-export const getAdjustedItemValue = (valueAdjustments, itemId) =>
+export const getAdjustedItemValue = (valueAdjustments: Record<string, number>, itemId: string): number =>
   Number(((valueAdjustments[itemId] || 1) * itemsMap[itemId].value).toFixed(2))
 
-/**
- * @param {farmhand.item} item
- * @returns {boolean}
- */
-export const isItemSoldInShop = ({ id }) => Boolean(purchasableItemMap[id])
 
-/**
- * @param {farmhand.item} item
- * @returns {number}
- */
-export const getResaleValue = ({ id }) => itemsMap[id].value / 2
+export const isItemSoldInShop = ({ id }): boolean => Boolean(purchasableItemMap[id])
 
-/**
- * @param {string} itemId
- * @returns {farmhand.plotContent}
- */
+
+export const getResaleValue = ({ id }): number => itemsMap[id].value / 2
+
+
 export const getPlotContentFromItemId = itemId => ({
   itemId,
   fertilizerType: fertilizerType.NONE,
 })
 
-/**
- * @param {string} itemId
- * @returns {farmhand.crop}
- */
+
 export const getCropFromItemId = itemId => ({
   ...getPlotContentFromItemId(itemId),
   daysOld: 0,
@@ -275,17 +238,11 @@ export const getCropFromItemId = itemId => ({
   wasWateredToday: false,
 })
 
-/**
- * @param {farmhand.plotContent} plotContent
- * @returns {?string}
- */
-export const getPlotContentType = ({ itemId }) =>
+
+export const getPlotContentType = ({ itemId }): string =>
   itemId ? itemsMap[itemId].type : null
 
-/**
- * @param {?farmhand.plotContent} plot
- * @returns {plot is farmhand.crop}
- */
+
 export const doesPlotContainCrop = plot =>
   plot !== null && getPlotContentType(plot) === itemType.CROP
 
@@ -305,10 +262,7 @@ export const getLifeStageRange = memoize((cropTimeline: number[]) => {
   return lifeStageRange
 }, {})
 
-/**
- * @param {farmhand.crop} crop
- * @returns {number}
- */
+
 export const getGrowingPhase = memoize(
   crop => {
     const { itemId, daysWatered } = crop
@@ -333,10 +287,7 @@ export const getGrowingPhase = memoize(
   }
 )
 
-/**
- * @param {farmhand.crop} crop
- * @returns {farmhand.cropLifeStage}
- */
+
 export const getCropLifeStage = crop => {
   const { itemId, daysWatered } = crop
   const { cropTimeline } = itemsMap[itemId]
@@ -348,13 +299,8 @@ export const getCropLifeStage = crop => {
   return getLifeStageRange(cropTimeline)[Math.floor(daysWatered || 0)] || GROWN
 }
 
-/**
- * @param {farmhand.plotContent | farmhand.shoveledPlot | null} plotContents
- * @param {number} x
- * @param {number} y
- * @returns {?string}
- */
-export const getPlotImage = (plotContents, x, y) => {
+
+export const getPlotImage = (plotContents: any, x: number, y: number): string => {
   if (isPlotContent(plotContents)) {
     if (isPlotContentACrop(plotContents)) {
       let itemImageId
@@ -396,13 +342,8 @@ export const getPlotImage = (plotContents, x, y) => {
   return null
 }
 
-/**
- * @param {number} rangeSize
- * @param {number} centerX
- * @param {number} centerY
- * @returns {{x: number, y: number}[][]}
- */
-export const getRangeCoords = (rangeSize, centerX, centerY) => {
+
+export const getRangeCoords = (rangeSize: number, centerX: number, centerY: number): {x: number, y: number => {
   const squareSize = 2 * rangeSize + 1
   const rangeStartX = centerX - rangeSize
   const rangeStartY = centerY - rangeSize
@@ -415,26 +356,18 @@ export const getRangeCoords = (rangeSize, centerX, centerY) => {
   )
 }
 
-/**
- * @param {farmhand.item} item
- * @param {number} [variantIdx]
- * @returns {farmhand.item | undefined}
- */
-export const getFinalCropItemFromSeedItem = ({ id }, variantIdx = 0) => {
+
+export const getFinalCropItemFromSeedItem = ({ id }, variantIdx?: number = 0): any => {
   const itemId = getFinalCropItemIdFromSeedItemId(id, variantIdx)
 
   if (itemId) return itemsMap[itemId]
 }
 
-/**
- * @param {string} seedItemId
- * @param {number} [variationIdx]
- * @returns {string=}
- */
+
 export const getFinalCropItemIdFromSeedItemId = (
-  seedItemId,
-  variationIdx = 0
-) => {
+  seedItemId: string,
+  variationIdx?: number = 0
+): string => {
   const { growsInto } = itemsMap[seedItemId]
 
   if (Array.isArray(growsInto)) {
@@ -469,20 +402,12 @@ export const getSeedItemIdFromFinalStageCropItemId = memoize(
   }
 )
 
-/**
- * @param {farmhand.cow} cow
- * @returns {string}
- */
-const getDefaultCowName = ({ id }) =>
+
+const getDefaultCowName = ({ id }): string =>
   fruitNames[convertStringToInteger(id) % fruitNames.length]
 
-/**
- * @param {farmhand.cow} cow
- * @param {string} playerId
- * @param {boolean} allowCustomPeerCowNames
- * @returns {string}
- */
-export const getCowDisplayName = (cow, playerId, allowCustomPeerCowNames) => {
+
+export const getCowDisplayName = (cow: any, playerId: string, allowCustomPeerCowNames: boolean): string => {
   return cow.originalOwnerId !== playerId && !allowCustomPeerCowNames
     ? getDefaultCowName(cow)
     : cow.name
@@ -490,8 +415,8 @@ export const getCowDisplayName = (cow, playerId, allowCustomPeerCowNames) => {
 
 /**
  * Generates a friendly cow.
- * @param {Object} [options]
- * @returns {farmhand.cow}
+
+
  */
 export const generateCow = (
   options: {
@@ -546,13 +471,13 @@ export const generateCow = (
 
 /**
  * Generates a cow based on two parents.
- * @param {farmhand.cow} cow1
- * @param {farmhand.cow} cow2
- * @param {string} ownerId
- * @param {Partial<farmhand.cow>?} customProps
- * @returns {farmhand.cow}
+
+
+
+
+
  */
-export const generateOffspringCow = (cow1, cow2, ownerId, customProps = {}) => {
+export const generateOffspringCow = (cow1: any, cow2: any, ownerId: string, customProps: Partial<farmhand.cow>? = {}): any => {
   if (cow1.gender === cow2.gender) {
     throw new Error(
       `${JSON.stringify(cow1)} ${JSON.stringify(
@@ -593,11 +518,8 @@ export const generateOffspringCow = (cow1, cow2, ownerId, customProps = {}) => {
   })
 }
 
-/**
- * @param {farmhand.cow} cow
- * @returns {farmhand.item}
- */
-export const getCowMilkItem = ({ color, happiness }) => {
+
+export const getCowMilkItem = ({ color, happiness }): any => {
   if (color === cowColors.BROWN) {
     return chocolateMilk
   }
@@ -613,17 +535,11 @@ export const getCowMilkItem = ({ color, happiness }) => {
   return isRainbowCow ? rainbowMilk3 : milk3
 }
 
-/**
- * @param {farmhand.cow} cow
- * @returns {farmhand.item}
- */
-export const getCowFertilizerItem = ({ color }) =>
+
+export const getCowFertilizerItem = ({ color }): any =>
   itemsMap[color === cowColors.RAINBOW ? 'rainbow-fertilizer' : 'fertilizer']
 
-/**
- * @param {farmhand.cow} cow
- * @returns {number}
- */
+
 export const getCowMilkRate = cow =>
   cow.gender === genders.FEMALE
     ? scaleNumber(
@@ -635,10 +551,7 @@ export const getCowMilkRate = cow =>
       )
     : Infinity
 
-/**
- * @param {farmhand.cow} cow
- * @returns {number}
- */
+
 export const getCowFertilizerProductionRate = cow =>
   cow.gender === genders.MALE
     ? scaleNumber(
@@ -650,19 +563,16 @@ export const getCowFertilizerProductionRate = cow =>
       )
     : Infinity
 
-/**
- * @param {farmhand.cow} cow
- * @returns {number}
- */
-export const getCowWeight = ({ baseWeight, weightMultiplier }) =>
+
+export const getCowWeight = ({ baseWeight, weightMultiplier }): number =>
   Math.round(baseWeight * weightMultiplier)
 
 /**
- * @param {farmhand.cow} cow
- * @param {boolean} [computeSaleValue=false]
- * @returns {number}
+
+ * @param [computeSaleValue=false]
+
  */
-export const getCowValue = (cow, computeSaleValue = false) =>
+export const getCowValue = (cow: any, computeSaleValue?: boolean = false): number =>
   computeSaleValue
     ? getCowWeight(cow) *
       clampNumber(
@@ -678,15 +588,13 @@ export const getCowValue = (cow, computeSaleValue = false) =>
       )
     : getCowWeight(cow) * 1.5
 
-/**
- * @param {farmhand.cow} cow
- */
+
 export const getCowSellValue = cow => getCowValue(cow, true)
 
 /**
- * @param {farmhand.recipe} recipe
- * @param {{id: string, quantity: number}[]} inventory
- * @returns {number}
+
+ * @param []} inventory
+
  */
 export const maxYieldOfRecipe = memoize(
   (
@@ -707,25 +615,19 @@ export const maxYieldOfRecipe = memoize(
 )
 
 /**
- * @param {farmhand.recipe} recipe
- * @param {{id: string, quantity: number}[]} inventory
- * @param {number} howMany
- * @returns {boolean}
+
+ * @param []} inventory
+
+
  */
-export const canMakeRecipe = (recipe, inventory, howMany) =>
+export const canMakeRecipe = (recipe: any, inventory, howMany: number): boolean =>
   maxYieldOfRecipe(recipe, inventory) >= howMany
 
-/**
- * @param {string[]} itemsIds
- * @returns {string[]}
- */
+
 export const filterItemIdsToSeeds = itemsIds =>
   itemsIds.filter(id => itemsMap[id]?.type === itemType.CROP)
 
-/**
- * @param {Array.<string>} unlockedSeedItemIds
- * @returns {farmhand.item}
- */
+
 export const getRandomUnlockedCrop = unlockedSeedItemIds => {
   const seedItemId = chooseRandom(unlockedSeedItemIds)
   const seedItem = itemsMap[seedItemId]
@@ -746,10 +648,7 @@ export const getRandomUnlockedCrop = unlockedSeedItemIds => {
   return itemsMap[finalCropItemId]
 }
 
-/**
- * @param {farmhand.item} cropItem
- * @returns {farmhand.priceEvent}
- */
+
 export const getPriceEventForCrop = cropItem => ({
   itemId: cropItem.id,
   daysRemaining:
@@ -759,7 +658,7 @@ export const getPriceEventForCrop = cropItem => ({
 export const doesMenuObstructStage = () => window.innerWidth < BREAKPOINTS.MD
 
 /** @type {Set<farmhand.itemType>} */
-const itemTypesToShowInReverse = new Set([itemType.MILK])
+const itemTypesToShowInReverse: Set<farmhand.itemType> = new Set([itemType.MILK])
 
 const sortItemIdsByTypeAndValue = memoize(
   (itemIds: string[]) =>
@@ -773,10 +672,7 @@ const sortItemIdsByTypeAndValue = memoize(
   {}
 )
 
-/**
- * @param {Array.<farmhand.item>} items
- * @return {Array.<farmhand.item>}
- */
+
 export const sortItems = items => {
   const map = {}
   items.forEach(item => (map[item.id] = item))
@@ -785,43 +681,31 @@ export const sortItems = items => {
 }
 
 export const inventorySpaceConsumed = memoize(
-  /**
-   * @param {farmhand.state['inventory']} inventory
-   * @returns {number}
-   */
+
   (inventory: Array<{ quantity?: number }>) =>
     inventory.reduce((sum, { quantity = 0 }) => sum + quantity, 0),
   {}
 )
 
 /**
- * @param {{ inventory: farmhand.state['inventory'], inventoryLimit: farmhand.state['inventoryLimit'] }} state
- * @returns {number}
+ * @param } state
+
  */
-export const inventorySpaceRemaining = ({ inventory, inventoryLimit }) =>
+export const inventorySpaceRemaining = ({ inventory, inventoryLimit }): number =>
   inventoryLimit === INFINITE_STORAGE_LIMIT
     ? Infinity
     : Math.max(0, inventoryLimit - inventorySpaceConsumed(inventory))
 
-/**
- * @param {farmhand.state} state
- * @returns {boolean}
- */
+
 export const doesInventorySpaceRemain = state =>
   inventorySpaceRemaining(state) > 0
 
 export const areHuggingMachinesInInventory = memoize(
-  /**
-   * @param {farmhand.state['inventory']} inventory
-   * @return {boolean}
-   */
+
   inventory => inventory.some(({ id }) => id === HUGGING_MACHINE_ITEM_ID)
 )
 
-/**
- * @param {number} arraySize
- * @returns {Array.<null>}
- */
+
 export const nullArray = memoize(
   arraySize => Object.freeze(new Array(arraySize).fill(null)),
   {
@@ -830,18 +714,11 @@ export const nullArray = memoize(
 )
 
 export const findCowById = memoize(
-  /**
-   * @param {Array.<farmhand.cow>} cowInventory
-   * @param {string} id
-   * @returns {farmhand.cow|undefined}
-   */
+
   (cowInventory, id) => cowInventory.find(cow => id === cow.id)
 )
 
-/**
- * @param {number} targetLevel
- * @returns {number}
- */
+
 export const experienceNeededForLevel = targetLevel =>
   ((targetLevel - 1) * 10) ** 2
 
@@ -858,8 +735,8 @@ export const getAvailableShopInventory = memoize((
 )
 
 /**
- * @param {number} level
- * @returns {farmhand.item} Will always be a crop seed item.
+
+ * @returns Will always be a crop seed item.
  */
 export const getRandomLevelUpReward = level =>
   itemsMap[
@@ -868,20 +745,14 @@ export const getRandomLevelUpReward = level =>
     )
   ]
 
-/**
- * @param {number} level
- * @returns {number}
- */
+
 export const getRandomLevelUpRewardQuantity = level => level * 10
 
 /**
- * @param {farmhand.state} state
- * @returns {Object} Data that is meant to be shared with Trystero peers.
+
+ * @returns Data that is meant to be shared with Trystero peers.
  */
-/**
- * @param {farmhand.state} state
- * @returns {farmhand.peerMetadata}
- */
+
 export const getPeerMetadata = state => {
   const reducedState = PEER_METADATA_STATE_KEYS.reduce(
     (acc, key) => {
@@ -902,8 +773,8 @@ export const getPeerMetadata = state => {
 }
 
 /**
- * @param {Partial<farmhand.state>} state
- * @returns {farmhand.state} A version of `state` that only contains keys of
+
+ * @returns A version of `state` that only contains keys of
  * farmhand.state data that should be persisted.
  */
 export const reduceByPersistedKeys = state =>
@@ -921,8 +792,8 @@ export const reduceByPersistedKeys = state =>
   }, {})
 
 /**
- * @param {Array.<number>} historicalData Must be no longer than 7 numbers long.
- * @return {number}
+ * @param historicalData Must be no longer than 7 numbers long.
+
  */
 export const get7DayAverage = historicalData =>
   historicalData.reduce((sum, revenue) => moneyTotal(sum, revenue), 0) /
@@ -941,36 +812,27 @@ const cowColorToIdMap = {
 
 export const getCowColorId = ({ color }) => `${cowColorToIdMap[color]}-cow`
 
-/**
- * @param {number} revenue
- * @param {number} losses
- * @return {number}
- */
-export const getProfit = (revenue, losses) => moneyTotal(revenue, losses)
 
-/**
- * @param {number} recordSingleDayProfit
- * @param {number} todaysRevenue
- * @param {number} todaysLosses
- * @returns {number}
- */
+export const getProfit = (revenue: number, losses: number): number => moneyTotal(revenue, losses)
+
+
 export const getProfitRecord = (
-  recordSingleDayProfit,
-  todaysRevenue,
-  todaysLosses
-) => Math.max(recordSingleDayProfit, getProfit(todaysRevenue, todaysLosses))
+  recordSingleDayProfit: number,
+  todaysRevenue: number,
+  todaysLosses: number
+): number => Math.max(recordSingleDayProfit, getProfit(todaysRevenue, todaysLosses))
 
 /**
- * @param {farmhand.state['todaysStartingInventory']} todaysStartingInventory
- * @param {farmhand.state['todaysPurchases']} todaysPurchases
- * @param {{ id: farmhand.item['id'], quantity: number }[]} inventory
- * @return {Object} Keys are item IDs, values are either 1 or -1.
+
+
+ * @param []} inventory
+ * @return Keys are item IDs, values are either 1 or -1.
  */
 export const computeMarketPositions = (
-  todaysStartingInventory,
-  todaysPurchases,
+  todaysStartingInventory: any,
+  todaysPurchases: any,
   inventory
-) =>
+): Object =>
   inventory.reduce((acc, { id, quantity: endingPosition }) => {
     const startingInventory = todaysStartingInventory[id] || 0
     const purchaseQuantity = todaysPurchases[id] || 0
@@ -996,10 +858,7 @@ export const computeMarketPositions = (
     return acc
   }, {})
 
-/**
- * @param {farmhand.state} state
- * @return {farmhand.state}
- */
+
 export const transformStateDataForImport = /** @type {(state: any) => farmhand.state} */ state => {
   let sanitizedState = { ...state }
 
@@ -1067,19 +926,13 @@ export const transformStateDataForImport = /** @type {(state: any) => farmhand.s
 }
 
 export const getPlayerName = memoize(
-  /**
-   * @param {string} playerId
-   * @returns {string}
-   */
+
   playerId => {
     return funAnimalName(playerId)
   }
 )
 
-/**
- * @param {number} currentInventoryLimit
- * @returns {number}
- */
+
 export const getCostOfNextStorageExpansion = currentInventoryLimit => {
   const upgradesPurchased =
     (currentInventoryLimit - INITIAL_STORAGE_LIMIT) / STORAGE_EXPANSION_AMOUNT
@@ -1092,16 +945,16 @@ export const getCostOfNextStorageExpansion = currentInventoryLimit => {
 
 /**
  * Create a no-op Promise that resolves in a specified amount of time.
- * @param {number} ms
- * @returns {Promise<void>}
+
+
  */
 export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 /**
- * @param {object} completedAchievements from game state
- * @returns {number} multiplier to be used for sales price adjustments based on completedAchievements
+ * @param completedAchievements from game state
+ * @returns multiplier to be used for sales price adjustments based on completedAchievements
  */
-export const getSalePriceMultiplier = (completedAchievements = {}) => {
+export const getSalePriceMultiplier = (completedAchievements: object = {}): number => {
   let salePriceMultiplier = 1
 
   if (completedAchievements['i-am-rich-3']) {
@@ -1115,17 +968,14 @@ export const getSalePriceMultiplier = (completedAchievements = {}) => {
   return salePriceMultiplier
 }
 
-/**
- * @param {farmhand.plotContent} plotContents
- * @returns {plotContents is farmhand.crop}
- */
+
 const isPlotContentACrop = plotContents =>
   getPlotContentType(plotContents) === itemType.CROP
 
 /**
  * @template T
- * @param {Array.<T & { weight: number }>} weightedOptions an array of objects each containing a `weight` property
- * @returns {T} one of the items from weightedOptions
+ * @param >} weightedOptions an array of objects each containing a `weight` property
+ * @returns one of the items from weightedOptions
  */
 export function randomChoice<T extends { weight: number }>(
   weightedOptions: T[]
@@ -1181,9 +1031,9 @@ const colorizeCowTemplate = (() => {
   })
 
   /**
-   * @param {string} cowTemplate Base64 representation of an image
-   * @param {string} color
-   * @returns {Promise.<string>} Base64 representation of an image
+   * @param cowTemplate Base64 representation of an image
+
+   * @returns Base64 representation of an image
    */
   return async (cowTemplate, color) => {
     if (color === cowColors.RAINBOW) return animals.cow.rainbow
@@ -1236,8 +1086,8 @@ const colorizeCowTemplate = (() => {
 })()
 
 /**
- * @param {farmhand.cow} cow
- * @returns {Promise<string>} Base64 representation of an image
+
+ * @returns Base64 representation of an image
  */
 export const getCowImage = async cow => {
   const cowIdNumber = convertStringToInteger(cow.id)
@@ -1249,8 +1099,8 @@ export const getCowImage = async cow => {
 
 /**
  * Adapted from https://www.javascripttutorial.net/dom/css/check-if-an-element-is-visible-in-the-viewport/
- * @param {Element} element
- * @returns {boolean}
+
+
  */
 export const isInViewport = element => {
   const { top, left, bottom, right } = element.getBoundingClientRect()
@@ -1266,20 +1116,12 @@ export const isInViewport = element => {
 export const shouldPrecipitateToday = () => random() < PRECIPITATION_CHANCE
 export const shouldStormToday = () => random() < STORM_CHANCE
 
-/**
- * @param {farmhand.cow} cow
- * @param {farmhand.cowBreedingPen} cowBreedingPen
- * @returns {boolean}
- */
-export const isCowInBreedingPen = (cow, cowBreedingPen) =>
+
+export const isCowInBreedingPen = (cow: any, cowBreedingPen: any): boolean =>
   cowBreedingPen.cowId1 === cow.id || cowBreedingPen.cowId2 === cow.id
 
-/**
- * @returns {boolean}
- */
-export const isOctober = () => new Date().getMonth() === 9
 
-/**
- * @returns {boolean}
- */
-export const isDecember = () => new Date().getMonth() === 11
+export const isOctober = (): boolean => new Date().getMonth() === 9
+
+
+export const isDecember = (): boolean => new Date().getMonth() === 11

--- a/src/utils/isItemAFarmProduct.ts
+++ b/src/utils/isItemAFarmProduct.ts
@@ -10,10 +10,7 @@ const FARM_PRODUCT_TYPES = [
   itemType.STONE,
 ]
 
-/**
- * @param {farmhand.item} item
- * @returns {boolean}
- */
+
 export const isItemAFarmProduct = item =>
   Boolean(
     isItemAGrownCrop(item) ||

--- a/src/utils/isItemAGrownCrop.ts
+++ b/src/utils/isItemAGrownCrop.ts
@@ -1,8 +1,5 @@
 import { itemType } from '../enums.js'
 
-/**
- * @param {farmhand.item} item
- * @returns {boolean}
- */
+
 export const isItemAGrownCrop = item =>
   Boolean(item.type === itemType.CROP && !item.growsInto)

--- a/src/utils/levelAchieved.ts
+++ b/src/utils/levelAchieved.ts
@@ -1,7 +1,4 @@
-/**
- * @param {number} [experience]
- * @returns {number}
- */
-export function levelAchieved(experience = 0) {
+
+export function levelAchieved(experience?: number = 0): number {
   return Math.floor(Math.sqrt(experience) / 10) + 1
 }

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -16,9 +16,9 @@ export class MemoizeCache {
   cacheSize: number
 
   /**
-   * @param {Object} [config] Can also contain the config options used to
+   * @param [config] Can also contain the config options used to
    * configure fast-memoize.
-   * @param {number} [config.cacheSize]
+   * @param [config.cacheSize]
    * @see https://github.com/caiogondim/fast-memoize.js
    */
   constructor({ cacheSize = MEMOIZE_CACHE_CLEAR_THRESHOLD } = {}) {
@@ -44,12 +44,12 @@ export class MemoizeCache {
 
 /**
  * @template {(...args: any[]) => any} T Copied from https://github.com/caiogondim/fast-memoize.js/blob/5cdfc8dde23d86b16e0104bae1b04cd447b98c63/typings/fast-memoize.d.ts#L1
- * @param {T} fn
- * @param {MemoizeOptions & Partial<{ cacheSize: number }>} [config]
+
+ * @param >} [config]
  * @returns T
  * @see https://github.com/caiogondim/fast-memoize.js
  */
-export const memoize = (fn, config = {}) =>
+export const memoize = (fn: T, config = {}) =>
   fastMemoize(fn, {
     cache: { create: () => new MemoizeCache(config) },
     ...config,

--- a/src/utils/moneyString.ts
+++ b/src/utils/moneyString.ts
@@ -1,8 +1,8 @@
 import { dinero, toDecimal, USD } from 'dinero.js'
 
 /**
- * @param {number} number
- * @returns {string} Include dollar sign and other formatting, as well as cents.
+
+ * @returns Include dollar sign and other formatting, as well as cents.
  */
 
 export const moneyString = number =>


### PR DESCRIPTION
Convert all JSDoc type definitions to TypeScript type definitions. Avoid Using JSDoc where TypeScript can suffice. DO NOT remove non-type comments/documentation.

---
*PR created automatically by Jules for task [8441152296698958445](https://jules.google.com/task/8441152296698958445) started by @jeremyckahn*