### PR TITLE
Prevent accidental feature enablement via query parameters

### DIFF
--- a/e2e/fixtures/near-level-15.json
+++ b/e2e/fixtures/near-level-15.json
@@ -1,0 +1,457 @@
+{
+  "allowCustomPeerCowNames": false,
+  "cellarInventory": [],
+  "completedAchievements": {
+    "plant-crop": true,
+    "water-crop": true
+  },
+  "cowBreedingPen": {
+    "cowId1": null,
+    "cowId2": null,
+    "daysUntilBirth": -1
+  },
+  "cowColorsPurchased": {},
+  "cowForSale": {
+    "baseWeight": 1601,
+    "color": "GREEN",
+    "colorsInBloodline": {
+      "GREEN": true
+    },
+    "daysOld": 1,
+    "daysSinceMilking": 0,
+    "daysSinceProducingFertilizer": 0,
+    "gender": "FEMALE",
+    "happiness": 0,
+    "happinessBoostsToday": 0,
+    "id": "b93a9c59-f73f-4986-b44e-ffb422bcd4c2",
+    "isBred": false,
+    "isUsingHuggingMachine": false,
+    "name": "Guava",
+    "ownerId": "",
+    "originalOwnerId": "",
+    "timesTraded": 0,
+    "weightMultiplier": 1
+  },
+  "cowInventory": [],
+  "cowsSold": {},
+  "cowsTraded": 0,
+  "cropsHarvested": {},
+  "dayCount": 6,
+  "experience": 0,
+  "farmName": "Unnamed",
+  "field": [
+    [
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      null,
+      null,
+      null
+    ],
+    [
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      null,
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      }
+    ],
+    [
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      {
+        "itemId": "carrot",
+        "fertilizerType": "NONE",
+        "daysOld": 5,
+        "daysWatered": 5,
+        "wasWateredToday": true
+      },
+      null,
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      }
+    ],
+    [
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      null,
+      null,
+      {
+        "itemId": "scarecrow",
+        "fertilizerType": "NONE"
+      },
+      null,
+      null
+    ],
+    [
+      null,
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      null
+    ],
+    [null, null, null, null, null, null],
+    [
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      null,
+      null,
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      }
+    ],
+    [
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      null,
+      null
+    ],
+    [
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      null
+    ],
+    [
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      },
+      null,
+      {
+        "itemId": "weed",
+        "fertilizerType": "NONE"
+      }
+    ]
+  ],
+  "forest": [[null, null, null, null]],
+  "historicalDailyLosses": [0, 0, 0, 0, -143.7],
+  "historicalDailyRevenue": [0, 0, 0, 0, 0],
+  "historicalValueAdjustments": [
+    {
+      "asparagus": 1.254561372610583,
+      "asparagus-seed": 0.8845336867381606,
+      "bronze-ore": 0.8820993693168143,
+      "carrot": 0.5151057244898383,
+      "carrot-seed": 0.8007552689761459,
+      "corn": 1.0577673788621866,
+      "corn-seed": 0.8492871019468962,
+      "garlic": 0.6502095798811709,
+      "garlic-seed": 0.6776417342031218,
+      "gold-ore": 1.1584127926987628,
+      "grape-cabernet-sauvignon": 1.0811524144134221,
+      "grape-chardonnay": 0.9566018874265536,
+      "grape-nebbiolo": 1.038616184743502,
+      "grape-sauvignon-blanc": 0.8420890144753135,
+      "grape-seed": 0.8711888712889699,
+      "grape-tempranillo": 0.8417473069445603,
+      "iron-ore": 0.8565852787467081,
+      "jalapeno": 0.8938267219202933,
+      "jalapeno-seed": 1.2806755799922187,
+      "olive": 0.894838025775234,
+      "olive-seed": 0.5819676400592492,
+      "onion": 1.388841964280044,
+      "onion-seed": 0.5548354705668044,
+      "pea": 1.4270874498629684,
+      "pea-seed": 1.3014170459989431,
+      "potato": 1.198063016021274,
+      "potato-seed": 1.1227007201477113,
+      "pumpkin": 1.256866505382895,
+      "pumpkin-seed": 0.9762702998744324,
+      "salt-rock": 1.318355654482557,
+      "silver-ore": 0.8675044285411415,
+      "soybean": 0.5974111121058051,
+      "soybean-seed": 1.2994025472815358,
+      "spinach": 1.3888914334365705,
+      "spinach-seed": 0.6511206276246511,
+      "strawberry": 0.6648639912973919,
+      "strawberry-seed": 1.2151617642366415,
+      "sunflower": 0.6441195107880303,
+      "sunflower-seed": 1.088430125646544,
+      "sweet-potato": 0.6854892825193449,
+      "sweet-potato-seed": 0.993009857740943,
+      "tomato": 1.287432200495485,
+      "tomato-seed": 1.1243978023384449,
+      "watermelon": 1.0980278225758555,
+      "watermelon-seed": 1.1400979011983594,
+      "wheat": 0.8063919814881977,
+      "wheat-seed": 0.9399986471778438
+    }
+  ],
+  "hoveredPlotRangeSize": 7,
+  "id": "d7a1db57-f021-4ce5-b632-ad382789f4f1",
+  "inventory": [
+    {
+      "id": "carrot-seed",
+      "quantity": 1
+    },
+    {
+      "id": "weed",
+      "quantity": 1
+    }
+  ],
+  "inventoryLimit": 100,
+  "isCombineEnabled": false,
+  "itemsSold": {},
+  "cellarItemsSold": {},
+  "learnedRecipes": {},
+  "loanBalance": 552.03,
+  "loansTakenOut": 1,
+  "money": 100106.3,
+  "newDayNotifications": [],
+  "notificationLog": [
+    {
+      "day": 6,
+      "notifications": {
+        "error": [],
+        "info": ["It rained in the night!"],
+        "success": [],
+        "warning": ["Your loan balance has grown to $552.03."]
+      }
+    },
+    {
+      "day": 5,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $541.21."]
+      }
+    },
+    {
+      "day": 4,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $530.60."]
+      }
+    },
+    {
+      "day": 3,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $520.20."]
+      }
+    },
+    {
+      "day": 2,
+      "notifications": {
+        "error": [],
+        "info": ["It rained in the night!"],
+        "success": [],
+        "warning": ["Your loan balance has grown to $510.00."]
+      }
+    }
+  ],
+  "priceCrashes": {},
+  "priceSurges": {},
+  "profitabilityStreak": 0,
+  "purchasedCombine": 0,
+  "purchasedComposter": 0,
+  "purchasedCowPen": 0,
+  "purchasedCellar": 0,
+  "purchasedField": 0,
+  "purchasedForest": 0,
+  "purchasedSmelter": 0,
+  "record7dayProfitAverage": 0,
+  "recordProfitabilityStreak": 0,
+  "recordSingleDayProfit": 0,
+  "revenue": 0,
+  "showHomeScreen": true,
+  "showNotifications": true,
+  "todaysLosses": 0,
+  "todaysPurchases": {},
+  "todaysRevenue": 0,
+  "todaysStartingInventory": {
+    "carrot-seed": 1,
+    "weed": 1
+  },
+  "toolLevels": {
+    "HOE": "DEFAULT",
+    "SCYTHE": "DEFAULT",
+    "SHOVEL": "UNAVAILABLE",
+    "WATERING_CAN": "DEFAULT"
+  },
+  "useAlternateEndDayButtonPosition": false,
+  "valueAdjustments": {
+    "asparagus": 0.7710329471429687,
+    "asparagus-seed": 0.6047945736371781,
+    "bronze-ore": 0.6523314669735881,
+    "carrot": 1.148946183956264,
+    "carrot-seed": 1.150865016558905,
+    "corn": 1.2916975621660312,
+    "corn-seed": 0.8194585108692283,
+    "garlic": 0.5890389828828759,
+    "garlic-seed": 1.0461378148234952,
+    "gold-ore": 1.1866263486101722,
+    "grape-cabernet-sauvignon": 0.9051176034381517,
+    "grape-chardonnay": 1.0449007660226393,
+    "grape-nebbiolo": 0.8715697232156476,
+    "grape-sauvignon-blanc": 0.6310523029050967,
+    "grape-seed": 0.9253596435820454,
+    "grape-tempranillo": 0.6756200431464858,
+    "iron-ore": 1.1565063783102898,
+    "jalapeno": 0.7091052379238315,
+    "jalapeno-seed": 1.132727916247675,
+    "olive": 1.311369163510936,
+    "olive-seed": 0.9192617853490546,
+    "onion": 0.7145057442803753,
+    "onion-seed": 0.6384400392400458,
+    "pea": 1.3438668707129882,
+    "pea-seed": 0.947899535167928,
+    "potato": 0.9114908865313538,
+    "potato-seed": 1.1068364751179312,
+    "pumpkin": 0.8377832985809028,
+    "pumpkin-seed": 1.4440859731959748,
+    "salt-rock": 1.3505767817681624,
+    "silver-ore": 0.9160677427267769,
+    "soybean": 0.7877249923876428,
+    "soybean-seed": 1.062021364573846,
+    "spinach": 1.2699413150967442,
+    "spinach-seed": 0.8490869162420625,
+    "strawberry": 1.41618172037454,
+    "strawberry-seed": 0.8777549220278436,
+    "sunflower": 0.5903344778618149,
+    "sunflower-seed": 0.974090939308244,
+    "sweet-potato": 0.5906894671175695,
+    "sweet-potato-seed": 0.6012857315253939,
+    "tomato": 1.1936926336320215,
+    "tomato-seed": 0.7109397222579946,
+    "watermelon": 0.666622692558885,
+    "watermelon-seed": 1.0104982645951823,
+    "wheat": 0.8632829757532291,
+    "wheat-seed": 0.7821587302079209
+  },
+  "version": "1.18.26"
+}

