### PR TITLE
Fix feature flags parsing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,7 @@ export const features: Features = Object.keys(import.meta.env ?? {}).reduce(
     const matches = key.match(/VITE_ENABLE_(.*)/)
 
     if (matches) {
-      acc[matches[1]] = true
+      acc[matches[1]] = String(import.meta.env[key]) !== 'false'
     }
 
     return acc
@@ -45,7 +45,7 @@ for (const key of searchParams.keys()) {
   const matches = key.match(/enable_(.*)/)
 
   if (matches) {
-    features[matches[1]] = true
+    features[matches[1]] = searchParams.get(key) !== 'false'
   }
 }
 


### PR DESCRIPTION
Fixes an issue where features like `FOREST` were enabled by default in production due to incorrect flag parsing in `src/config.ts`. The updated logic checks the string values of environment variables and URL parameters to evaluate `"false"` to `false`.

---
*PR created automatically by Jules for task [13609944860681813018](https://jules.google.com/task/13609944860681813018) started by @jeremyckahn*