### PR TITLE
Add an E2E test case for Rainbow Mulch mechanics

### DIFF
--- a/e2e/fixtures/forest-tree-rainbow-mulch.json
+++ b/e2e/fixtures/forest-tree-rainbow-mulch.json
@@ -58,7 +58,11 @@
         "daysOld": 3,
         "daysSinceLastHarvest": 0
       },
-      null,
+      {
+        "itemId": "apple",
+        "daysOld": 3,
+        "daysSinceLastHarvest": 0
+      },
       null,
       null
     ],

--- a/e2e/fixtures/forest-tree-rainbow-mulch.json
+++ b/e2e/fixtures/forest-tree-rainbow-mulch.json
@@ -127,6 +127,10 @@
     {
       "id": "rainbow-mulch",
       "quantity": 1
+    },
+    {
+      "id": "mulch",
+      "quantity": 1
     }
   ],
   "inventoryLimit": 100,

--- a/e2e/fixtures/forest-tree-rainbow-mulch.json
+++ b/e2e/fixtures/forest-tree-rainbow-mulch.json
@@ -1,0 +1,263 @@
+{
+  "allowCustomPeerCowNames": false,
+  "cellarInventory": [],
+  "completedAchievements": {
+    "plant-crop": true,
+    "water-crop": true
+  },
+  "cowBreedingPen": {
+    "cowId1": null,
+    "cowId2": null,
+    "daysUntilBirth": -1
+  },
+  "cowColorsPurchased": {},
+  "cowForSale": {
+    "baseWeight": 1601,
+    "color": "GREEN",
+    "colorsInBloodline": {
+      "GREEN": true
+    },
+    "daysOld": 1,
+    "daysSinceMilking": 0,
+    "daysSinceProducingFertilizer": 0,
+    "gender": "FEMALE",
+    "happiness": 0,
+    "happinessBoostsToday": 0,
+    "id": "b93a9c59-f73f-4986-b44e-ffb422bcd4c2",
+    "isBred": false,
+    "isUsingHuggingMachine": false,
+    "name": "Guava",
+    "ownerId": "",
+    "originalOwnerId": "",
+    "timesTraded": 0,
+    "weightMultiplier": 1
+  },
+  "cowInventory": [],
+  "cowsSold": {},
+  "cowsTraded": 0,
+  "cropsHarvested": {},
+  "dayCount": 6,
+  "experience": 20000,
+  "farmName": "Unnamed",
+  "field": [
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null]
+  ],
+  "forest": [
+    [
+      {
+        "itemId": "apple",
+        "daysOld": 3,
+        "daysSinceLastHarvest": 0
+      },
+      null,
+      null,
+      null
+    ],
+    [null, null, null, null]
+  ],
+  "historicalDailyLosses": [0, 0, 0, 0, -143.7],
+  "historicalDailyRevenue": [0, 0, 0, 0, 0],
+  "historicalValueAdjustments": [
+    {
+      "asparagus": 1.254561372610583,
+      "asparagus-seed": 0.8845336867381606,
+      "bronze-ore": 0.8820993693168143,
+      "carrot": 0.5151057244898383,
+      "carrot-seed": 0.8007552689761459,
+      "corn": 1.0577673788621866,
+      "corn-seed": 0.8492871019468962,
+      "garlic": 0.6502095798811709,
+      "garlic-seed": 0.6776417342031218,
+      "gold-ore": 1.1584127926987628,
+      "grape-cabernet-sauvignon": 1.0811524144134221,
+      "grape-chardonnay": 0.9566018874265536,
+      "grape-nebbiolo": 1.038616184743502,
+      "grape-sauvignon-blanc": 0.8420890144753135,
+      "grape-seed": 0.8711888712889699,
+      "grape-tempranillo": 0.8417473069445603,
+      "iron-ore": 0.8565852787467081,
+      "jalapeno": 0.8938267219202933,
+      "jalapeno-seed": 1.2806755799922187,
+      "olive": 0.894838025775234,
+      "olive-seed": 0.5819676400592492,
+      "onion": 1.388841964280044,
+      "onion-seed": 0.5548354705668044,
+      "pea": 1.4270874498629684,
+      "pea-seed": 1.3014170459989431,
+      "potato": 1.198063016021274,
+      "potato-seed": 1.1227007201477113,
+      "pumpkin": 1.256866505382895,
+      "pumpkin-seed": 0.9762702998744324,
+      "salt-rock": 1.318355654482557,
+      "silver-ore": 0.8675044285411415,
+      "soybean": 0.5974111121058051,
+      "soybean-seed": 1.2994025472815358,
+      "spinach": 1.3888914334365705,
+      "spinach-seed": 0.6511206276246511,
+      "strawberry": 0.6648639912973919,
+      "strawberry-seed": 1.2151617642366415,
+      "sunflower": 0.6441195107880303,
+      "sunflower-seed": 1.088430125646544,
+      "sweet-potato": 0.6854892825193449,
+      "sweet-potato-seed": 0.993009857740943,
+      "tomato": 1.287432200495485,
+      "tomato-seed": 1.1243978023384449,
+      "watermelon": 1.0980278225758555,
+      "watermelon-seed": 1.1400979011983594,
+      "wheat": 0.8063919814881977,
+      "wheat-seed": 0.9399986471778438
+    }
+  ],
+  "hoveredPlotRangeSize": 7,
+  "id": "d7a1db57-f021-4ce5-b632-ad382789f4f1",
+  "inventory": [
+    {
+      "id": "rainbow-mulch",
+      "quantity": 1
+    }
+  ],
+  "inventoryLimit": 100,
+  "isCombineEnabled": false,
+  "itemsSold": {},
+  "cellarItemsSold": {},
+  "learnedRecipes": {},
+  "loanBalance": 552.03,
+  "loansTakenOut": 1,
+  "money": 250106.3,
+  "newDayNotifications": [],
+  "notificationLog": [
+    {
+      "day": 6,
+      "notifications": {
+        "error": [],
+        "info": ["It rained in the night!"],
+        "success": [],
+        "warning": ["Your loan balance has grown to $552.03."]
+      }
+    },
+    {
+      "day": 5,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $541.21."]
+      }
+    },
+    {
+      "day": 4,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $530.60."]
+      }
+    },
+    {
+      "day": 3,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $520.20."]
+      }
+    },
+    {
+      "day": 2,
+      "notifications": {
+        "error": [],
+        "info": ["It rained in the night!"],
+        "success": [],
+        "warning": ["Your loan balance has grown to $510.00."]
+      }
+    }
+  ],
+  "priceCrashes": {},
+  "priceSurges": {},
+  "profitabilityStreak": 0,
+  "purchasedCombine": 0,
+  "purchasedComposter": 0,
+  "purchasedCowPen": 0,
+  "purchasedCellar": 0,
+  "purchasedField": 0,
+  "purchasedForest": 1,
+  "purchasedSmelter": 0,
+  "record7dayProfitAverage": 0,
+  "recordProfitabilityStreak": 0,
+  "recordSingleDayProfit": 0,
+  "revenue": 0,
+  "showHomeScreen": true,
+  "showNotifications": true,
+  "todaysLosses": -250000,
+  "todaysPurchases": {},
+  "todaysRevenue": 0,
+  "todaysStartingInventory": {
+    "rainbow-mulch": 1
+  },
+  "toolLevels": {
+    "HOE": "DEFAULT",
+    "SCYTHE": "DEFAULT",
+    "SHOVEL": "UNAVAILABLE",
+    "WATERING_CAN": "DEFAULT"
+  },
+  "useAlternateEndDayButtonPosition": false,
+  "valueAdjustments": {
+    "asparagus": 0.7710329471429687,
+    "asparagus-seed": 0.6047945736371781,
+    "bronze-ore": 0.6523314669735881,
+    "carrot": 1.148946183956264,
+    "carrot-seed": 1.150865016558905,
+    "corn": 1.2916975621660312,
+    "corn-seed": 0.8194585108692283,
+    "garlic": 0.5890389828828759,
+    "garlic-seed": 1.0461378148234952,
+    "gold-ore": 1.1866263486101722,
+    "grape-cabernet-sauvignon": 0.9051176034381517,
+    "grape-chardonnay": 1.0449007660226393,
+    "grape-nebbiolo": 0.8715697232156476,
+    "grape-sauvignon-blanc": 0.6310523029050967,
+    "grape-seed": 0.9253596435820454,
+    "grape-tempranillo": 0.6756200431464858,
+    "iron-ore": 1.1565063783102898,
+    "jalapeno": 0.7091052379238315,
+    "jalapeno-seed": 1.132727916247675,
+    "olive": 1.311369163510936,
+    "olive-seed": 0.9192617853490546,
+    "onion": 0.7145057442803753,
+    "onion-seed": 0.6384400392400458,
+    "pea": 1.3438668707129882,
+    "pea-seed": 0.947899535167928,
+    "potato": 0.9114908865313538,
+    "potato-seed": 1.1068364751179312,
+    "pumpkin": 0.8377832985809028,
+    "pumpkin-seed": 1.4440859731959748,
+    "salt-rock": 1.3505767817681624,
+    "silver-ore": 0.9160677427267769,
+    "soybean": 0.7877249923876428,
+    "soybean-seed": 1.062021364573846,
+    "spinach": 1.2699413150967442,
+    "spinach-seed": 0.8490869162420625,
+    "strawberry": 1.41618172037454,
+    "strawberry-seed": 0.8777549220278436,
+    "sunflower": 0.5903344778618149,
+    "sunflower-seed": 0.974090939308244,
+    "sweet-potato": 0.5906894671175695,
+    "sweet-potato-seed": 0.6012857315253939,
+    "tomato": 1.1936926336320215,
+    "tomato-seed": 0.7109397222579946,
+    "watermelon": 0.666622692558885,
+    "watermelon-seed": 1.0104982645951823,
+    "wheat": 0.8632829757532291,
+    "wheat-seed": 0.7821587302079209
+  },
+  "version": "1.18.26"
+}

