### PR TITLE
fix: Skip number and progress animations when prefers-reduced-motion is active

### DIFF
--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -30,6 +30,7 @@ const AnimatedNumber = ({
       }
 
       previousNumberRef.current = number
+      setDisplayedNumber(number)
       return
     }
 

--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 // eslint-disable-next-line no-unused-vars
 import { tween, Tweenable } from 'shifty'
 import { func as funcProp, number as numberProp } from 'prop-types'
+
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion.js'
 
 const defaultFormatter = (num: number) => `${num}`
 
@@ -15,25 +17,25 @@ const AnimatedNumber = ({
   number: number
   formatter?: typeof defaultFormatter
 }): JSX.Element => {
+  const prefersReducedMotion = usePrefersReducedMotion()
   const [displayedNumber, setDisplayedNumber] = useState(number)
-  const [previousNumber, setPreviousNumber] = useState(number)
-  const [currentTweenable, setCurrentTweenable] = useState<
-    Tweenable | undefined
-  >()
+  const previousNumberRef = useRef(number)
+  const tweenableRef = useRef<Tweenable | null>(null)
 
   useEffect(() => {
-    setPreviousNumber(number)
-  }, [number, setPreviousNumber])
-
-  useEffect(() => {
-    if (number !== previousNumber) {
-      if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
-        setDisplayedNumber(number)
-        return
+    if (prefersReducedMotion) {
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+        tweenableRef.current = null
       }
 
-      if (currentTweenable) {
-        currentTweenable.cancel()
+      previousNumberRef.current = number
+      return
+    }
+
+    if (previousNumberRef.current !== number) {
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
       }
 
       const tweenable = tween({
@@ -43,22 +45,26 @@ const AnimatedNumber = ({
           setDisplayedNumber(Number(tweenedNumber))
         },
         from: {
-          number: previousNumber,
+          number: previousNumberRef.current,
         },
         to: { number },
       })
 
-      setCurrentTweenable(tweenable)
+      tweenableRef.current = tweenable
+      previousNumberRef.current = number
     }
 
     return () => {
-      if (currentTweenable) {
-        currentTweenable.cancel()
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+        tweenableRef.current = null
       }
     }
-  }, [currentTweenable, number, previousNumber])
+  }, [number, prefersReducedMotion])
 
