### PR TITLE
feat: Replace `any`s with strict types

### DIFF
--- a/src/utils/chooseRandom.ts
+++ b/src/utils/chooseRandom.ts
@@ -1,3 +1,3 @@
 import { chooseRandomIndex } from './chooseRandomIndex.js'
 
-export const chooseRandom = (list: any[]): any => list[chooseRandomIndex(list)]
+export const chooseRandom = <T>(list: T[]): T => list[chooseRandomIndex(list)]

--- a/src/utils/chooseRandomIndex.ts
+++ b/src/utils/chooseRandomIndex.ts
@@ -1,5 +1,5 @@
 import { random } from '../common/utils.js'
 
-export const chooseRandomIndex = (list: any[]): number =>
+export const chooseRandomIndex = <T>(list: T[]): number =>
   // TODO: Fix statistical bias by using Math.floor(random() * list.length).
   Math.round(random() * (list.length - 1))

--- a/src/utils/computeMarketPositions.ts
+++ b/src/utils/computeMarketPositions.ts
@@ -4,28 +4,31 @@ export const computeMarketPositions = (
   todaysStartingInventory: farmhand.state['todaysStartingInventory'],
   todaysPurchases: farmhand.state['todaysPurchases'],
   inventory: Array<{ id: string; quantity: number }>
-): any =>
-  inventory.reduce((acc: any, { id, quantity: endingPosition }) => {
-    const startingInventory = todaysStartingInventory[id] || 0
-    const purchaseQuantity = todaysPurchases[id] || 0
+): Record<string, number> =>
+  inventory.reduce(
+    (acc: Record<string, number>, { id, quantity: endingPosition }) => {
+      const startingInventory = todaysStartingInventory[id] || 0
+      const purchaseQuantity = todaysPurchases[id] || 0
 
-    if (!itemsMap[id].doesPriceFluctuate) {
-      return acc
-    }
-
-    if (startingInventory !== endingPosition) {
-      if (
-        endingPosition < startingInventory ||
-        endingPosition < purchaseQuantity
-      ) {
-        acc[id] = -1
-      } else if (
-        endingPosition > startingInventory ||
-        endingPosition > purchaseQuantity
-      ) {
-        acc[id] = 1
+      if (!itemsMap[id].doesPriceFluctuate) {
+        return acc
       }
-    }
 
-    return acc
-  }, {})
+      if (startingInventory !== endingPosition) {
+        if (
+          endingPosition < startingInventory ||
+          endingPosition < purchaseQuantity
+        ) {
+          acc[id] = -1
+        } else if (
+          endingPosition > startingInventory ||
+          endingPosition > purchaseQuantity
+        ) {
+          acc[id] = 1
+        }
+      }
+
+      return acc
+    },
+    {}
+  )

--- a/src/utils/generateCow.ts
+++ b/src/utils/generateCow.ts
@@ -16,7 +16,7 @@ export const generateCow = (
     gender?: farmhand.cow['gender']
     color?: farmhand.cow['color']
     id?: farmhand.cow['id']
-    [key: string]: any
+    [key: string]: unknown
   } = {}
 ): farmhand.cow => {
   const gender =

--- a/src/utils/getPeerMetadata.ts
+++ b/src/utils/getPeerMetadata.ts
@@ -3,11 +3,14 @@ import { PEER_METADATA_STATE_KEYS } from '../constants.js'
 export const getPeerMetadata = (
   state: farmhand.state
 ): farmhand.peerMetadata => {
-  const reducedState = PEER_METADATA_STATE_KEYS.reduce((acc: any, key) => {
-    acc[key] = state[key as keyof farmhand.state]
+  const reducedState = PEER_METADATA_STATE_KEYS.reduce(
+    (acc: Record<string, unknown>, key) => {
+      acc[key] = state[key as keyof farmhand.state]
 
-    return acc
-  }, {})
+      return acc
+    },
+    {}
+  )
 
   Object.assign(reducedState, {
     cowOfferedForTrade: state.cowInventory.find(
@@ -15,5 +18,5 @@ export const getPeerMetadata = (
     ),
   })
 
-  return reducedState as farmhand.peerMetadata
+  return (reducedState as unknown) as farmhand.peerMetadata
 }

--- a/src/utils/getPlotImage.test.ts
+++ b/src/utils/getPlotImage.test.ts
@@ -1,6 +1,7 @@
 import { testCrop } from '../test-utils/index.js'
 import { items as itemImages } from '../img/index.js'
 import { silverOre } from '../data/items.js'
+import { fertilizerType } from '../enums.js'
 
 import { getPlotImage } from './getPlotImage.js'
 import { getPlotContentFromItemId } from './getPlotContentFromItemId.js'
@@ -66,6 +67,23 @@ describe('getPlotImage', () => {
         0,
         0
       )
+    ).toBe((itemImages as Record<string, string>)[silverOre.id])
+  })
+
+  test('returns ore image for a freshly-shoveled plot', () => {
+    // Mirrors the shape minePlot() produces: itemId is an empty string
+    // while the plot is shoveled, so isPlotContent() must not mistake it
+    // for real plot content based on itemId's mere presence.
+    const shoveledPlot = {
+      itemId: '',
+      fertilizerType: fertilizerType.NONE,
+      isShoveled: true,
+      daysUntilClear: 3,
+      oreId: silverOre.id,
+    }
+
+    expect(
+      getPlotImage((shoveledPlot as unknown) as farmhand.shoveledPlot, 0, 0)
     ).toBe((itemImages as Record<string, string>)[silverOre.id])
   })
 