--- a/e2e/tests/forest-investigation.test.js
+++ b/e2e/tests/forest-investigation.test.js
@@ -3,24 +3,19 @@ import { loadFixture } from '../test-utils/load-fixture.js'
 
 test.describe('Forest unlock investigation', () => {
   test('does NOT show forest notification at level 15 when flag is off', async ({ page }) => {
-    // Level 15 needs (15-1)*10 = 140^2 = 19600 experience.
-    // Level 14 needs (14-1)*10 = 130^2 = 16900 experience.
     await loadFixture(page, 'near-level-15')
 
-    // Set experience to just below level 15
     await page.evaluate(() => {
         window.farmhand.setState({ experience: 19599 });
     });
 
-    // Sell something to gain 1 experience and reach level 15
-    await page.getByRole('button', { name: 'View Inventory (i)' }).click()
-    await page.getByText('Carrot Seed').first().click()
-    await page.getByRole('button', { name: 'Sell' }).click()
+    await page.getByRole('button', { name: 'Open Farmer\'s Log (l)' }).click()
+    await page.getByRole('button', { name: 'Close' }).click()
 
-    // Verify level 15 reached
+    await page.getByRole('button', { name: 'End the day to save your' }).click()
+
     await expect(page.getByText('level: 15')).toBeVisible()
 
-    // Verify notification content
     await expect(page.getByText('You reached level 15!')).toBeVisible()
     await expect(page.getByText('The Forest is now available!')).not.toBeVisible()
   })
@@ -29,34 +24,16 @@ test.describe('Forest unlock investigation', () => {
     const appUrl = process.env.APP_URL || 'http://localhost:3000'
     await page.goto(`${appUrl}?enable_FOREST=false`)
 
-    // Ensure the app is loaded before evaluating
     await expect(page.getByRole('button', { name: 'View Settings (comma)' })).toBeVisible()
 
     await page.evaluate(() => {
-        const state = {
-            experience: 19599,
-            inventory: [{ id: 'carrot-seed', quantity: 10 }],
-            money: 1000,
-            showNotifications: true,
-            todaysNotifications: [],
-            inventoryLimit: 100,
-            toolLevels: {
-                HOE: 'DEFAULT',
-                SCYTHE: 'DEFAULT',
-                SHOVEL: 'UNAVAILABLE',
-                WATERING_CAN: 'DEFAULT'
-            }
-        };
-        window.farmhand.setState(state);
+        window.farmhand.setState({ experience: 19599 });
     });
 
-    await page.getByRole('button', { name: 'View Inventory (i)' }).click()
-    await page.getByText('Carrot Seed').first().click()
-    await page.getByRole('button', { name: 'Sell' }).click()
+    await page.getByRole('button', { name: 'End the day to save your' }).click()
 
     await expect(page.getByText('level: 15')).toBeVisible()
 
-    // After the fix, this should NOT be visible
     await expect(page.getByText('The Forest is now available!')).not.toBeVisible()
   })
 })

