### PR TITLE
Update CodeQL Actions and Checkout to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Successfully upgraded the GitHub actions references in .github/workflows/codeql-analysis.yml. Specifically:
- Updated Checkout step from `actions/checkout@v3` to `actions/checkout@v4`
- Updated CodeQL initialization step from `github/codeql-action/init@v1` to `github/codeql-action/init@v4`
- Updated CodeQL autobuild step from `github/codeql-action/autobuild@v1` to `github/codeql-action/autobuild@v4`
- Updated CodeQL analysis step from `github/codeql-action/analyze@v1` to `github/codeql-action/analyze@v4`

---
*PR created automatically by Jules for task [5918641051587810442](https://jules.google.com/task/5918641051587810442) started by @jeremyckahn*