### PR TITLE
Fix Vite and NPM warnings in e2e logs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 progress=false
 legacy-peer-deps=true
-no-optional=true

--- a/vite.config.js
+++ b/vite.config.js
@@ -90,8 +90,8 @@ const viteConfig = defineConfig({
   // NOTE: This makes Vite treat .js files as .jsx (for legacy support)
   // See: https://stackoverflow.com/a/76458411/470685
   optimizeDeps: {
-    esbuildOptions: {
-      loader: {
+    rolldownOptions: {
+      moduleTypes: {
         '.js': 'jsx',
       },
     },


### PR DESCRIPTION
Addresses user request to reduce noise in E2E test logs by silencing Vite deprecation warnings and NPM config warnings.

---
*PR created automatically by Jules for task [3094011161521364766](https://jules.google.com/task/3094011161521364766) started by @jeremyckahn*