### PR TITLE
test: add e2e test for purchasing cow pen and cows

### DIFF
--- a/e2e/tests/cow-pen/cow-pen.test.js
+++ b/e2e/tests/cow-pen/cow-pen.test.js
@@ -21,7 +21,7 @@ test('should purchase a cow pen and a cow, and verify hugging works', async ({ p
   await page.getByRole('option', { name: ': Cows' }).click()
 
   // Buy the cow for sale
-  await page.getByRole('button', { name: 'Buy' }).first().click()
+  await page.locator('.CowPenContextMenu').getByRole('button', { name: 'Buy' }).first().click()
 
   // Assert that we can Hug and Sell the purchased cow in the context menu
   const hugButton = page.getByRole('button', { name: 'Hug' })

--- a/e2e/tests/cow-pen/cow-pen.test.js
+++ b/e2e/tests/cow-pen/cow-pen.test.js
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+
+import { loadFixture } from '../../test-utils/load-fixture.js'
+
+test('should purchase a cow pen and a cow', async ({ page }) => {
+  // The crops-mature fixture has > $100k
+  await loadFixture(page, 'crops-mature')
+
+  // Go to Shop to buy Cow Pen
+  await page.getByText(': Home').click()
+  await page.getByRole('option', { name: ': Shop' }).click()
+
+  // Switch to the Upgrades tab where the Cow Pen purchase button is located
+  await page.getByRole('tab', { name: 'Upgrades' }).click()
+
+  // Buy Cow Pen
+  await page.locator('li').filter({ hasText: 'Buy cow pen' }).getByRole('button', { name: 'Buy' }).click()
+
+  // Navigate to Cow Pen
+  await page.getByText(': Shop').click()
+  await page.getByRole('option', { name: ': Cows' }).click()
+
+  // Buy the cow for sale
+  // We expect a cow card "For sale" with a "Buy" button
+  await page.getByRole('button', { name: 'Buy' }).first().click()
+
+  // Assert that we can Hug and Sell the purchased cow in the context menu
+  await expect(page.getByRole('button', { name: 'Hug' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Sell' })).toBeVisible()
+})

--- a/e2e/tests/cow-pen/cow-pen.test.js
+++ b/e2e/tests/cow-pen/cow-pen.test.js
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 import { loadFixture } from '../../test-utils/load-fixture.js'
 
-test('should purchase a cow pen and a cow, and verify hugging works', async ({ page }) => {
+test('should purchase a cow pen and a cow, verify hugging and selling works', async ({ page }) => {
   // The crops-mature fixture has > $100k
   await loadFixture(page, 'crops-mature')
 
@@ -21,12 +21,13 @@ test('should purchase a cow pen and a cow, and verify hugging works', async ({ p
   await page.getByRole('option', { name: ': Cows' }).click()
 
   // Buy the cow for sale
-  await page.locator('.CowPenContextMenu').getByRole('button', { name: 'Buy' }).first().click()
+  await page.getByRole('button', { name: 'Buy' }).first().click()
 
   // Assert that we can Hug and Sell the purchased cow in the context menu
   const hugButton = page.getByRole('button', { name: 'Hug' })
+  const sellButton = page.getByRole('button', { name: 'Sell' })
   await expect(hugButton).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Sell' })).toBeVisible()
+  await expect(sellButton).toBeVisible()
 
   // In CowPen.sass, the animation heart has the class `.fa-heart.animation`.
   // When a cow is hugged, the class `.is-animating` is added to it: `.fa-heart.animation.is-animating`
@@ -39,4 +40,11 @@ test('should purchase a cow pen and a cow, and verify hugging works', async ({ p
   // Wait for the animation heart to show up
   await animatingHeart.waitFor({ state: 'attached' })
   await expect(animatingHeart).toBeAttached()
+
+  // Sell the cow
+  await sellButton.click()
+
+  // Assert the cow has been sold (Hug/Sell buttons should no longer be visible)
+  await expect(hugButton).not.toBeVisible()
+  await expect(sellButton).not.toBeVisible()
 })

--- a/e2e/tests/cow-pen/cow-pen.test.js
+++ b/e2e/tests/cow-pen/cow-pen.test.js
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 import { loadFixture } from '../../test-utils/load-fixture.js'
 
-test('should purchase a cow pen and a cow', async ({ page }) => {
+test('should purchase a cow pen and a cow, and verify hugging works', async ({ page }) => {
   // The crops-mature fixture has > $100k
   await loadFixture(page, 'crops-mature')
 
@@ -21,10 +21,22 @@ test('should purchase a cow pen and a cow', async ({ page }) => {
   await page.getByRole('option', { name: ': Cows' }).click()
 
   // Buy the cow for sale
-  // We expect a cow card "For sale" with a "Buy" button
   await page.getByRole('button', { name: 'Buy' }).first().click()
 
   // Assert that we can Hug and Sell the purchased cow in the context menu
-  await expect(page.getByRole('button', { name: 'Hug' })).toBeVisible()
+  const hugButton = page.getByRole('button', { name: 'Hug' })
+  await expect(hugButton).toBeVisible()
   await expect(page.getByRole('button', { name: 'Sell' })).toBeVisible()
+
+  // In CowPen.sass, the animation heart has the class `.fa-heart.animation`.
+  // When a cow is hugged, the class `.is-animating` is added to it: `.fa-heart.animation.is-animating`
+  // We can just verify this element exists in the DOM after clicking "Hug".
+  const animatingHeart = page.locator('.fa-heart.animation.is-animating').first()
+
+  // Click hug
+  await hugButton.click()
+
+  // Wait for the animation heart to show up
+  await animatingHeart.waitFor({ state: 'attached' })
+  await expect(animatingHeart).toBeAttached()
 })


### PR DESCRIPTION
This PR adds a new end-to-end test using Playwright to cover previously untested functionality regarding cow pen and cow purchases.

The test verifies that:
- A user can purchase a Cow Pen from the Upgrades tab in the Shop.
- A user can navigate to the newly unlocked Cows view.
- A user can purchase a cow from the "For sale" section.
- The purchased cow is interactable and displays the expected "Hug" and "Sell" buttons in the UI.

---
*PR created automatically by Jules for task [2038332853095699091](https://jules.google.com/task/2038332853095699091) started by @jeremyckahn*