--- a/e2e/tests/forest-investigation.test.js
+++ b/e2e/tests/forest-investigation.test.js
@@ -9,13 +9,12 @@ test.describe('Forest unlock investigation', () => {
 
     // Set experience to just below level 15
     await page.evaluate(() => {
-        window.__TEST_STATE__.experience = 19599;
-        window.__UPDATE_STATE__();
+        window.farmhand.setState({ experience: 19599 });
     });
 
     // Sell something to gain 1 experience and reach level 15
     await page.getByRole('button', { name: 'View Inventory (i)' }).click()
-    await page.getByText('Carrot seed').first().click()
+    await page.getByText('Carrot Seed').first().click()
     await page.getByRole('button', { name: 'Sell' }).click()
 
     // Verify level 15 reached
@@ -48,11 +47,11 @@ test.describe('Forest unlock investigation', () => {
                 WATERING_CAN: 'DEFAULT'
             }
         };
-        window.__UPDATE_STATE__(state);
+        window.farmhand.setState(state);
     });
 
     await page.getByRole('button', { name: 'View Inventory (i)' }).click()
-    await page.getByText('Carrot seed').first().click()
+    await page.getByText('Carrot Seed').first().click()
     await page.getByRole('button', { name: 'Sell' }).click()
 
     await expect(page.getByText('level: 15')).toBeVisible()

