### PR TITLE
fix: correct name attribute for 'Play online' toggle

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -125,7 +125,7 @@ const OnlineControls = ({
                 onChange={(_, checked) => {
                   handleSwitchChange(checked)
                 }}
-                name="use-alternate-end-day-button-position"
+                name="play-online"
               />
             }
             label="Play online"


### PR DESCRIPTION
Fixes a copy-paste error where the `name` attribute of the "Play online" Switch in `Navigation.tsx` was incorrectly set to `use-alternate-end-day-button-position` instead of `play-online`.

---
*PR created automatically by Jules for task [11943289334891116822](https://jules.google.com/task/11943289334891116822) started by @jeremyckahn*