--- a/src/utils/getPlotImage.ts
+++ b/src/utils/getPlotImage.ts
@@ -8,11 +8,25 @@ import { getPlotContentType } from './getPlotContentType.js'
 
 const { SEED, GROWING, GROWN } = cropLifeStage
 
-const isPlotContent = (obj: any = {}): obj is farmhand.plotContent =>
-  Boolean(obj && obj['itemId'] && obj['fertilizerType'])
+const isPlotContent = (obj: unknown = {}): obj is farmhand.plotContent =>
+  Boolean(
+    obj &&
+      typeof obj === 'object' &&
+      'itemId' in obj &&
+      'fertilizerType' in obj &&
+      obj.itemId &&
+      obj.fertilizerType
+  )
 
-const isShoveledPlot = (obj: any = {}): obj is farmhand.shoveledPlot =>
-  Boolean(obj && obj['isShoveled'] && obj['daysUntilClear'])
+const isShoveledPlot = (obj: unknown = {}): obj is farmhand.shoveledPlot =>
+  Boolean(
+    obj &&
+      typeof obj === 'object' &&
+      'isShoveled' in obj &&
+      'daysUntilClear' in obj &&
+      obj.isShoveled &&
+      obj.daysUntilClear
+  )
 
 const isPlotContentACrop = (
   plotContents: farmhand.plotContent
@@ -45,7 +59,7 @@ export const getPlotImage = (
           itemImageId = seedItem.id
       }
 
-      return (itemImages as any)[itemImageId]
+      return (itemImages as Record<string, string>)[itemImageId]
     }
 
     if (getPlotContentType(plotContents) === itemType.WEED) {
@@ -54,16 +68,18 @@ export const getPlotImage = (
       // negative modulo index.
       const color = weedColors[(x * y) % weedColors.length]
 
-      return (itemImages as any)[`weed-${color}`]
+      return (itemImages as Record<string, string>)[`weed-${color}`]
     }
 
     // Handle other plot content (non-crop, non-weed)
-    return (itemImages as any)[(plotContents as farmhand.plotContent).itemId]
+    return (itemImages as Record<string, string>)[
+      (plotContents as farmhand.plotContent).itemId
+    ]
   }
 
   if (isShoveledPlot(plotContents)) {
     if (plotContents?.oreId) {
-      return (itemImages as any)[plotContents.oreId]
+      return (itemImages as Record<string, string>)[plotContents.oreId]
     }
   }
 

--- a/src/utils/getPriceEventForCrop.ts
+++ b/src/utils/getPriceEventForCrop.ts
@@ -7,6 +7,6 @@ export const getPriceEventForCrop = (
 ): farmhand.priceEvent => ({
   itemId: cropItem.id,
   daysRemaining:
-    getCropLifecycleDuration(cropItem as any) -
+    getCropLifecycleDuration(cropItem as { cropTimeline: number[] }) -
     PRICE_EVENT_STANDARD_DURATION_DECREASE,
 })