--- a/e2e/tests/forest-investigation.test.js
+++ b/e2e/tests/forest-investigation.test.js
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import { loadFixture } from '../test-utils/load-fixture.js'
+
+test.describe('Forest unlock investigation', () => {
+  test('does NOT show forest notification at level 15 when flag is off', async ({ page }) => {
+    // Level 15 needs (15-1)*10 = 140^2 = 19600 experience.
+    // Level 14 needs (14-1)*10 = 130^2 = 16900 experience.
+    await loadFixture(page, 'near-level-15')
+
+    // Set experience to just below level 15
+    await page.evaluate(() => {
+        window.__TEST_STATE__.experience = 19599;
+        window.__UPDATE_STATE__();
+    });
+
+    // Sell something to gain 1 experience and reach level 15
+    await page.getByRole('button', { name: 'View Inventory (i)' }).click()
+    await page.getByText('Carrot seed').first().click()
+    await page.getByRole('button', { name: 'Sell' }).click()
+
+    // Verify level 15 reached
+    await expect(page.getByText('level: 15')).toBeVisible()
+
+    // Verify notification content
+    await expect(page.getByText('You reached level 15!')).toBeVisible()
+    await expect(page.getByText('The Forest is now available!')).not.toBeVisible()
+  })
+
+  test('correctly hides forest notification at level 15 when enable_FOREST=false is used', async ({ page }) => {
+    const appUrl = process.env.APP_URL || 'http://localhost:3000'
+    await page.goto(`${appUrl}?enable_FOREST=false`)
+
+    // Ensure the app is loaded before evaluating
+    await expect(page.getByRole('button', { name: 'View Settings (comma)' })).toBeVisible()
+
+    await page.evaluate(() => {
+        const state = {
+            experience: 19599,
+            inventory: [{ id: 'carrot-seed', quantity: 10 }],
+            money: 1000,
+            showNotifications: true,
+            todaysNotifications: [],
+            inventoryLimit: 100,
+            toolLevels: {
+                HOE: 'DEFAULT',
+                SCYTHE: 'DEFAULT',
+                SHOVEL: 'UNAVAILABLE',
+                WATERING_CAN: 'DEFAULT'
+            }
+        };
+        window.__UPDATE_STATE__(state);
+    });
+
+    await page.getByRole('button', { name: 'View Inventory (i)' }).click()
+    await page.getByText('Carrot seed').first().click()
+    await page.getByRole('button', { name: 'Sell' }).click()
+
+    await expect(page.getByText('level: 15')).toBeVisible()
+
+    // After the fix, this should NOT be visible
+    await expect(page.getByText('The Forest is now available!')).not.toBeVisible()
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,11 +41,11 @@ export const features: Features = Object.keys(import.meta.env ?? {}).reduce(
 // this is running in a Node.js context.
 const searchParams = new URLSearchParams(globalWindow.location?.search)
 
-for (const key of searchParams.keys()) {
+for (const [key, value] of searchParams.entries()) {
   const matches = key.match(/enable_(.*)/)
 
   if (matches) {
-    features[matches[1]] = true
+    features[matches[1]] = value !== 'false'
   }
 }
 


### PR DESCRIPTION
I have investigated how the Forest notification could have appeared in production and found a bug in the feature flag configuration.

In `src/config.ts`, any URL query parameter starting with `enable_` was automatically setting the corresponding feature flag to `true`, even if the user explicitly provided `false` (e.g., `?enable_FOREST=false`). This would enable the development-only "Forest" feature for any user who happened to use that URL or follow a link containing it.

I have:
1.  **Fixed the bug**: Updated `src/config.ts` to respect the `false` value in query parameters.
2.  **Verified the fix**: Created a new E2E test suite (`e2e/tests/forest-investigation.test.js`) and a supporting state fixture (`e2e/fixtures/near-level-15.json`) that confirms the Forest notification is properly hidden when the flag is disabled or set to false at level 15.
3.  **Audit**: Searched the codebase for any other hardcoded references to level 15 or the Forest that might be visible to users and found none.

This fix ensures that experimental features remain strictly hidden unless explicitly and correctly enabled.

---
*PR created automatically by Jules for task [11119945595517878657](https://jules.google.com/task/11119945595517878657) started by @jeremyckahn*