### PR TITLE
Fix: Toolbelt divider not visible in wide layout

### DIFF
--- a/src/styles/sx.ts
+++ b/src/styles/sx.ts
@@ -123,9 +123,11 @@ export const quickSelectSx = (theme: Theme, isMenuOpen: boolean) => ({
   '& .MuiDivider-root': {
     margin: '0 0.5em',
     [`@media (orientation: landscape) and (min-height: ${breakpoints.largePhone}px)`]: {
-      margin: '0 0 1em 0',
+      margin: '0.5em 0',
       height: '1px',
       width: '100%',
+      borderRightWidth: 0,
+      borderBottomWidth: 'thin',
     },
   },
 })


### PR DESCRIPTION
### What this PR does

Fixes the Toolbelt divider (between the tools and seeds/items) so it's visible in both layouts. Previously it only showed up in the narrow/portrait layout where the Toolbelt sits at the bottom — in the wide/landscape layout where the Toolbelt moves to the right side, the divider was invisible.

Root cause: the wide-layout media query in `quickSelectSx` (`src/styles/sx.ts`) resized `.MuiDivider-root` to a 1px horizontal bar (`height: '1px'`, `width: '100%'`) but never overrode MUI's vertical-orientation border defaults (`borderRightWidth: 'thin'`, `borderBottomWidth: 0`), so the only border that was drawn had zero height and was effectively invisible.

### How this change can be validated

1. Open the Field (or Forest) view.
2. In a narrow/portrait window, confirm the divider line is visible between the tool icons and the seed/item icons in the bottom toolbelt.
3. Widen the window into landscape (or resize past the `largePhone` breakpoint) so the toolbelt moves to the right side, and confirm the divider is now also visible there, as a horizontal line between the tool icons and item icons.

### Questions or concerns about this change

None — this is a scoped CSS fix with no behavioral changes.

### Additional information

Verified visually with Playwright screenshots at both a narrow viewport (400x800) and a wide viewport (1200x800).

Before:

<img width="236" height="450" alt="image" src="https://github.com/user-attachments/assets/b2ba048c-0828-450a-8162-99481b3e0106" />

After:

<img width="236" height="450" alt="Screenshot from 2026-07-16 21-12-24" src="https://github.com/user-attachments/assets/47ce58bb-80db-4a55-9856-e4d7d20ad533" />