### PR TITLE
chore: update e2e script to use VERCEL_TOKEN from environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check:types": "tsc && tsc -p src/game-logic/reducers/tsconfig.json",
     "dev": "mprocs \"cross-env VITE_TRACKER_URL='ws://localhost:8000' npm run start\" \"npm run start:api\" \"npm run start:backend\" \"npm run start:tracker\"",
     "dev:native": "mprocs \"BROWSER=none npm run start\" \"npm run start:api\" \"npm run start:backend\" \"npm run electron\"",
-    "e2e": "gh act --secret GITHUB_TOKEN=\"$(gh auth token)\" --secret VERCEL_TOKEN=\"$(jq .token ~/.local/share/com.vercel.cli/auth.json)\" -j e2e",
+    "e2e": "gh act --secret GITHUB_TOKEN=\"$(gh auth token)\" --secret VERCEL_TOKEN=\"${VERCEL_TOKEN:-$(jq .token ~/.local/share/com.vercel.cli/auth.json)}\" -j e2e",
     "e2e:stop": "docker compose -f e2e/docker-compose.yml down",
     "e2e:cleanup": "docker rmi $(docker images --filter \"reference=ghcr.io/jeremyckahn/farmhand/*\" -q)",
     "e2e:serve-app": "npx vite preview --port 3000 --host",


### PR DESCRIPTION
This change updates the `e2e` script in `package.json` to prioritize using the `VERCEL_TOKEN` environment variable if it exists. If it does not exist, it falls back to the previous behavior of extracting the token from the Vercel CLI config using `jq`.

---
*PR created automatically by Jules for task [1251326886013633505](https://jules.google.com/task/1251326886013633505) started by @jeremyckahn*