-  return <span className="AnimatedNumber">{formatter(displayedNumber)}</span>
+  const valueToDisplay = prefersReducedMotion ? number : displayedNumber
+
+  return <span className="AnimatedNumber">{formatter(valueToDisplay)}</span>
 }
 
 AnimatedNumber.propTypes = {

--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -23,49 +23,36 @@ const AnimatedNumber = ({
   const tweenableRef = useRef<Tweenable | null>(null)
 
   useEffect(() => {
-    if (prefersReducedMotion) {
-      if (tweenableRef.current) {
-        tweenableRef.current.cancel()
-        tweenableRef.current = null
-      }
+    tweenableRef.current?.cancel()
+    tweenableRef.current = null
 
+    if (prefersReducedMotion || previousNumberRef.current === number) {
       previousNumberRef.current = number
       setDisplayedNumber(number)
       return
     }
 
-    if (previousNumberRef.current !== number) {
-      if (tweenableRef.current) {
-        tweenableRef.current.cancel()
-      }
+    tweenableRef.current = tween({
+      easing: 'easeOutQuad',
+      duration: 750,
+      render: ({ number: tweenedNumber }: any) => {
+        setDisplayedNumber(Number(tweenedNumber))
+      },
+      from: {
+        number: previousNumberRef.current,
+      },
+      to: { number },
+    })
 
-      const tweenable = tween({
-        easing: 'easeOutQuad',
-        duration: 750,
-        render: ({ number: tweenedNumber }: any) => {
-          setDisplayedNumber(Number(tweenedNumber))
-        },
-        from: {
-          number: previousNumberRef.current,
-        },
-        to: { number },
-      })
-
-      tweenableRef.current = tweenable
-      previousNumberRef.current = number
-    }
+    previousNumberRef.current = number
 
     return () => {
-      if (tweenableRef.current) {
-        tweenableRef.current.cancel()
-        tweenableRef.current = null
-      }
+      tweenableRef.current?.cancel()
+      tweenableRef.current = null
     }
   }, [number, prefersReducedMotion])
 
-  const valueToDisplay = prefersReducedMotion ? number : displayedNumber
-
-  return <span className="AnimatedNumber">{formatter(valueToDisplay)}</span>
+  return <span className="AnimatedNumber">{formatter(displayedNumber)}</span>
 }
 
 AnimatedNumber.propTypes = {

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -29,6 +29,8 @@ const MoneyDisplay = ({ money }: { money: number }) => {
       }
 
       previousMoneyRef.current = money
+      setDisplayedMoney(money)
+      setTextColor(idleColor)
       return
     }
 

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 // eslint-disable-next-line no-unused-vars
 import { tween, Tweenable } from 'shifty'
 import { array, bool, func, number, string } from 'prop-types'
@@ -11,23 +11,31 @@ import StepIcon from '@mui/material/StepIcon/index.js'
 import FarmhandContext from '../Farmhand/Farmhand.context.js'
 import { moneyString } from '../../utils/moneyString.js'
 import { breakpoints } from '../../styles/tokens.js'
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion.js'
 
 const MoneyDisplay = ({ money }: { money: number }) => {
   const idleColor = 'rgb(255, 255, 255)'
+  const prefersReducedMotion = usePrefersReducedMotion()
   const [displayedMoney, setDisplayedMoney] = useState(money)
   const [textColor, setTextColor] = useState(idleColor)
-  const [previousMoney, setPreviousMoney] = useState(money)
-  const [currentTweenable, setCurrentTweenable] = useState<
-    Tweenable | undefined
-  >()
+  const previousMoneyRef = useRef(money)
+  const tweenableRef = useRef<Tweenable | null>(null)
 
   useEffect(() => {
-    setPreviousMoney(money)
-  }, [money, setPreviousMoney])
+    if (prefersReducedMotion) {
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+        tweenableRef.current = null
+      }
 
-  useEffect(() => {
-    if (money !== previousMoney) {
-      currentTweenable?.cancel()
+      previousMoneyRef.current = money
+      return
+    }
+
+    if (previousMoneyRef.current !== money) {
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+      }
 
       const tweenable = tween({
         easing: 'easeOutQuad',
@@ -37,29 +45,39 @@ const MoneyDisplay = ({ money }: { money: number }) => {
           setDisplayedMoney(Number(currentMoney))
         },
         from: {
-          color: money > previousMoney ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)',
-          money: previousMoney,
+          color:
+            money > previousMoneyRef.current
+              ? 'rgb(0, 255, 0)'
+              : 'rgb(255, 0, 0)',
+          money: previousMoneyRef.current,
         },
         to: { color: idleColor, money },
       })
 
-      setCurrentTweenable(tweenable)
+      tweenableRef.current = tweenable
+      previousMoneyRef.current = money
     }
 
     return () => {
-      currentTweenable?.cancel()
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+        tweenableRef.current = null
+      }
     }
-  }, [currentTweenable, money, previousMoney])
+  }, [money, prefersReducedMotion])
+
+  const amountToDisplay = prefersReducedMotion ? money : displayedMoney
+  const colorToDisplay = prefersReducedMotion ? idleColor : textColor
 
   return (
     <span
       {...{
         style: {
-          color: textColor,
+          color: colorToDisplay,
         },
       }}
     >
-      {moneyString(displayedMoney)}
+      {moneyString(amountToDisplay)}
     </span>
   )
 }

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -22,64 +22,50 @@ const MoneyDisplay = ({ money }: { money: number }) => {
   const tweenableRef = useRef<Tweenable | null>(null)
 
   useEffect(() => {
-    if (prefersReducedMotion) {
-      if (tweenableRef.current) {
-        tweenableRef.current.cancel()
-        tweenableRef.current = null
-      }
+    tweenableRef.current?.cancel()
+    tweenableRef.current = null
 
+    if (prefersReducedMotion || previousMoneyRef.current === money) {
       previousMoneyRef.current = money
       setDisplayedMoney(money)
       setTextColor(idleColor)
       return
     }
 
-    if (previousMoneyRef.current !== money) {
-      if (tweenableRef.current) {
-        tweenableRef.current.cancel()
-      }
+    const startColor =
+      money > previousMoneyRef.current ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)'
 
-      const tweenable = tween({
-        easing: 'easeOutQuad',
-        duration: 750,
-        render: ({ color, money: currentMoney }: any) => {
-          setTextColor(String(color))
-          setDisplayedMoney(Number(currentMoney))
-        },
-        from: {
-          color:
-            money > previousMoneyRef.current
-              ? 'rgb(0, 255, 0)'
-              : 'rgb(255, 0, 0)',
-          money: previousMoneyRef.current,
-        },
-        to: { color: idleColor, money },
-      })
+    tweenableRef.current = tween({
+      easing: 'easeOutQuad',
+      duration: 750,
+      render: ({ color, money: currentMoney }: any) => {
+        setTextColor(String(color))
+        setDisplayedMoney(Number(currentMoney))
+      },
+      from: {
+        color: startColor,
+        money: previousMoneyRef.current,
+      },
+      to: { color: idleColor, money },
+    })
 
-      tweenableRef.current = tweenable
-      previousMoneyRef.current = money
-    }
+    previousMoneyRef.current = money
 
     return () => {
-      if (tweenableRef.current) {
-        tweenableRef.current.cancel()
-        tweenableRef.current = null
-      }
+      tweenableRef.current?.cancel()
+      tweenableRef.current = null
     }
   }, [money, prefersReducedMotion])
-
-  const amountToDisplay = prefersReducedMotion ? money : displayedMoney
-  const colorToDisplay = prefersReducedMotion ? idleColor : textColor
 
   return (
     <span
       {...{
         style: {
-          color: colorToDisplay,
+          color: textColor,
         },
       }}
     >
-      {moneyString(amountToDisplay)}
+      {moneyString(displayedMoney)}
     </span>
   )
 }