--- a/e2e/tests/forest.test.ts
+++ b/e2e/tests/forest.test.ts
@@ -258,20 +258,18 @@ test('should apply rainbow mulch to one tree and leave another unmulched, advanc
   await expect(page.getByRole('tooltip')).toContainText('Rainbow Mulched')
 
   // Advance the days so the rainbow mulched tree grows faster than the other
-  // FERTILIZER_BONUS is 0.5. So 1 day = 1.5 days of growth.
-  // Apple sapling stages are [5, 5, 5, 5, 5]. It takes 25 days to fully grow.
-  // The trees in the fixture are 3 days old. Let's advance 14 days.
-  // The unmulched tree will be 17 days old (17 < 25), so still Growing.
-  // The rainbow mulched tree will be 3 + (14 * 1.5) = 24 days grown (24 < 25), still Growing...
-  // Wait, 15 days: unmulched = 18 days, mulched = 3 + 22.5 = 25.5 (Grown!).
+  // The trees in the fixture are 3 days old.
+  // We want to advance time so one tree reaches GROWN (and begins fruiting)
+  // while the other stays in the Growing stage.
+  // Apple tree timeline is 25 days. FERTILIZER_BONUS gives an extra 0.5 days per day (so 1 day = 1.5 days grown).
+  // Advancing 15 days:
+  // - unmulched tree: 3 + 15 = 18 days old (still Growing...)
+  // - rainbow mulched tree: 3 + (15 * 1.5) = 25.5 days grown (reaches GROWN at 25, starts fruiting)
 
   for (let day = 0; day < 15; day++) {
     await page.getByRole('button', { name: 'End the day to save your' }).click()
   }
 
-  // After 15 days:
-  // Unmulched tree is 18 days old, so it's still "Growing..."
-  // Rainbow-mulched tree is 25.5 days grown, so it reaches GROWN stage and starts fruiting ("Fruiting... (Rainbow Mulched)")
   // Wait a small bit before hovering to allow the end-day tooltip to disappear,
   // or use the tooltip filter if there's multiple
   await page.mouse.move(0, 0)
@@ -283,7 +281,7 @@ test('should apply rainbow mulch to one tree and leave another unmulched, advanc
   await page.mouse.move(0, 0)
   await page.waitForTimeout(100)
   await secondPlot.hover()
-  await expect(page.getByRole('tooltip').filter({ hasText: 'Apple Tree' })).toContainText('Growing...')
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Apple Tree' }).first()).toContainText('Growing...')
 })
 
 test("should be able to buy Mulch directly from the Shop's Supplies tab", async ({

--- a/e2e/tests/forest.test.ts
+++ b/e2e/tests/forest.test.ts
@@ -235,7 +235,7 @@ test('should purchase a Wood Chipper and craft the Wood Chips -> Mulch recipe ch
   ).toBeVisible()
 })
 
-test('should apply rainbow mulch to a tree and consume it from inventory', async ({
+test('should apply rainbow mulch to one tree and leave another unmulched, advancing time to assert growth differences', async ({
   page,
 }) => {
   await loadFixture(page, 'forest-tree-rainbow-mulch')
@@ -243,18 +243,47 @@ test('should apply rainbow mulch to a tree and consume it from inventory', async
   await page.getByText(': Home').click()
   await page.getByRole('option', { name: ': Forest' }).click()
 
-  const treePlot = page.locator('.ForestPlot').first()
+  const firstPlot = page.locator('.ForestPlot').nth(0)
+  const secondPlot = page.locator('.ForestPlot').nth(1)
 
+  // Apply rainbow mulch to the first tree
   await page.getByRole('button', { name: 'Rainbow Mulch' }).click()
-  await treePlot.click()
+  await firstPlot.click()
 
-  // The rainbow mulch was the player's only one, so it's gone from inventory
-  // and the toolbelt no longer offers it.
+  // Verify the mulch is consumed
   await expect(page.getByRole('button', { name: 'Rainbow Mulch' })).not.toBeVisible()
 
-  // Verify tooltip reflects Rainbow Mulch status
-  await treePlot.hover()
+  // Verify tooltip reflects Rainbow Mulch status on the first tree
+  await firstPlot.hover()
   await expect(page.getByRole('tooltip')).toContainText('Rainbow Mulched')
+
+  // Advance the days so the rainbow mulched tree grows faster than the other
+  // FERTILIZER_BONUS is 0.5. So 1 day = 1.5 days of growth.
+  // Apple sapling stages are [5, 5, 5, 5, 5]. It takes 25 days to fully grow.
+  // The trees in the fixture are 3 days old. Let's advance 14 days.
+  // The unmulched tree will be 17 days old (17 < 25), so still Growing.
+  // The rainbow mulched tree will be 3 + (14 * 1.5) = 24 days grown (24 < 25), still Growing...
+  // Wait, 15 days: unmulched = 18 days, mulched = 3 + 22.5 = 25.5 (Grown!).
+
+  for (let day = 0; day < 15; day++) {
+    await page.getByRole('button', { name: 'End the day to save your' }).click()
+  }
+
+  // After 15 days:
+  // Unmulched tree is 18 days old, so it's still "Growing..."
+  // Rainbow-mulched tree is 25.5 days grown, so it reaches GROWN stage and starts fruiting ("Fruiting... (Rainbow Mulched)")
+  // Wait a small bit before hovering to allow the end-day tooltip to disappear,
+  // or use the tooltip filter if there's multiple
+  await page.mouse.move(0, 0)
+  await page.waitForTimeout(100)
+
+  await firstPlot.hover()
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Rainbow Mulched' })).toContainText('Fruiting... (Rainbow Mulched)')
+
+  await page.mouse.move(0, 0)
+  await page.waitForTimeout(100)
+  await secondPlot.hover()
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Apple Tree' })).toContainText('Growing...')
 })
 
 test("should be able to buy Mulch directly from the Shop's Supplies tab", async ({

--- a/e2e/tests/forest.test.ts
+++ b/e2e/tests/forest.test.ts
@@ -235,6 +235,28 @@ test('should purchase a Wood Chipper and craft the Wood Chips -> Mulch recipe ch
   ).toBeVisible()
 })
 
+test('should apply rainbow mulch to a tree and consume it from inventory', async ({
+  page,
+}) => {
+  await loadFixture(page, 'forest-tree-rainbow-mulch')
+
+  await page.getByText(': Home').click()
+  await page.getByRole('option', { name: ': Forest' }).click()
+
+  const treePlot = page.locator('.ForestPlot').first()
+
+  await page.getByRole('button', { name: 'Rainbow Mulch' }).click()
+  await treePlot.click()
+
+  // The rainbow mulch was the player's only one, so it's gone from inventory
+  // and the toolbelt no longer offers it.
+  await expect(page.getByRole('button', { name: 'Rainbow Mulch' })).not.toBeVisible()
+
+  // Verify tooltip reflects Rainbow Mulch status
+  await treePlot.hover()
+  await expect(page.getByRole('tooltip')).toContainText('Rainbow Mulched')
+})
+
 test("should be able to buy Mulch directly from the Shop's Supplies tab", async ({
   page,
 }) => {

--- a/e2e/tests/forest.test.ts
+++ b/e2e/tests/forest.test.ts
@@ -250,23 +250,45 @@ test('should apply rainbow mulch to one tree and leave another unmulched, advanc
   await page.getByRole('button', { name: 'Rainbow Mulch' }).click()
   await firstPlot.click()
 
-  // Verify the mulch is consumed
+  // Verify the rainbow mulch is consumed
   await expect(page.getByRole('button', { name: 'Rainbow Mulch' })).not.toBeVisible()
+
+  // Apply regular mulch to the second tree
+  await page.getByRole('button', { name: 'Mulch' }).click()
+  await secondPlot.click()
+
+  // Verify the regular mulch is consumed
+  await expect(page.getByRole('button', { name: 'Mulch' })).not.toBeVisible()
 
   // Verify tooltip reflects Rainbow Mulch status on the first tree
   await firstPlot.hover()
-  await expect(page.getByRole('tooltip')).toContainText('Rainbow Mulched')
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Rainbow Mulched' })).toContainText('Rainbow Mulched')
+
+  await page.mouse.move(0, 0)
+  await page.waitForTimeout(100)
+
+  // Verify tooltip reflects regular Mulch status on the second tree
+  await secondPlot.hover()
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Growing... (Mulched)' })).toContainText('Mulched')
 
   // Advance the days so the rainbow mulched tree grows faster than the other
   // The trees in the fixture are 3 days old.
-  // We want to advance time so one tree reaches GROWN (and begins fruiting)
-  // while the other stays in the Growing stage.
-  // Apple tree timeline is 25 days. FERTILIZER_BONUS gives an extra 0.5 days per day (so 1 day = 1.5 days grown).
-  // Advancing 15 days:
-  // - unmulched tree: 3 + 15 = 18 days old (still Growing...)
-  // - rainbow mulched tree: 3 + (15 * 1.5) = 25.5 days grown (reaches GROWN at 25, starts fruiting)
+  // We want to advance time so the rainbow mulched tree reaches fruit growth
+  // while the regular mulched tree does not.
+  // Standard mulch speeds up initial tree growth, but not the fruit cycle.
+  // Rainbow mulch speeds up BOTH initial tree growth AND the fruit cycle.
+  // Apple tree timeline is 25 days to GROWN. FERTILIZER_BONUS gives an extra 0.5 days per day (so 1 day = 1.5 days grown).
+  // Advancing 15 days gets both trees to GROWN state: 3 + (15 * 1.5) = 25.5 days grown.
+  // Apple fruit timeline is [2, 2, 2], meaning it takes 6 days to be "Ready to pick!".
+  // After reaching GROWN (day 15 for both), the fruit cycle starts:
+  // - Standard mulched tree: Fruit cycle progresses at normal speed (1 day/day).
+  // - Rainbow mulched tree: Fruit cycle progresses at accelerated speed (1.5 days/day).
+  // Let's advance a total of 19 days.
+  // At day 15, both are GROWN. 4 more days pass:
+  // - Standard mulched tree: 4 days of fruit growth. 4 < 6, so it's still "Fruiting...".
+  // - Rainbow mulched tree: 4 * 1.5 = 6 days of fruit growth. 6 >= 6, so it's "Ready to pick!".
 
-  for (let day = 0; day < 15; day++) {
+  for (let day = 0; day < 19; day++) {
     await page.getByRole('button', { name: 'End the day to save your' }).click()
   }
 
@@ -276,12 +298,12 @@ test('should apply rainbow mulch to one tree and leave another unmulched, advanc
   await page.waitForTimeout(100)
 
   await firstPlot.hover()
-  await expect(page.getByRole('tooltip').filter({ hasText: 'Rainbow Mulched' })).toContainText('Fruiting... (Rainbow Mulched)')
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Rainbow Mulched' })).toContainText('Ready to pick! (Rainbow Mulched)')
 
   await page.mouse.move(0, 0)
   await page.waitForTimeout(100)
   await secondPlot.hover()
-  await expect(page.getByRole('tooltip').filter({ hasText: 'Apple Tree' }).first()).toContainText('Growing...')
+  await expect(page.getByRole('tooltip').filter({ hasText: 'Mulched' }).first()).toContainText('Fruiting... (Mulched)')
 })
 
 test("should be able to buy Mulch directly from the Shop's Supplies tab", async ({


### PR DESCRIPTION
Added an E2E test case to exercise the Rainbow Mulch mechanics. I included an appropriate test fixture to simplify the test setup by copying the existing mulch fixture. The new test applies Rainbow Mulch to a tree, verifies the item is consumed, and checks that the correct tooltip state applies.

---
*PR created automatically by Jules for task [17910047291748339874](https://jules.google.com/task/17910047291748339874) started by @jeremyckahn*