### PR TITLE
fix: Prevent duplicate "Progress saved!" toasts from stacking on rapid End Day clicks

### DIFF
--- a/e2e/tests/notifications.test.ts
+++ b/e2e/tests/notifications.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 
+import { NOTIFICATION_DURATION } from '../../src/constants.js'
 import { openPage } from '../test-utils/open-page.js'
 
 // window.farmhand is a real, supported debug hook (documented in
@@ -68,11 +69,11 @@ test('clears a notification after its display duration elapses without crashing 
   await showNotification(page, 'Progress saved!')
   await expect(page.getByText('Progress saved!')).toBeVisible()
 
-  // NOTIFICATION_DURATION (src/constants.ts) is 6000ms outside of unit
-  // tests. The page's clock is virtualized (see openPage), so this jumps
-  // the notification's own auto-hide timer forward instead of a real
-  // multi-second wait.
-  await page.clock.fastForward(7000)
+  // The page's clock is virtualized (see openPage), so this jumps the
+  // notification's own auto-hide timer forward instead of a real
+  // multi-second wait. The extra 1000ms is just a margin past the
+  // notification's actual configured duration.
+  await page.clock.fastForward(NOTIFICATION_DURATION + 1000)
 
   await expect(page.getByText('Progress saved!')).toBeHidden()
   expect(pageErrors).toEqual([])

--- a/e2e/tests/notifications.test.ts
+++ b/e2e/tests/notifications.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test'
+
+import { openPage } from '../test-utils/open-page.js'
+
+// window.farmhand is a real, supported debug hook (documented in
+// README.md's "Debugging" section) but its ambient type declaration lives
+// in src/react-app-env.d.ts, which isn't part of this project's
+// TypeScript scope - so it's redeclared locally here with the shape this
+// file actually relies on.
+declare global {
+  interface Window {
+    farmhand?: {
+      setState: (partialState: Record<string, unknown>) => void
+    }
+  }
+}
+
+// These tests drive the notification system directly through the
+// window.farmhand.setState debug hook (documented in README.md's
+// "Debugging" section) rather than through repeated real End Day clicks.
+// That keeps them focused on NotificationSystem's own behavior and fast/
+// deterministic, without unrelated game-economy side effects (loan
+// interest, bankruptcy, price events, day-transition timing) that a real
+// end-of-day flow would introduce.
+const showNotification = (
+  page: import('@playwright/test').Page,
+  message: string,
+  severity: 'info' | 'success' | 'warning' | 'error' = 'info'
+) =>
+  page.evaluate(
+    ({ message, severity }) =>
+      window.farmhand?.setState({ latestNotification: { message, severity } }),
+    { message, severity }
+  )
+
+test('does not stack duplicate toasts when the same notification is triggered rapidly', async ({
+  page,
+}) => {
+  await openPage(page)
+
+  for (let i = 0; i < 5; i++) {
+    await showNotification(page, 'Progress saved!')
+  }
+
+  await expect(page.getByText('Progress saved!')).toHaveCount(1)
+})
+
+test('shows two different notifications concurrently rather than over-deduping', async ({
+  page,
+}) => {
+  await openPage(page)
+
+  await showNotification(page, 'Test notification A')
+  await showNotification(page, 'Test notification B')
+
+  await expect(page.getByText('Test notification A')).toBeVisible()
+  await expect(page.getByText('Test notification B')).toBeVisible()
+})
+
+test('clears a notification after its display duration elapses without crashing the page', async ({
+  page,
+}) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+
+  await openPage(page)
+
+  await showNotification(page, 'Progress saved!')
+  await expect(page.getByText('Progress saved!')).toBeVisible()
+
+  // NOTIFICATION_DURATION (src/constants.ts) is 6000ms outside of unit
+  // tests. The page's clock is virtualized (see openPage), so this jumps
+  // the notification's own auto-hide timer forward instead of a real
+  // multi-second wait.
+  await page.clock.fastForward(7000)
+
+  await expect(page.getByText('Progress saved!')).toBeHidden()
+  expect(pageErrors).toEqual([])
+
+  // Confirm the app is still responsive afterward, not wedged - a new
+  // notification should show up normally. A different message is used
+  // here since the just-closed one may still be mid-exit-transition in
+  // notistack's own internal state for a moment, which would otherwise
+  // make this re-trigger an unrelated, separately-timed dedupe race
+  // rather than a check of "is the app still responsive".
+  await showNotification(page, 'Another notification')
+  await expect(page.getByText('Another notification')).toBeVisible()
+  expect(pageErrors).toEqual([])
+})

