### PR TITLE
fix(e2e): Make price-fluctuation assertions immune to the AnimatedNumber tween race

### DIFF
--- a/e2e/tests/multiplayer/price-fluctuation.test.ts
+++ b/e2e/tests/multiplayer/price-fluctuation.test.ts
@@ -39,6 +39,19 @@ test('uses server-based price values', async ({ page }) => {
     Math.round(baseCarrotValue * carrotValueAdjustment * 100) / 100
   ).toFixed(2)
 
+  // The sell price is rendered via AnimatedNumber, which tweens the
+  // displayed value over 750ms via requestAnimationFrame - reading it right
+  // after the server pushes a new value races that live animation under a
+  // slow/contended CI runner. Pausing the clock right at this instant (it
+  // otherwise free-runs in real time - see open-page.ts) and then running
+  // it forward past the tween's duration makes the read deterministic
+  // instead. A real (not fake-clock) wait first ensures any in-flight
+  // nav-menu transition has actually finished before we take over the
+  // clock, otherwise pausing mid-transition leaves its backdrop stuck.
+  await page.waitForTimeout(500)
+  await page.clock.pauseAt(await page.evaluate(() => Date.now()))
+  await page.clock.runFor(800)
+
   await expect(page.getByRole('complementary')).toContainText(
     `CarrotSell price: $${adjustedCarrotPrice}Total: $${adjustedCarrotPrice}`
   )

--- a/e2e/tests/price-fluctuation.test.ts
+++ b/e2e/tests/price-fluctuation.test.ts
@@ -16,8 +16,21 @@ test('should fluctuate crop prices', async ({ page }) => {
   await expect(page.locator('#shop-tabpanel-0')).toContainText(
     'Carrot SeedPrice: $17.73Total: $17.73In inventory: 0Days to mature: 5'
   )
+  // Carrot Seed's price is rendered via AnimatedNumber, which tweens the
+  // displayed value over 750ms via requestAnimationFrame - reading it right
+  // after "End the day" races that live animation. Pausing the clock right
+  // at this instant (it otherwise free-runs in real time - see
+  // open-page.ts) and then running it forward past the tween's duration
+  // makes the read deterministic instead. Scoped to just this moment so it
+  // doesn't affect earlier nav-menu transitions, which rely on real timers -
+  // a real (not fake-clock) wait first ensures the nav combobox's own
+  // closing transition has actually finished before we take over the clock,
+  // otherwise pausing mid-transition leaves its backdrop stuck forever.
+  await page.waitForTimeout(500)
+  await page.clock.pauseAt(await page.evaluate(() => Date.now()))
   await page.getByRole('button', { name: 'End the day to save your' }).click()
+  await page.clock.runFor(800)
   await expect(page.locator('#shop-tabpanel-0')).toContainText(
-    'Carrot SeedPrice: $17.73Total: $17.73In inventory: 0Days to mature: 5'
+    'Carrot SeedPrice: $18.23Total: $18.23In inventory: 0Days to mature: 5'
   )
 })


### PR DESCRIPTION
### What this PR does

`price-fluctuation.test.ts` has been intermittently failing in CI with a range of nearby-but-wrong Carrot Seed prices (e.g. `$17.79`-`$18.23` in one run). Root cause: every Shop/sell price renders via `<AnimatedNumber>`, which tweens the displayed value over 750ms via `requestAnimationFrame` whenever it changes on an already-mounted component - exactly what happens right after "End the day" recomputes prices while the Shop tab is open. `e2e/test-utils/open-page.ts` installs Playwright's fake clock but never actually pauses it, so `requestAnimationFrame` keeps advancing in real wall-clock time, and reading a price immediately after such an action races that live animation. A live repro confirmed the underlying reducer pipeline (`computeStateForNextDay.ts`) is fully deterministic - only the *observed* displayed text was racing the animation.

Fix: pause Playwright's clock right before the price-changing action and run it forward past the tween's duration, so the read is deterministic. This is scoped locally to each affected assertion rather than globally in `open-page.ts` - a global pause was tried first and reverted, since it breaks this app's MUI-`Select`-based navigation everywhere (the menu-close transition also depends on a real timer that would otherwise never fire, leaving a stuck, click-intercepting backdrop after the very first nav interaction in nearly every test).

`price-fluctuation.test.ts`'s hardcoded expected price is also corrected from `$17.73` (itself an artifact of a racy read) to `$18.23`, the actual deterministic settled value.

### How this change can be validated

- `npx playwright test e2e/tests/price-fluctuation.test.ts --repeat-each=10` - 10/10 passed locally, where before the fix it failed intermittently.
- Full local e2e suite run clean except the multiplayer/WebSocket test files, which fail in this sandbox for an unrelated, pre-existing reason (this environment's networking can't establish real WebRTC/tracker connections - confirmed reproducible even against unmodified `develop`).
- `npx tsc --noEmit`, `npm run check:types`, and `eslint` all pass.

### Questions or concerns about this change

`e2e/tests/multiplayer/price-fluctuation.test.ts` got the same fix (it reads a server-pushed price via the same `AnimatedNumber`), but I couldn't verify it locally since this sandbox can't establish the multiplayer connection the test needs. Worth watching this specific file in CI.

### Additional information

None.