--- a/src/utils/isItemAFarmProduct.ts
+++ b/src/utils/isItemAFarmProduct.ts
@@ -2,7 +2,7 @@ import { itemType } from '../enums.js'
 
 import { isItemAGrownCrop } from './isItemAGrownCrop.js'
 
-const FARM_PRODUCT_TYPES = [
+const FARM_PRODUCT_TYPES: farmhand.itemType[] = [
   itemType.CRAFTED_ITEM,
   itemType.FUEL,
   itemType.MILK,
@@ -11,6 +11,4 @@ const FARM_PRODUCT_TYPES = [
 ]
 
 export const isItemAFarmProduct = (item: farmhand.item): boolean =>
-  Boolean(
-    isItemAGrownCrop(item) || FARM_PRODUCT_TYPES.includes(item.type as any)
-  )
+  Boolean(isItemAGrownCrop(item) || FARM_PRODUCT_TYPES.includes(item.type))

--- a/src/utils/memoizationSerializer.ts
+++ b/src/utils/memoizationSerializer.ts
@@ -1,4 +1,4 @@
-export const memoizationSerializer = (args: any[]) =>
+export const memoizationSerializer = (args: unknown[]) =>
   JSON.stringify(
     [...args].map(arg => (typeof arg === 'function' ? arg.toString() : arg))
   )

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -41,6 +41,11 @@ configure fast-memoize.
  * @returns T
  * @see ://github.com/caiogondim/fast-memoize.js
  */
+// `never[]` (rather than `any[]`) as the rest-parameter type is intentional:
+// `never` is assignable to any parameter type, so this constrains T to "any
+// function type" without introducing `any`, while inference still preserves
+// fn's real parameter list — calling the memoized function with the wrong
+// argument types still errors as expected.
 export const memoize = <T extends (...args: never[]) => unknown>(
   fn: T,
   config: Record<string, unknown> = {}

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -6,8 +6,8 @@ import { MEMOIZE_CACHE_CLEAR_THRESHOLD } from '../constants.js'
 // clears the cache once the size exceeds MEMOIZE_CACHE_CLEAR_THRESHOLD to
 // prevent memory bloat.
 // https://github.com/caiogondim/fast-memoize.js/blob/5cdfc8dde23d86b16e0104bae1b04cd447b98c63/src/index.js#L114-L128
-export class MemoizeCache {
-  cache: Record<string, any> = {}
+export class MemoizeCache<TValue = unknown> {
+  cache: Record<string, TValue> = {}
   cacheSize: number
 
   /**
@@ -23,11 +23,11 @@ configure fast-memoize.
     return key in this.cache
   }
 
-  get(key: string) {
+  get(key: string): TValue {
     return this.cache[key]
   }
 
-  set(key: string, value: any) {
+  set(key: string, value: TValue) {
     if (Object.keys(this.cache).length > this.cacheSize) {
       this.cache = {}
     }
@@ -41,11 +41,11 @@ configure fast-memoize.
  * @returns T
  * @see ://github.com/caiogondim/fast-memoize.js
  */
-export const memoize = <T extends (...args: any[]) => any>(
+export const memoize = <T extends (...args: never[]) => unknown>(
   fn: T,
-  config: any = {}
+  config: Record<string, unknown> = {}
 ): T =>
   fastMemoize(fn, {
-    cache: { create: () => new MemoizeCache(config) },
+    cache: { create: () => new MemoizeCache<ReturnType<T>>(config) },
     ...config,
   }) as T

--- a/src/utils/reduceByPersistedKeys.ts
+++ b/src/utils/reduceByPersistedKeys.ts
@@ -1,14 +1,27 @@
 import { PERSISTED_STATE_KEYS } from '../constants.js'
 
+// Assigning through a single generic type parameter (rather than indexing
+// both sides with the raw `keyof farmhand.state` union inline) is what lets
+// TypeScript verify that acc[key] and state[key] agree without a cast.
+const assignPersistedKey = <TKey extends keyof farmhand.state>(
+  acc: Partial<farmhand.state>,
+  state: Partial<farmhand.state>,
+  key: TKey
+): void => {
+  const value = state[key]
+
+  // This check prevents old exports from corrupting game state when
+  // imported.
+  if (typeof value !== 'undefined') {
+    acc[key] = value
+  }
+}
+
 export const reduceByPersistedKeys = (
   state: Partial<farmhand.state>
 ): farmhand.state =>
-  PERSISTED_STATE_KEYS.reduce((acc: any, key) => {
-    // This check prevents old exports from corrupting game state when
-    // imported.
-    if (typeof state[key as keyof farmhand.state] !== 'undefined') {
-      acc[key] = state[key as keyof farmhand.state]
-    }
+  (PERSISTED_STATE_KEYS as Array<keyof farmhand.state>).reduce((acc, key) => {
+    assignPersistedKey(acc, state, key)
 
     return acc
-  }, {}) as farmhand.state
+  }, {} as Partial<farmhand.state>) as farmhand.state

--- a/src/utils/totalIngredientsInRecipe.ts
+++ b/src/utils/totalIngredientsInRecipe.ts
@@ -1,7 +1,10 @@
-export function totalIngredientsInRecipe(recipe: any, amount = 1) {
+export function totalIngredientsInRecipe(
+  recipe: { ingredients: Record<string, number> },
+  amount = 1
+) {
   return (
     amount *
-    Object.values(recipe.ingredients as Record<string, number>).reduce(
+    Object.values(recipe.ingredients).reduce(
       (acc: number, quantity: number) => acc + quantity,
       0
     )

--- a/src/utils/transformStateDataForImport.ts
+++ b/src/utils/transformStateDataForImport.ts
@@ -6,7 +6,7 @@ import { farmProductsSold } from './farmProductsSold.js'
 export const transformStateDataForImport = (
   state: farmhand.state
 ): farmhand.state => {
-  let sanitizedState: any = { ...state }
+  let sanitizedState: Record<string, unknown> = { ...state }
 
   const rejectedKeys = ['version']
 
@@ -35,7 +35,10 @@ export const transformStateDataForImport = (
     // TODO: Add defensive check safeguards for sanitizedState.cowBreedingPen
     // and sanitizedState.cowInventory to prevent TypeError crashes during
     // corrupt/legacy state imports.
-    const { cowId1, cowId2 } = sanitizedState.cowBreedingPen
+    const {
+      cowId1,
+      cowId2,
+    } = sanitizedState.cowBreedingPen as farmhand.state['cowBreedingPen']
 
     const cowPenIdMap = (sanitizedState.cowInventory as farmhand.cow[]).reduce(
       (acc: Record<string, farmhand.cow>, cow: farmhand.cow) => {
@@ -68,5 +71,5 @@ export const transformStateDataForImport = (
     delete sanitizedState.id
   }
 
-  return sanitizedState as farmhand.state
+  return (sanitizedState as unknown) as farmhand.state
 }


### PR DESCRIPTION
### What this PR does

Replaces `any` types across several `src/utils` files with accurate, specific types: generics for `chooseRandom`/`chooseRandomIndex`/`memoizationSerializer`, `Record` types for accumulator/cache objects, a generic `MemoizeCache<TValue>`, and a narrowed helper for `reduceByPersistedKeys` so the key/value pairing type-checks without a broad cast.

While doing this, `getPlotImage`'s `isPlotContent`/`isShoveledPlot` type guards had to move off `obj['key']`-style property access, which isn't valid on `obj: unknown`. Fixing this correctly required checking both that a property exists and that its value is truthy, matching the original behavior. This mattered in practice: `minePlot.ts` creates freshly-shoveled plots with `itemId: ''`, and a naive presence-only check would misclassify them as real plot content, hiding their ore image.

### How this change can be validated

- `tsc --noEmit` and `eslint src --max-warnings=0` are clean
- Full test suite passes (182 files / 932 tests)
- Added a regression test for the freshly-shoveled-plot case in `getPlotImage.test.ts`, verified to fail without the truthy-value check and pass with it

### Questions or concerns about this change

None — this is intended to be a behavior-preserving refactor of `src/utils`.

### Additional information

🤖 Generated with [Claude Code](https://claude.com/claude-code)