### PR TITLE
fix: Center the range slider thumb in its grey container

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -503,9 +503,11 @@ export const Field = (props: FieldProps) => {
             backgroundSize: 'calc(100% * (1 / 12) * 1.5)',
           },
           '& .slider-wrapper': {
+            alignItems: 'center',
             background: 'rgba(128, 128, 128, 0.5)',
             borderRadius: '2em',
             bottom: '7.5em',
+            display: 'flex',
             left: isMenuOpen
               ? `calc(50vw + ${layout.sidebarWidth} / 2)`
               : '50%',


### PR DESCRIPTION
### What this PR does

Fixes the range slider on the Field screen so its thumb is vertically centered in its grey pill-shaped container.

MUI's `Slider` root renders with `display: inline-block` and `vertical-align: baseline`. Inside the block-level `.slider-wrapper` container, that baseline alignment reserved descender space beneath the slider, making the container ~7px taller than the slider's own content and pushing the thumb above center. Making `.slider-wrapper` a flex container with `alignItems: center` removes that offset.

### How this change can be validated

1. Open the Field screen.
2. Select a tool with an adjustable range (e.g. the watering can) so the range slider appears.
3. Confirm the slider thumb is vertically centered within its grey background, rather than sitting slightly above center.

Verified with Playwright against the dev server: before the fix the wrapper was 37px tall with the thumb center 3.5px above the wrapper's center; after the fix the wrapper is 30px tall and the thumb center exactly matches the wrapper's center. `Field.test.tsx` still passes (32/32).

### Questions or concerns about this change

None.

### Additional information

Before:

<img width="544" height="317" alt="Screenshot from 2026-07-14 08-37-55" src="https://github.com/user-attachments/assets/0fc14e3c-3327-4f58-9808-65350ad11ee0" />

After:

<img width="544" height="317" alt="Screenshot from 2026-07-14 08-37-42" src="https://github.com/user-attachments/assets/1b4cb213-f88a-4a62-8089-15c8f8862b04" />
