### PR TITLE
Fix npm publish provenance failure: pin npm upgrade below v12

### DIFF
--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -43,10 +43,14 @@ jobs:
           # legacy .npmrc that expects NODE_AUTH_TOKEN, which conflicts with OIDC.
 
       - name: Upgrade npm
-        # Ensure latest npm for reliable Trusted Publisher (OIDC) support.
+        # Ensure a recent npm for reliable Trusted Publisher (OIDC) support.
         # Upgrading incrementally avoids a known issue in Node 22.22.2 with promise-retry.
         # See: https://github.com/nodejs/node/issues/62425
-        run: npm install -g npm@^10 && npm install -g npm@latest
+        #
+        # Pinned below npm 12 because npm 12.0.0's published tarball is missing the
+        # bundled `sigstore` dependency, breaking `npm publish --provenance`.
+        # See: https://github.com/npm/cli/issues/9722
+        run: npm install -g npm@^10 && npm install -g npm@^11
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- The [release workflow run](https://github.com/jeremyckahn/farmhand/actions/runs/28982764870/job/86005060424) failed at `npm publish --provenance --access public` with `Cannot find module 'sigstore'`.
- Root cause: npm 12.0.0's published tarball is missing the bundled `sigstore` dependency that `libnpmpublish` requires for provenance/OIDC signing. This is a confirmed upstream bug — [npm/cli#9722](https://github.com/npm/cli/issues/9722) — not something we can fix in this repo. Verified locally: installing `npm@12` produces a `node_modules/npm/node_modules/libnpmpublish` with `sigstore` listed as a dependency but no `sigstore` folder actually present, while `npm@11.18.0` has it correctly bundled.
- The release workflow's "Upgrade npm" step previously installed `npm@latest`, which now resolves to the broken 12.0.0. Pinned it to `npm@^11` until npm ships a fix.

This is a separate, later failure from #673 (which fixed the earlier `npm ci` / `allow-git` issue in the same pipeline — that fix already worked, `npm ci` passed in this run).

## Test plan
- [x] Reproduced the exact failure locally by installing npm 12.0.0 and confirming `sigstore` is missing from its bundled `node_modules`.
- [x] Confirmed npm 11.18.0 has `sigstore` correctly bundled.
- [ ] Re-run the release workflow to confirm `npm publish --provenance` succeeds.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Sbodhp6t32yKatoek287iD