--- a/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/ProgressBar.test.tsx
@@ -181,6 +181,7 @@ describe('ProgressBar', () => {
     expect(tween).toHaveBeenCalledTimes(1)
     expect(tween).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        from: { currentPercent: 0 },
         to: { currentPercent: 25 },
       })
     )
@@ -192,6 +193,7 @@ describe('ProgressBar', () => {
     expect(tween).toHaveBeenCalledTimes(2)
     expect(tween).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        from: { currentPercent: 25 },
         to: { currentPercent: 75 },
       })
     )

--- a/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/ProgressBar.test.tsx
@@ -185,12 +185,16 @@ describe('ProgressBar', () => {
       })
     )
 
-    // Update percent prop - this won't create a new tween since currentTweenable already exists
+    // Update percent prop - this cancels previous tween and creates a new tween for 75
     rerender(<ProgressBar {...{ percent: 75 }} />)
 
-    // Should still only have one tween call since the component only creates
-    // a new tween when currentTweenable is falsy
-    expect(tween).toHaveBeenCalledTimes(1)
+    expect(mockTweenInstance.cancel).toHaveBeenCalled()
+    expect(tween).toHaveBeenCalledTimes(2)
+    expect(tween).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        to: { currentPercent: 75 },
+      })
+    )
   })
 
   test('starts with incomplete color initially', () => {

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -23,6 +23,7 @@ const ProgressBar = ({ percent }: { percent: number }) => {
       : incompleteColor
   )
   const tweenableRef = useRef<any | null>(null)
+  const previousPercentRef = useRef(prefersReducedMotion ? percent : 0)
 
   useEffect(() => {
     const finalColor = interpolate(
@@ -34,6 +35,7 @@ const ProgressBar = ({ percent }: { percent: number }) => {
     if (prefersReducedMotion) {
       setDisplayedProgress(percent)
       setDisplayedColor(finalColor)
+      previousPercentRef.current = percent
 
       if (tweenableRef.current) {
         tweenableRef.current.cancel()
@@ -48,7 +50,7 @@ const ProgressBar = ({ percent }: { percent: number }) => {
         delay: 750,
         easing: 'easeInOutQuad',
         duration: 1500,
-        from: { currentPercent: 0 },
+        from: { currentPercent: previousPercentRef.current },
         to: { currentPercent: percent },
         render: ({ currentPercent }: any) => {
           const currentPercentNumber = Number(currentPercent)
@@ -65,6 +67,7 @@ const ProgressBar = ({ percent }: { percent: number }) => {
       })
 
       tweenableRef.current = tweenable
+      previousPercentRef.current = percent
     }
 
     return () => {

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,22 +1,49 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { number } from 'prop-types'
 import { interpolate, tween } from 'shifty'
 
 import { Div, P } from '../Elements/index.js'
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion.js'
 
 const incompleteColor = '#ff9f00'
 const completeColor = '#00e500'
 
 const ProgressBar = ({ percent }: { percent: number }) => {
-  const [displayedProgress, setDisplayedProgress] = useState(0)
-  const [displayedColor, setDisplayedColor] = useState(incompleteColor)
-  const [currentTweenable, setCurrentTweenable]: [
-    any | undefined,
-    React.Dispatch<React.SetStateAction<any | undefined>>
-  ] = useState<any | undefined>()
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const [displayedProgress, setDisplayedProgress] = useState(
+    prefersReducedMotion ? percent : 0
+  )
+  const [displayedColor, setDisplayedColor] = useState(
+    prefersReducedMotion
+      ? interpolate(
+          { color: incompleteColor },
+          { color: completeColor },
+          percent / 100
+        ).color
+      : incompleteColor
+  )
+  const tweenableRef = useRef<any | null>(null)
 
   useEffect(() => {
-    if (!currentTweenable) {
+    const finalColor = interpolate(
+      { color: incompleteColor },
+      { color: completeColor },
+      percent / 100
+    ).color
+
+    if (prefersReducedMotion) {
+      setDisplayedProgress(percent)
+      setDisplayedColor(finalColor)
+
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+        tweenableRef.current = null
+      }
+
+      return
+    }
+
+    if (!tweenableRef.current) {
       const tweenable = tween({
         delay: 750,
         easing: 'easeInOutQuad',
@@ -37,15 +64,16 @@ const ProgressBar = ({ percent }: { percent: number }) => {
         },
       })
 
-      setCurrentTweenable(tweenable)
+      tweenableRef.current = tweenable
     }
 
     return () => {
-      if (currentTweenable) {
-        currentTweenable.cancel()
+      if (tweenableRef.current) {
+        tweenableRef.current.cancel()
+        tweenableRef.current = null
       }
     }
-  }, [currentTweenable, percent])
+  }, [percent, prefersReducedMotion])
 
   return (
     <Div className="ProgressBar" sx={{ margin: '0 auto' }}>

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Hook to detect if the user prefers reduced motion, either system-wide
+ * or via browser / Chrome DevTools emulation, updating dynamically on change.
+ */
+export const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return false
+    }
+
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return
+    }
+
+    const mediaQueryList = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches)
+    }
+
+    if (mediaQueryList.addEventListener) {
+      mediaQueryList.addEventListener('change', listener)
+    } else if ('addListener' in mediaQueryList) {
+      // Compatibility for legacy mediaQueryList implementations
+      ;((mediaQueryList as unknown) as {
+        addListener: (cb: (e: MediaQueryListEvent) => void) => void
+      }).addListener(listener)
+    }
+
+    return () => {
+      if (mediaQueryList.removeEventListener) {
+        mediaQueryList.removeEventListener('change', listener)
+      } else if ('removeListener' in mediaQueryList) {
+        ;((mediaQueryList as unknown) as {
+          removeListener: (cb: (e: MediaQueryListEvent) => void) => void
+        }).removeListener(listener)
+      }
+    }
+  }, [])
+
+  return prefersReducedMotion
+}


### PR DESCRIPTION
### What this PR does

- Introduces a reactive `usePrefersReducedMotion` hook that subscribes to `(prefers-reduced-motion: reduce)` media query change events (`window.matchMedia.addEventListener('change')`).
- Updates `AnimatedNumber`, `MoneyDisplay` (`AppBar`), and `ProgressBar` to respect reduced motion preferences, disabling Shifty tweening synchronously when reduced motion is preferred.
- Simplifies `AnimatedNumber` and `MoneyDisplay` component state by deriving output directly during reduced motion and using refs to manage prior animation states.
- Follows up on PR #725 (the initial attempt to prevent AnimatedNumber test flakiness) by addressing un-queried components like `AppBar` and enabling dynamic Chrome DevTools media feature toggling.

### How this change can be validated

1. Run `npx vitest run src/components/AnimatedNumber src/components/ProgressBar` (all unit tests pass).
2. Run `npm run e2e` (all 44 Playwright E2E tests pass synchronously without timer race conditions).
3. In Chrome DevTools (Rendering panel), toggle **Emulate CSS media feature prefers-reduced-motion: reduce** — numbers and progress bars in `AnimatedNumber`, `AppBar`, and `ProgressBar` will update synchronously without animation.

### Questions or concerns about this change

None.

### Additional information

Refers to PR #725.