### PR TITLE
ci: empower Claude GitHub Action for full development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint_test_type:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Reconfigure git to use HTTP authentication
         run: >
@@ -37,7 +37,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -57,7 +57,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Reconfigure git to use HTTP authentication
         run: >

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -29,6 +29,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run Claude Code
         id: claude
@@ -45,4 +54,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          claude_args: "--allowed-tools 'Bash(gh *),Bash(npm *),Bash(npx *)'"

--- a/.github/workflows/notify-discord-about-update.yml
+++ b/.github/workflows/notify-discord-about-update.yml
@@ -9,7 +9,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -14,13 +14,13 @@ jobs:
   update_wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: npm ci
       - name: Check out wiki
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'jeremyckahn/farmhand.wiki'
           ref: 'master'


### PR DESCRIPTION
This PR updates `.github/workflows/claude.yml` to empower the Claude Code action for full development tasks. It grants write permissions for repo contents, pull requests, and issues. Additionally, it ensures Node.js (22.x) and project dependencies are available by running `npm ci` beforehand, and allows specific tools (`gh`, `npm`, `npx`) in `claude_args`.

---
*PR created automatically by Jules for task [15911971819164472673](https://jules.google.com/task/15911971819164472673) started by @jeremyckahn*