### PR TITLE
fix: Close the unterminated url() in QuickSelect's item icon background

### DIFF
--- a/src/components/QuickSelect/QuickSelect.tsx
+++ b/src/components/QuickSelect/QuickSelect.tsx
@@ -77,7 +77,7 @@ const ItemList = ({
               style: {
                 backgroundImage: `url(${
                   itemImages[item.id as keyof typeof itemImages]
-                }`,
+                })`,
               },
             }}
             sx={{ ...squareImgSx, ...spriteShadowSx }}


### PR DESCRIPTION
### What this PR does

The Sass-to-MUI `sx` prop migration (#678) left `ItemList`'s icon `backgroundImage` set to a template literal missing its closing paren for `url(...)`:

```ts
backgroundImage: `url(${
  itemImages[item.id as keyof typeof itemImages]
}`,
```

Adds the missing `)`.

### How this change can be validated

Chromium's `style.backgroundImage` setter happens to silently normalize the malformed value away, so this wasn't visibly broken in practice (confirmed by comparing rendered output before/after the fix) - but it's invalid CSS syntax that shouldn't be relied on to keep working across browsers/parsers. Verified no other instance of this pattern exists elsewhere in the codebase.

- `npx tsc --noEmit`
- `npx eslint src --max-warnings=0`