--- a/e2e/tests/notifications.test.ts
+++ b/e2e/tests/notifications.test.ts
@@ -16,13 +16,14 @@ declare global {
   }
 }
 
-// These tests drive the notification system directly through the
-// window.farmhand.setState debug hook (documented in README.md's
-// "Debugging" section) rather than through repeated real End Day clicks.
-// That keeps them focused on NotificationSystem's own behavior and fast/
-// deterministic, without unrelated game-economy side effects (loan
-// interest, bankruptcy, price events, day-transition timing) that a real
-// end-of-day flow would introduce.
+// The "Test notification A/B" and display-duration tests below drive the
+// notification system directly through the window.farmhand.setState debug
+// hook (documented in README.md's "Debugging" section) rather than through
+// real game actions. That keeps them focused on NotificationSystem's own
+// generic dedup/lifecycle behavior and fast/deterministic, without
+// unrelated game-economy side effects (loan interest, bankruptcy, price
+// events, day-transition timing) that a real end-of-day flow would
+// introduce.
 const showNotification = (
   page: import('@playwright/test').Page,
   message: string,
@@ -34,13 +35,28 @@ const showNotification = (
     { message, severity }
   )
 
+const endDay = (page: import('@playwright/test').Page) =>
+  page.getByRole('button', { name: 'End the day to save your' }).click()
+
 test('does not stack duplicate toasts when the same notification is triggered rapidly', async ({
   page,
 }) => {
   await openPage(page)
 
+  // Unlike the other tests in this file, this one drives the real
+  // showNotification reducer (src/game-logic/reducers/showNotification.ts)
+  // through repeated "End the day" clicks instead of the debug hook. That
+  // reducer is the actual root cause this fix addresses: it always builds
+  // a brand new `latestNotification` object on every call, so this test
+  // needs the real object-identity churn a live day-advancement cycle
+  // produces (handleClickEndDayButton -> incrementDay -> the reducer) -
+  // injecting an equivalent-looking object via setState wouldn't exercise
+  // that. Clicking End Day back-to-back without waiting reproduces the
+  // rapid-clicking bug report, where each cycle's "Progress saved!" call
+  // could re-fire while an identical toast from a prior cycle was still
+  // visible.
   for (let i = 0; i < 5; i++) {
-    await showNotification(page, 'Progress saved!')
+    await endDay(page)
   }
 
   await expect(page.getByText('Progress saved!')).toHaveCount(1)

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -21,6 +21,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "../src/farmhand.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/src/components/NotificationSystem/NotificationSystem.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.test.tsx
@@ -19,6 +19,15 @@ test('renders', () => {
 })
 
 test('calls enqueueSnackbar with a content-derived key when latestNotification is provided', () => {
+  // Regression test: notistack's closeSnackbar(key) invokes the matching
+  // snack's own `onClose` before removing it from state. An onClose
+  // handler here that calls closeSnackbar with its own key recurses
+  // infinitely the moment the snack naturally auto-hides (stack overflow
+  // after the first "Progress saved!" toast expires). No onClose handler
+  // should be passed at all - notistack manages the snack's lifecycle
+  // (auto-hide, then removal) on its own once autoHideDuration/key are set.
+  // The exact-match assertion below guards against onClose (or any other
+  // unexpected option) being reintroduced.
   const enqueueSnackbar = vitest.fn()
   const latestNotification: farmhand.notification = {
     message: 'Test notification',
@@ -38,31 +47,6 @@ test('calls enqueueSnackbar with a content-derived key when latestNotification i
     autoHideDuration: 1, // NOTIFICATION_DURATION in test mode
     preventDuplicate: true,
   })
-})
-
-test("does not pass an onClose handler that calls closeSnackbar with this notification's own key", () => {
-  // Regression test: notistack's closeSnackbar(key) invokes the matching
-  // snack's own `onClose` before removing it from state. An onClose
-  // handler here that calls closeSnackbar with its own key recurses
-  // infinitely the moment the snack naturally auto-hides (stack overflow
-  // after the first "Progress saved!" toast expires). No onClose handler
-  // should be passed at all - notistack manages the snack's lifecycle
-  // (auto-hide, then removal) on its own once autoHideDuration/key are set.
-  const enqueueSnackbar = vitest.fn()
-  const latestNotification: farmhand.notification = {
-    message: 'Test notification',
-    severity: 'info',
-  }
-
-  renderWithSnackbar(
-    <NotificationSystem
-      {...defaultProps}
-      enqueueSnackbar={enqueueSnackbar}
-      latestNotification={latestNotification}
-    />
-  )
-
-  expect(enqueueSnackbar.mock.calls[0][1]).not.toHaveProperty('onClose')
 })
 
 test('does not call enqueueSnackbar when latestNotification is null', () => {

--- a/src/components/NotificationSystem/NotificationSystem.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 
-import { NotificationSystem } from './NotificationSystem.js'
+import { NotificationSystem, getNotificationKey } from './NotificationSystem.js'
 
 const defaultProps = {
   enqueueSnackbar: vitest.fn(),
@@ -84,7 +84,7 @@ test('re-enqueues notification when latestNotification changes to a different me
 
   expect(enqueueSnackbar).toHaveBeenCalledTimes(1)
   expect(enqueueSnackbar).toHaveBeenCalledWith(initialNotification, {
-    key: 'info:First notification',
+    key: getNotificationKey(initialNotification),
     autoHideDuration: 1,
     preventDuplicate: true,
   })
@@ -102,7 +102,7 @@ test('re-enqueues notification when latestNotification changes to a different me
 
   expect(enqueueSnackbar).toHaveBeenCalledTimes(2)
   expect(enqueueSnackbar).toHaveBeenLastCalledWith(newNotification, {
-    key: 'success:Second notification',
+    key: getNotificationKey(newNotification),
     autoHideDuration: 1,
     preventDuplicate: true,
   })

--- a/src/components/NotificationSystem/NotificationSystem.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.test.tsx
@@ -5,7 +5,6 @@ import { SnackbarProvider } from 'notistack'
 import { NotificationSystem } from './NotificationSystem.js'
 
 const defaultProps = {
-  closeSnackbar: vitest.fn(),
   enqueueSnackbar: vitest.fn(),
   latestNotification: null,
 }
@@ -19,7 +18,7 @@ test('renders', () => {
   // NotificationSystem renders null, so we just verify it doesn't crash
 })
 
-test('calls enqueueSnackbar when latestNotification is provided', () => {
+test('calls enqueueSnackbar with a content-derived key when latestNotification is provided', () => {
   const enqueueSnackbar = vitest.fn()
   const latestNotification: farmhand.notification = {
     message: 'Test notification',
@@ -35,10 +34,35 @@ test('calls enqueueSnackbar when latestNotification is provided', () => {
   )
 
   expect(enqueueSnackbar).toHaveBeenCalledWith(latestNotification, {
+    key: 'info:Test notification',
     autoHideDuration: 1, // NOTIFICATION_DURATION in test mode
-    onClose: expect.any(Function),
     preventDuplicate: true,
   })
+})
+
+test("does not pass an onClose handler that calls closeSnackbar with this notification's own key", () => {
+  // Regression test: notistack's closeSnackbar(key) invokes the matching
+  // snack's own `onClose` before removing it from state. An onClose
+  // handler here that calls closeSnackbar with its own key recurses
+  // infinitely the moment the snack naturally auto-hides (stack overflow
+  // after the first "Progress saved!" toast expires). No onClose handler
+  // should be passed at all - notistack manages the snack's lifecycle
+  // (auto-hide, then removal) on its own once autoHideDuration/key are set.
+  const enqueueSnackbar = vitest.fn()
+  const latestNotification: farmhand.notification = {
+    message: 'Test notification',
+    severity: 'info',
+  }
+
+  renderWithSnackbar(
+    <NotificationSystem
+      {...defaultProps}
+      enqueueSnackbar={enqueueSnackbar}
+      latestNotification={latestNotification}
+    />
+  )
+
+  expect(enqueueSnackbar.mock.calls[0][1]).not.toHaveProperty('onClose')
 })
 
 test('does not call enqueueSnackbar when latestNotification is null', () => {
@@ -55,32 +79,7 @@ test('does not call enqueueSnackbar when latestNotification is null', () => {
   expect(enqueueSnackbar).not.toHaveBeenCalled()
 })
 
-test('calls closeSnackbar when onClose is triggered', () => {
-  const closeSnackbar = vitest.fn()
-  const enqueueSnackbar = vitest.fn()
-  const latestNotification: farmhand.notification = {
-    message: 'Test notification',
-    severity: 'info',
-  }
-
-  renderWithSnackbar(
-    <NotificationSystem
-      {...defaultProps}
-      closeSnackbar={closeSnackbar}
-      enqueueSnackbar={enqueueSnackbar}
-      latestNotification={latestNotification}
-    />
-  )
-
-  // Get the onClose function from the enqueueSnackbar call
-  const onCloseCallback = enqueueSnackbar.mock.calls[0][1].onClose
-
-  onCloseCallback()
-
-  expect(closeSnackbar).toHaveBeenCalledTimes(1)
-})
-
-test('re-enqueues notification when latestNotification changes', () => {
+test('re-enqueues notification when latestNotification changes to a different message', () => {
   const enqueueSnackbar = vitest.fn()
   const initialNotification: farmhand.notification = {
     message: 'First notification',
@@ -101,8 +100,8 @@ test('re-enqueues notification when latestNotification changes', () => {
 
   expect(enqueueSnackbar).toHaveBeenCalledTimes(1)
   expect(enqueueSnackbar).toHaveBeenCalledWith(initialNotification, {
+    key: 'info:First notification',
     autoHideDuration: 1,
-    onClose: expect.any(Function),
     preventDuplicate: true,
   })
 
@@ -119,8 +118,46 @@ test('re-enqueues notification when latestNotification changes', () => {
 
   expect(enqueueSnackbar).toHaveBeenCalledTimes(2)
   expect(enqueueSnackbar).toHaveBeenLastCalledWith(newNotification, {
+    key: 'success:Second notification',
     autoHideDuration: 1,
-    onClose: expect.any(Function),
     preventDuplicate: true,
   })
+})
+
+test('uses the same key for repeated notifications with identical message and severity, letting notistack dedupe them', () => {
+  const enqueueSnackbar = vitest.fn()
+  const firstNotification: farmhand.notification = {
+    message: 'Progress saved!',
+    severity: 'info',
+  }
+  const secondNotification: farmhand.notification = {
+    message: 'Progress saved!',
+    severity: 'info',
+  }
+
+  const { rerender } = renderWithSnackbar(
+    <NotificationSystem
+      {...defaultProps}
+      enqueueSnackbar={enqueueSnackbar}
+      latestNotification={firstNotification}
+    />
+  )
+
+  rerender(
+    <SnackbarProvider>
+      <NotificationSystem
+        {...defaultProps}
+        enqueueSnackbar={enqueueSnackbar}
+        latestNotification={secondNotification}
+      />
+    </SnackbarProvider>
+  )
+
+  expect(enqueueSnackbar).toHaveBeenCalledTimes(2)
+
+  // Identical key is what allows notistack's own preventDuplicate to skip
+  // showing a second toast while the first is still visible or queued.
+  expect(enqueueSnackbar.mock.calls[0][1].key).toBe(
+    enqueueSnackbar.mock.calls[1][1].key
+  )
 })

--- a/src/components/NotificationSystem/NotificationSystem.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.tsx
@@ -7,6 +7,11 @@ import { withSnackbar } from 'notistack'
 import { NOTIFICATION_DURATION } from '../../constants.js'
 import FarmhandContext from '../Farmhand/Farmhand.context.js'
 
+const getNotificationKey = ({
+  message,
+  severity,
+}: farmhand.notification): string => `${severity}:${message}`
+
 export const snackbarProviderContentCallback = (
   key: string | number,
   {
@@ -31,23 +36,29 @@ export const snackbarProviderContentCallback = (
 )
 
 export const NotificationSystem = ({
-  closeSnackbar,
   enqueueSnackbar,
   latestNotification,
 }: {
-  closeSnackbar: () => void
   enqueueSnackbar: (notification: farmhand.notification, options: any) => void
   latestNotification: farmhand.notification | null
 }) => {
   useEffect(() => {
-    if (latestNotification) {
-      enqueueSnackbar(latestNotification, {
-        autoHideDuration: NOTIFICATION_DURATION,
-        onClose: () => closeSnackbar(),
-        preventDuplicate: true,
-      })
+    if (!latestNotification) {
+      return
     }
-  }, [closeSnackbar, enqueueSnackbar, latestNotification])
+
+    // A stable, content-derived key (rather than a fresh object identity
+    // every call) is what lets preventDuplicate below actually do
+    // something - it skips enqueueing when a snack with this key is
+    // already shown or queued, instead of stacking a duplicate. notistack
+    // handles the rest of the lifecycle itself (auto-hide, then removal)
+    // once autoHideDuration and a key are set - no onClose needed here.
+    enqueueSnackbar(latestNotification, {
+      key: getNotificationKey(latestNotification),
+      autoHideDuration: NOTIFICATION_DURATION,
+      preventDuplicate: true,
+    })
+  }, [enqueueSnackbar, latestNotification])
 
   return null
 }

--- a/src/components/NotificationSystem/NotificationSystem.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.tsx
@@ -7,7 +7,7 @@ import { withSnackbar } from 'notistack'
 import { NOTIFICATION_DURATION } from '../../constants.js'
 import FarmhandContext from '../Farmhand/Farmhand.context.js'
 
-const getNotificationKey = ({
+export const getNotificationKey = ({
   message,
   severity,
 }: farmhand.notification): string => `${severity}:${message}`


### PR DESCRIPTION
### What this PR does

Ending the day shows a "Progress saved!" toast that fades after a few seconds. Ending the day rapidly many times in a row caused these toasts to queue up and keep reappearing for many seconds after the player had stopped.

Root cause: `NotificationSystem` relied on notistack's `preventDuplicate` option, but it compared the message value passed to `enqueueSnackbar` by reference - and `showNotification` constructs a fresh object on every call, so identical consecutive notifications (e.g. "Progress saved!" fired on every end-of-day cycle) never actually deduped against each other.

Fix: give each notification a stable, content-derived key (`severity:message`) so `preventDuplicate` can actually match it against what's currently shown or queued. This generalizes to any notification message, not just "Progress saved!".

An earlier version of this fix used `persist: true` with a self-managed dismiss timer to also *extend* a visible toast's duration on a duplicate trigger. That approach caused a real regression - it filled notistack's 4-slot concurrent limit with persisted toasts from unrelated messages (loan interest, price events, etc. all fire from a single day-end), starving "Progress saved!" from reappearing until other toasts cooled down. It was reverted in favor of the simpler, native `preventDuplicate` + stable key approach, which lets notistack's own auto-hide behavior work as it always did for every other notification type.

That same earlier version also had a genuine infinite-recursion bug: its `onClose: () => closeSnackbar(key)` handler caused notistack's `closeSnackbar(key)` to invoke its own snack's `onClose` before removing it, recursing until a stack overflow the moment any toast's timer naturally elapsed. This is fixed by not passing an `onClose` handler at all - notistack fully manages a snack's lifecycle (auto-hide, then removal) once `autoHideDuration` and a `key` are set.

### How this change can be validated

- `npx vitest run src/components/NotificationSystem/NotificationSystem.test.tsx` - unit tests covering the dedup key logic and a regression test asserting no `onClose` handler is passed (guards against the recursion bug reappearing).
- `npx playwright test e2e/tests/notifications.test.ts` - new e2e coverage: duplicate notifications don't stack, distinct notifications aren't over-deduped, and a notification clears after its display duration elapses without crashing the page (this test was verified to actually catch the recursion bug by temporarily reintroducing it).
- Manual: run `npm start`, end the day rapidly many times in a row - only one "Progress saved!" toast is ever visible at a time, and it clears out normally rather than lingering.
- Full regression pass: `npx vitest run` (full unit suite), `npm run lint`, `npm run check:types`, and a broad sweep of the e2e suite (all passing files unrelated to this change still pass; the only failures are a pre-existing, unrelated "Play online" checkbox/tracker-connectivity issue in this environment, confirmed to fail identically without this change).

### Questions or concerns about this change

None currently.

### Additional information

comparison videos.

#### before

notice how the "progress saved" notification repeats frequently (often while a previous one is still in view) and the animation pacing is quite distracting, almost impossible to read at times.

https://github.com/user-attachments/assets/c775fb15-4a8c-4dd5-b429-5d0daeeeeece

#### after

the "progress saved" notification no longer repeats itself while still in view, and the flow is much less chaotic feeling

https://github.com/user-attachments/assets/fb350f0d-5a01-4e6d-9532-dcd42db78b4d



🤖 Generated with [Claude Code](https://claude.com/claude-code)