### PR TITLE
Add tappable navigation stepper icons

### DIFF
--- a/e2e/fixtures/bottom-navigation-all-views.json
+++ b/e2e/fixtures/bottom-navigation-all-views.json
@@ -1,0 +1,263 @@
+{
+  "allowCustomPeerCowNames": false,
+  "cellarInventory": [],
+  "completedAchievements": {
+    "plant-crop": true,
+    "water-crop": true
+  },
+  "cowBreedingPen": {
+    "cowId1": null,
+    "cowId2": null,
+    "daysUntilBirth": -1
+  },
+  "cowColorsPurchased": {},
+  "cowForSale": {
+    "baseWeight": 1601,
+    "color": "GREEN",
+    "colorsInBloodline": {
+      "GREEN": true
+    },
+    "daysOld": 1,
+    "daysSinceMilking": 0,
+    "daysSinceProducingFertilizer": 0,
+    "gender": "FEMALE",
+    "happiness": 0,
+    "happinessBoostsToday": 0,
+    "id": "b93a9c59-f73f-4986-b44e-ffb422bcd4c2",
+    "isBred": false,
+    "isUsingHuggingMachine": false,
+    "name": "Guava",
+    "ownerId": "",
+    "originalOwnerId": "",
+    "timesTraded": 0,
+    "weightMultiplier": 1
+  },
+  "cowInventory": [],
+  "cowsSold": {},
+  "cowsTraded": 0,
+  "cropsHarvested": {},
+  "dayCount": 6,
+  "experience": 20000,
+  "farmName": "Unnamed",
+  "field": [
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null],
+    [null, null, null, null, null, null]
+  ],
+  "forest": [
+    [
+      {
+        "itemId": "apple",
+        "daysOld": 25,
+        "daysSinceLastHarvest": 6
+      },
+      null,
+      null,
+      null
+    ],
+    [null, null, null, null]
+  ],
+  "historicalDailyLosses": [0, 0, 0, 0, -143.7],
+  "historicalDailyRevenue": [0, 0, 0, 0, 0],
+  "historicalValueAdjustments": [
+    {
+      "asparagus": 1.254561372610583,
+      "asparagus-seed": 0.8845336867381606,
+      "bronze-ore": 0.8820993693168143,
+      "carrot": 0.5151057244898383,
+      "carrot-seed": 0.8007552689761459,
+      "corn": 1.0577673788621866,
+      "corn-seed": 0.8492871019468962,
+      "garlic": 0.6502095798811709,
+      "garlic-seed": 0.6776417342031218,
+      "gold-ore": 1.1584127926987628,
+      "grape-cabernet-sauvignon": 1.0811524144134221,
+      "grape-chardonnay": 0.9566018874265536,
+      "grape-nebbiolo": 1.038616184743502,
+      "grape-sauvignon-blanc": 0.8420890144753135,
+      "grape-seed": 0.8711888712889699,
+      "grape-tempranillo": 0.8417473069445603,
+      "iron-ore": 0.8565852787467081,
+      "jalapeno": 0.8938267219202933,
+      "jalapeno-seed": 1.2806755799922187,
+      "olive": 0.894838025775234,
+      "olive-seed": 0.5819676400592492,
+      "onion": 1.388841964280044,
+      "onion-seed": 0.5548354705668044,
+      "pea": 1.4270874498629684,
+      "pea-seed": 1.3014170459989431,
+      "potato": 1.198063016021274,
+      "potato-seed": 1.1227007201477113,
+      "pumpkin": 1.256866505382895,
+      "pumpkin-seed": 0.9762702998744324,
+      "salt-rock": 1.318355654482557,
+      "silver-ore": 0.8675044285411415,
+      "soybean": 0.5974111121058051,
+      "soybean-seed": 1.2994025472815358,
+      "spinach": 1.3888914334365705,
+      "spinach-seed": 0.6511206276246511,
+      "strawberry": 0.6648639912973919,
+      "strawberry-seed": 1.2151617642366415,
+      "sunflower": 0.6441195107880303,
+      "sunflower-seed": 1.088430125646544,
+      "sweet-potato": 0.6854892825193449,
+      "sweet-potato-seed": 0.993009857740943,
+      "tomato": 1.287432200495485,
+      "tomato-seed": 1.1243978023384449,
+      "watermelon": 1.0980278225758555,
+      "watermelon-seed": 1.1400979011983594,
+      "wheat": 0.8063919814881977,
+      "wheat-seed": 0.9399986471778438
+    }
+  ],
+  "hoveredPlotRangeSize": 7,
+  "id": "d7a1db57-f021-4ce5-b632-ad382789f4f1",
+  "inventory": [
+    {
+      "id": "apple-sapling",
+      "quantity": 1
+    }
+  ],
+  "inventoryLimit": 100,
+  "isCombineEnabled": false,
+  "itemsSold": {},
+  "cellarItemsSold": {},
+  "learnedRecipes": {},
+  "loanBalance": 552.03,
+  "loansTakenOut": 1,
+  "money": 250106.3,
+  "newDayNotifications": [],
+  "notificationLog": [
+    {
+      "day": 6,
+      "notifications": {
+        "error": [],
+        "info": ["It rained in the night!"],
+        "success": [],
+        "warning": ["Your loan balance has grown to $552.03."]
+      }
+    },
+    {
+      "day": 5,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $541.21."]
+      }
+    },
+    {
+      "day": 4,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $530.60."]
+      }
+    },
+    {
+      "day": 3,
+      "notifications": {
+        "error": [],
+        "info": [],
+        "success": [],
+        "warning": ["Your loan balance has grown to $520.20."]
+      }
+    },
+    {
+      "day": 2,
+      "notifications": {
+        "error": [],
+        "info": ["It rained in the night!"],
+        "success": [],
+        "warning": ["Your loan balance has grown to $510.00."]
+      }
+    }
+  ],
+  "priceCrashes": {},
+  "priceSurges": {},
+  "profitabilityStreak": 0,
+  "purchasedCombine": 0,
+  "purchasedComposter": 0,
+  "purchasedCowPen": 1,
+  "purchasedCellar": 1,
+  "purchasedField": 0,
+  "purchasedForest": 1,
+  "purchasedSmelter": 0,
+  "record7dayProfitAverage": 0,
+  "recordProfitabilityStreak": 0,
+  "recordSingleDayProfit": 0,
+  "revenue": 0,
+  "showHomeScreen": true,
+  "showNotifications": true,
+  "todaysLosses": -250000,
+  "todaysPurchases": {},
+  "todaysRevenue": 0,
+  "todaysStartingInventory": {
+    "apple-sapling": 1
+  },
+  "toolLevels": {
+    "HOE": "DEFAULT",
+    "SCYTHE": "DEFAULT",
+    "SHOVEL": "UNAVAILABLE",
+    "WATERING_CAN": "DEFAULT"
+  },
+  "useAlternateEndDayButtonPosition": false,
+  "valueAdjustments": {
+    "asparagus": 0.7710329471429687,
+    "asparagus-seed": 0.6047945736371781,
+    "bronze-ore": 0.6523314669735881,
+    "carrot": 1.148946183956264,
+    "carrot-seed": 1.150865016558905,
+    "corn": 1.2916975621660312,
+    "corn-seed": 0.8194585108692283,
+    "garlic": 0.5890389828828759,
+    "garlic-seed": 1.0461378148234952,
+    "gold-ore": 1.1866263486101722,
+    "grape-cabernet-sauvignon": 0.9051176034381517,
+    "grape-chardonnay": 1.0449007660226393,
+    "grape-nebbiolo": 0.8715697232156476,
+    "grape-sauvignon-blanc": 0.6310523029050967,
+    "grape-seed": 0.9253596435820454,
+    "grape-tempranillo": 0.6756200431464858,
+    "iron-ore": 1.1565063783102898,
+    "jalapeno": 0.7091052379238315,
+    "jalapeno-seed": 1.132727916247675,
+    "olive": 1.311369163510936,
+    "olive-seed": 0.9192617853490546,
+    "onion": 0.7145057442803753,
+    "onion-seed": 0.6384400392400458,
+    "pea": 1.3438668707129882,
+    "pea-seed": 0.947899535167928,
+    "potato": 0.9114908865313538,
+    "potato-seed": 1.1068364751179312,
+    "pumpkin": 0.8377832985809028,
+    "pumpkin-seed": 1.4440859731959748,
+    "salt-rock": 1.3505767817681624,
+    "silver-ore": 0.9160677427267769,
+    "soybean": 0.7877249923876428,
+    "soybean-seed": 1.062021364573846,
+    "spinach": 1.2699413150967442,
+    "spinach-seed": 0.8490869162420625,
+    "strawberry": 1.41618172037454,
+    "strawberry-seed": 0.8777549220278436,
+    "sunflower": 0.5903344778618149,
+    "sunflower-seed": 0.974090939308244,
+    "sweet-potato": 0.5906894671175695,
+    "sweet-potato-seed": 0.6012857315253939,
+    "tomato": 1.1936926336320215,
+    "tomato-seed": 0.7109397222579946,
+    "watermelon": 0.666622692558885,
+    "watermelon-seed": 1.0104982645951823,
+    "wheat": 0.8632829757532291,
+    "wheat-seed": 0.7821587302079209
+  },
+  "version": "1.18.26"
+}

--- a/e2e/tests/bottom-navigation.test.ts
+++ b/e2e/tests/bottom-navigation.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+import { loadFixture } from '../test-utils/load-fixture.js'
+
+test('clicking a view icon navigates directly to that view', async ({
+  page,
+}) => {
+  await loadFixture(page, 'bottom-navigation-all-views')
+
+  await page.getByRole('button', { name: 'Go to Workshop' }).click()
+
+  await expect(page.locator('.Workshop')).toBeVisible()
+})
+
+test('the active view button is marked current, and only that one', async ({
+  page,
+}) => {
+  await loadFixture(page, 'bottom-navigation-all-views')
+
+  const homeButton = page.getByRole('button', { name: 'Go to Home' })
+  const workshopButton = page.getByRole('button', { name: 'Go to Workshop' })
+
+  await expect(homeButton).toHaveAttribute('aria-current', 'true')
+  await expect(workshopButton).not.toHaveAttribute('aria-current')
+
+  await workshopButton.click()
+
+  await expect(workshopButton).toHaveAttribute('aria-current', 'true')
+  await expect(homeButton).not.toHaveAttribute('aria-current')
+})
+
+test('all view buttons stay visible at a narrow viewport with every view unlocked', async ({
+  page,
+}) => {
+  await loadFixture(page, 'bottom-navigation-all-views')
+  await page.setViewportSize({ width: 320, height: 640 })
+
+  for (const label of [
+    'Go to Home',
+    'Go to Shop',
+    'Go to Field',
+    'Go to Forest',
+    'Go to Cows',
+    'Go to Workshop',
+    'Go to Cellar',
+  ]) {
+    await expect(page.getByRole('button', { name: label })).toBeVisible()
+  }
+})
+
+test('the view button row does not overlap the Field toolbelt in portrait orientation', async ({
+  page,
+}) => {
+  await loadFixture(page, 'bottom-navigation-all-views')
+  await page.setViewportSize({ width: 375, height: 667 })
+
+  await page.getByRole('button', { name: 'Go to Field' }).click()
+
+  const toolbeltBox = await page.locator('.Toolbelt').boundingBox()
+  const viewButtonBox = await page
+    .getByRole('button', { name: 'Go to Field' })
+    .boundingBox()
+
+  if (!toolbeltBox || !viewButtonBox) {
+    throw new Error('Expected both the toolbelt and view buttons to render.')
+  }
+
+  expect(toolbeltBox.y + toolbeltBox.height).toBeLessThanOrEqual(
+    viewButtonBox.y
+  )
+})

--- a/src/components/BottomControls/BottomControls.test.tsx
+++ b/src/components/BottomControls/BottomControls.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { stageFocusType } from '../../enums.js'
+
+import { BottomControls } from './BottomControls.js'
+
+describe('<BottomControls />', () => {
+  const { COW_PEN, FIELD, FOREST, SHOP, WORKSHOP } = stageFocusType
+
+  const noop = () => {}
+
+  const renderBottomControls = (
+    props: Partial<Parameters<typeof BottomControls>[0]> = {}
+  ) =>
+    render(
+      <BottomControls
+        {...{
+          focusNextView: noop,
+          focusPreviousView: noop,
+          handleMenuToggle: noop,
+          handleViewChangeButtonClick: noop,
+          isMenuOpen: false,
+          stageFocus: SHOP,
+          viewList: [SHOP, FIELD, WORKSHOP],
+          ...props,
+        }}
+      />
+    )
+
+  test('renders a view button for each entry in viewList, in order', () => {
+    renderBottomControls({ viewList: [SHOP, FIELD, WORKSHOP] })
+
+    const viewButtons = screen
+      .getAllByRole('button')
+      .filter(button => button.getAttribute('aria-label')?.startsWith('Go to'))
+
+    expect(
+      viewButtons.map(button => button.getAttribute('aria-label'))
+    ).toEqual(['Go to Shop', 'Go to Field', 'Go to Workshop'])
+  })
+
+  test('does not render a button for a view missing from viewList', () => {
+    renderBottomControls({ viewList: [SHOP, FIELD] })
+
+    expect(
+      screen.queryByRole('button', { name: 'Go to Forest' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('clicking a view button calls handleViewChangeButtonClick with that view', async () => {
+    const handleViewChangeButtonClick = vitest.fn()
+
+    renderBottomControls({
+      handleViewChangeButtonClick,
+      viewList: [SHOP, FIELD, WORKSHOP],
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Go to Workshop' })
+    )
+
+    expect(handleViewChangeButtonClick).toHaveBeenCalledWith(WORKSHOP)
+  })
+
+  test('marks the button matching stageFocus as active, and no others', () => {
+    renderBottomControls({
+      stageFocus: FIELD,
+      viewList: [SHOP, FIELD, WORKSHOP],
+    })
+
+    const activeButton = screen.getByRole('button', { name: 'Go to Field' })
+    const inactiveButton = screen.getByRole('button', { name: 'Go to Shop' })
+
+    expect(activeButton).toHaveAttribute('aria-current', 'true')
+    expect(activeButton.classList.contains('selected')).toEqual(true)
+
+    expect(inactiveButton).not.toHaveAttribute('aria-current')
+    expect(inactiveButton.classList.contains('selected')).toEqual(false)
+  })
+
+  test('the previous/menu/next buttons still call their handlers', async () => {
+    const focusPreviousView = vitest.fn()
+    const focusNextView = vitest.fn()
+    const handleMenuToggle = vitest.fn()
+
+    renderBottomControls({
+      focusPreviousView,
+      focusNextView,
+      handleMenuToggle,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Previous view' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Open drawer' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Next view' }))
+
+    expect(focusPreviousView).toHaveBeenCalled()
+    expect(handleMenuToggle).toHaveBeenCalled()
+    expect(focusNextView).toHaveBeenCalled()
+  })
+})

--- a/src/components/BottomControls/BottomControls.test.tsx
+++ b/src/components/BottomControls/BottomControls.test.tsx
@@ -99,4 +99,14 @@ describe('<BottomControls />', () => {
     expect(handleMenuToggle).toHaveBeenCalled()
     expect(focusNextView).toHaveBeenCalled()
   })
+
+  test('shows a tooltip naming the view when a button is hovered', async () => {
+    renderBottomControls({ viewList: [SHOP, FIELD, WORKSHOP] })
+
+    await userEvent.hover(screen.getByRole('button', { name: 'Go to Field' }))
+
+    expect(
+      await screen.findByRole('tooltip', { name: 'Field' })
+    ).toBeInTheDocument()
+  })
 })

--- a/src/components/BottomControls/BottomControls.tsx
+++ b/src/components/BottomControls/BottomControls.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import classNames from 'classnames'
+import { array, bool, func, string } from 'prop-types'
+
+import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft.js'
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight.js'
+import MenuIcon from '@mui/icons-material/Menu.js'
+import Fab from '@mui/material/Fab/index.js'
+import { Theme } from '@mui/material/styles/index.js'
+
+import { STAGE_ICON_MAP, STAGE_TITLE_MAP } from '../../constants.js'
+import { breakpoints, layout } from '../../styles/tokens.js'
+import { Div } from '../Elements/index.js'
+import FarmhandContext from '../Farmhand/Farmhand.context.js'
+
+export const BottomControls = ({
+  focusNextView,
+  focusPreviousView,
+  handleMenuToggle,
+  handleViewChangeButtonClick,
+  isMenuOpen,
+  stageFocus,
+  viewList,
+}: {
+  focusNextView: () => void
+  focusPreviousView: () => void
+  handleMenuToggle: () => void
+  handleViewChangeButtonClick: (view: farmhand.stageFocusType) => void
+  isMenuOpen: boolean
+  stageFocus: farmhand.stageFocusType
+  viewList: farmhand.stageFocusType[]
+}) => (
+  <Div
+    className="bottom-controls"
+    sx={(t: Theme) => ({
+      alignItems: 'center',
+      bottom: '1em',
+      display: 'flex',
+      flexFlow: 'column',
+      justifyContent: 'center',
+      left: '50%',
+      position: 'fixed',
+      transition: t.transitions.create('left', {
+        duration: t.transitions.duration.enteringScreen,
+        easing: t.transitions.easing.easeOut,
+      }),
+      width: 0,
+      zIndex: 20,
+      [`@media (max-width: ${breakpoints.mediumPhone}px)`]: {
+        bottom: '0.5em',
+      },
+      '& .view-buttons': {
+        display: 'flex',
+        flexFlow: 'row',
+        '& button': {
+          backgroundColor: t.palette.grey[400],
+          margin: '0 0.25em',
+          position: 'relative',
+          '& .view-icon': {
+            fontSize: '1.3em',
+          },
+          '&:hover': {
+            backgroundColor: t.palette.grey[500],
+          },
+          [`@media (max-width: ${breakpoints.mediumPhone}px)`]: {
+            margin: '0 0.15em',
+          },
+          '@media (max-width: 320px)': {
+            margin: '0 0.1em',
+          },
+          '&.selected': {
+            backgroundColor: t.palette.common.white,
+            border: `2px solid ${t.palette.primary.main}`,
+            '&:hover': {
+              backgroundColor: t.palette.grey[100],
+            },
+          },
+        },
+      },
+      '& .fab-buttons': {
+        display: 'flex',
+        flexFlow: 'row',
+        opacity: 0.85,
+        '& button': {
+          margin: '0.5em',
+          position: 'relative',
+          [`@media (max-width: ${breakpoints.mediumPhone}px)`]: {
+            margin: '0.25em 0.5em',
+          },
+          '@media (max-width: 320px)': {
+            margin: '0.25em 0.1em',
+          },
+        },
+      },
+      '& .menu-button': {
+        transition: t.transitions.create('transform', {
+          duration: t.transitions.duration.shorter,
+        }),
+        transform: isMenuOpen ? 'rotate(-90deg)' : 'rotate(0deg)',
+      },
+      ...(isMenuOpen && {
+        '@media (orientation: landscape)': {
+          left: `calc(50vw + ${layout.sidebarWidth} / 2)`,
+        },
+      }),
+    })}
+  >
+    <div className="view-buttons">
+      {viewList.map(view => {
+        const isActive = view === stageFocus
+        const viewKey = view as keyof typeof STAGE_TITLE_MAP
+
+        return (
+          <Fab
+            key={view}
+            aria-label={`Go to ${STAGE_TITLE_MAP[viewKey]}`}
+            aria-current={isActive ? 'true' : undefined}
+            className={classNames('view-button', { selected: isActive })}
+            size="small"
+            onClick={() => handleViewChangeButtonClick(view)}
+          >
+            <span className="view-icon" role="img" aria-hidden="true">
+              {STAGE_ICON_MAP[viewKey]}
+            </span>
+          </Fab>
+        )
+      })}
+    </div>
+    <div className="fab-buttons buttons">
+      <Fab
+        aria-label="Previous view"
+        color="primary"
+        onClick={focusPreviousView}
+      >
+        <KeyboardArrowLeft />
+      </Fab>
+      <Fab
+        className={classNames('menu-button', { 'is-open': isMenuOpen })}
+        color="primary"
+        aria-label="Open drawer"
+        onClick={() => handleMenuToggle()}
+      >
+        <MenuIcon />
+      </Fab>
+      <Fab aria-label="Next view" color="primary" onClick={focusNextView}>
+        <KeyboardArrowRight />
+      </Fab>
+    </div>
+  </Div>
+)
+
+BottomControls.propTypes = {
+  focusNextView: func.isRequired,
+  focusPreviousView: func.isRequired,
+  handleMenuToggle: func.isRequired,
+  handleViewChangeButtonClick: func.isRequired,
+  isMenuOpen: bool.isRequired,
+  stageFocus: string.isRequired,
+  viewList: array.isRequired,
+}
+
+export default function Consumer(
+  props: Partial<Parameters<typeof BottomControls>[0]>
+) {
+  return (
+    <FarmhandContext.Consumer>
+      {({ gameState, handlers }) => (
+        <BottomControls
+          {...({
+            ...gameState,
+            ...handlers,
+            ...props,
+          } as Parameters<typeof BottomControls>[0])}
+        />
+      )}
+    </FarmhandContext.Consumer>
+  )
+}

--- a/src/components/BottomControls/BottomControls.tsx
+++ b/src/components/BottomControls/BottomControls.tsx
@@ -6,6 +6,7 @@ import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft.js'
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight.js'
 import MenuIcon from '@mui/icons-material/Menu.js'
 import Fab from '@mui/material/Fab/index.js'
+import Tooltip from '@mui/material/Tooltip/index.js'
 import { Theme } from '@mui/material/styles/index.js'
 
 import { STAGE_ICON_MAP, STAGE_TITLE_MAP } from '../../constants.js'
@@ -111,18 +112,24 @@ export const BottomControls = ({
         const viewKey = view as keyof typeof STAGE_TITLE_MAP
 
         return (
-          <Fab
+          <Tooltip
             key={view}
-            aria-label={`Go to ${STAGE_TITLE_MAP[viewKey]}`}
-            aria-current={isActive ? 'true' : undefined}
-            className={classNames('view-button', { selected: isActive })}
-            size="small"
-            onClick={() => handleViewChangeButtonClick(view)}
+            arrow={true}
+            placement="top"
+            title={STAGE_TITLE_MAP[viewKey]}
           >
-            <span className="view-icon" role="img" aria-hidden="true">
-              {STAGE_ICON_MAP[viewKey]}
-            </span>
-          </Fab>
+            <Fab
+              aria-label={`Go to ${STAGE_TITLE_MAP[viewKey]}`}
+              aria-current={isActive ? 'true' : undefined}
+              className={classNames('view-button', { selected: isActive })}
+              size="small"
+              onClick={() => handleViewChangeButtonClick(view)}
+            >
+              <span className="view-icon" role="img" aria-hidden="true">
+                {STAGE_ICON_MAP[viewKey]}
+              </span>
+            </Fab>
+          </Tooltip>
         )
       })}
     </div>

--- a/src/components/BottomControls/BottomControls.tsx
+++ b/src/components/BottomControls/BottomControls.tsx
@@ -9,10 +9,27 @@ import Fab from '@mui/material/Fab/index.js'
 import Tooltip from '@mui/material/Tooltip/index.js'
 import { Theme } from '@mui/material/styles/index.js'
 
-import { STAGE_ICON_MAP, STAGE_TITLE_MAP } from '../../constants.js'
+import { STAGE_TITLE_MAP } from '../../constants.js'
+import { stageFocusType } from '../../enums.js'
+import { animals, items } from '../../img/index.js'
+import winePurple from '../../img/wines/wine-purple.png'
 import { breakpoints, layout } from '../../styles/tokens.js'
 import { Div } from '../Elements/index.js'
 import FarmhandContext from '../Farmhand/Farmhand.context.js'
+
+// Chosen from existing game art rather than drawn specifically for this
+// row - Home and Shop in particular have no literal "house"/"storefront"
+// sprite in the game, so the scarecrow (the farm's default fixture, and
+// every player's starting item) and the storage crate stand in for them.
+const STAGE_ICON_MAP = {
+  [stageFocusType.HOME]: items.scarecrow,
+  [stageFocusType.FIELD]: items.carrot,
+  [stageFocusType.FOREST]: items['apple-tree-grown'],
+  [stageFocusType.SHOP]: items['inventory-box'],
+  [stageFocusType.COW_PEN]: animals.cow.variations[0],
+  [stageFocusType.WORKSHOP]: items.bread,
+  [stageFocusType.CELLAR]: winePurple,
+}
 
 export const BottomControls = ({
   focusNextView,
@@ -58,7 +75,9 @@ export const BottomControls = ({
           margin: '0 0.25em',
           position: 'relative',
           '& .view-icon': {
-            fontSize: '1.3em',
+            height: '1.5em',
+            objectFit: 'contain',
+            width: '1.5em',
           },
           '&:hover': {
             backgroundColor: t.palette.grey[500],
@@ -125,9 +144,7 @@ export const BottomControls = ({
               size="small"
               onClick={() => handleViewChangeButtonClick(view)}
             >
-              <span className="view-icon" role="img" aria-hidden="true">
-                {STAGE_ICON_MAP[viewKey]}
-              </span>
+              <img className="view-icon" src={STAGE_ICON_MAP[viewKey]} alt="" />
             </Fab>
           </Tooltip>
         )

--- a/src/components/BottomControls/index.ts
+++ b/src/components/BottomControls/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BottomControls.js'

--- a/src/components/Farmhand/Farmhand.tsx
+++ b/src/components/Farmhand/Farmhand.tsx
@@ -1,11 +1,7 @@
 import HotelIcon from '@mui/icons-material/Hotel.js'
-import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft.js'
-import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight.js'
-import MenuIcon from '@mui/icons-material/Menu.js'
 import CssBaseline from '@mui/material/CssBaseline/index.js'
 import Drawer from '@mui/material/Drawer/index.js'
 import Fab from '@mui/material/Fab/index.js'
-import MobileStepper from '@mui/material/MobileStepper/index.js'
 import { Theme, ThemeProvider } from '@mui/material/styles/index.js'
 import Tooltip from '@mui/material/Tooltip/index.js'
 import classNames from 'classnames'
@@ -26,6 +22,7 @@ import 'animate.css/source/_base.css'
 import 'animate.css/source/attention_seekers/heartBeat.css'
 
 import AppBar from '../AppBar/index.js'
+import BottomControls from '../BottomControls/index.js'
 import { ChatRoom } from '../ChatRoom/index.js'
 import ContextPane from '../ContextPane/index.js'
 import Navigation from '../Navigation/index.js'
@@ -53,7 +50,6 @@ const Farmhand = (props: FarmhandProps) => {
     keyHandlers,
     redirect,
     state,
-    viewList,
     focusPreviousView,
     focusNextView,
     isChatAvailable,
@@ -110,45 +106,6 @@ const Farmhand = (props: FarmhandProps) => {
                   paddingTop: '4em',
                 },
                 '& .sidebar-wrapper': { display: 'flex' },
-                '& .bottom-controls': {
-                  alignItems: 'center',
-                  bottom: '1em',
-                  display: 'flex',
-                  flexFlow: 'column',
-                  justifyContent: 'center',
-                  left: '50%',
-                  opacity: 0.85,
-                  position: 'fixed',
-                  transition: t.transitions.create('left', {
-                    duration: t.transitions.duration.enteringScreen,
-                    easing: t.transitions.easing.easeOut,
-                  }),
-                  width: 0,
-                  zIndex: 20,
-                  [`@media (max-width: ${breakpoints.mediumPhone}px)`]: {
-                    bottom: '0.5em',
-                  },
-                  '& .MuiMobileStepper-root': { background: 'none' },
-                  '& .fab-buttons': {
-                    display: 'flex',
-                    flexFlow: 'row',
-                    '& button': {
-                      margin: '0.5em',
-                      position: 'relative',
-                      [`@media (max-width: ${breakpoints.mediumPhone}px)`]: {
-                        margin: '0.25em 0.5em',
-                      },
-                      '@media (max-width: 320px)': {
-                        margin: '0.25em 0.1em',
-                      },
-                    },
-                  },
-                  ...(state.isMenuOpen && {
-                    '@media (orientation: landscape)': {
-                      left: `calc(50vw + ${layout.sidebarWidth} / 2)`,
-                    },
-                  }),
-                },
                 '& .end-day': {
                   position: 'fixed',
                   top: '5em',
@@ -161,14 +118,6 @@ const Farmhand = (props: FarmhandProps) => {
                     right: 'auto',
                     left: '1em',
                   }),
-                },
-                '& .menu-button': {
-                  transition: t.transitions.create('transform', {
-                    duration: t.transitions.duration.shorter,
-                  }),
-                  transform: state.isMenuOpen
-                    ? 'rotate(-90deg)'
-                    : 'rotate(0deg)',
                 },
               })}
             >
@@ -205,43 +154,10 @@ const Farmhand = (props: FarmhandProps) => {
                 <div className="spacer" />
               </Drawer>
               <Stage />
-              <div className="bottom-controls">
-                <MobileStepper
-                  variant="dots"
-                  steps={viewList.length}
-                  position="static"
-                  activeStep={viewList.indexOf(state.stageFocus)}
-                  className=""
-                  backButton={null}
-                  nextButton={null}
-                />
-                <div className="fab-buttons buttons">
-                  <Fab
-                    aria-label="Previous view"
-                    color="primary"
-                    onClick={focusPreviousView}
-                  >
-                    <KeyboardArrowLeft />
-                  </Fab>
-                  <Fab
-                    className={classNames('menu-button', {
-                      'is-open': state.isMenuOpen,
-                    })}
-                    color="primary"
-                    aria-label="Open drawer"
-                    onClick={() => handlers.handleMenuToggle()}
-                  >
-                    <MenuIcon />
-                  </Fab>
-                  <Fab
-                    aria-label="Next view"
-                    color="primary"
-                    onClick={focusNextView}
-                  >
-                    <KeyboardArrowRight />
-                  </Fab>
-                </div>
-              </div>
+              <BottomControls
+                focusPreviousView={focusPreviousView}
+                focusNextView={focusNextView}
+              />
               <Tooltip
                 placement="left"
                 title={

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -151,16 +151,6 @@ export const STAGE_TITLE_MAP = {
   [stageFocusType.CELLAR]: 'Cellar',
 }
 
-export const STAGE_ICON_MAP = {
-  [stageFocusType.HOME]: '🏠',
-  [stageFocusType.FIELD]: '🥕',
-  [stageFocusType.FOREST]: '🌲',
-  [stageFocusType.SHOP]: '🛒',
-  [stageFocusType.COW_PEN]: '🐮',
-  [stageFocusType.WORKSHOP]: '🛠️',
-  [stageFocusType.CELLAR]: '🍷',
-}
-
 export const DAILY_FINANCIAL_HISTORY_RECORD_LENGTH = 7
 
 export const RECIPE_INGREDIENT_VALUE_MULTIPLIER = 1.25

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -151,6 +151,16 @@ export const STAGE_TITLE_MAP = {
   [stageFocusType.CELLAR]: 'Cellar',
 }
 
+export const STAGE_ICON_MAP = {
+  [stageFocusType.HOME]: '🏠',
+  [stageFocusType.FIELD]: '🥕',
+  [stageFocusType.FOREST]: '🌲',
+  [stageFocusType.SHOP]: '🛒',
+  [stageFocusType.COW_PEN]: '🐮',
+  [stageFocusType.WORKSHOP]: '🛠️',
+  [stageFocusType.CELLAR]: '🍷',
+}
+
 export const DAILY_FINANCIAL_HISTORY_RECORD_LENGTH = 7
 
 export const RECIPE_INGREDIENT_VALUE_MULTIPLIER = 1.25

--- a/src/styles/sx.ts
+++ b/src/styles/sx.ts
@@ -69,7 +69,9 @@ export const spriteShadowSx = {
 // different inventories.
 export const quickSelectSx = (theme: Theme, isMenuOpen: boolean) => ({
   ...cardStyleSx(theme),
-  bottom: '7.5em',
+  // Clears the bottom-controls view-icon row above the prev/menu/next
+  // buttons; keep in sync with BottomControls.tsx's rendered height.
+  bottom: '8.5em',
   left: '50%',
   maxWidth: 'calc(100% - 2em)',
   position: 'fixed',

--- a/src/test-utils/ui.ts
+++ b/src/test-utils/ui.ts
@@ -21,6 +21,12 @@ export const nextView = async () => {
   await userEvent.click(nextViewButton)
 }
 
+export const goToView = async (viewLabel: string) => {
+  const viewButton = await screen.findByLabelText(`Go to ${viewLabel}`)
+
+  await userEvent.click(viewButton)
+}
+
 export const getItemByName = async (itemName: string) => {
   const header = await screen.findByText(itemName)
   const item = header.closest('.Item')


### PR DESCRIPTION
### What this PR does

Closes #66.

Replaces the bottom navigation's non-interactive dots with a row of tappable, tooltipped icon buttons (one per unlocked view, in order) that jump straight to that screen. The active view is highlighted (white background, blue outline); others are gray. Icons are plain unicode emoji for now (still deciding on final art - see discussion), chosen so swapping in different icons later is a small, isolated change (`STAGE_ICON_MAP` in `BottomControls.tsx`).

The URL-hash view/tab persistence that was originally part of this PR has been split out into #740 so it can be reviewed independently.

### How this change can be validated

- `npx vitest run` / `npm run check:types` / `npm run lint`
- e2e: `npx playwright test e2e/tests/bottom-navigation.test.ts`
- Manually: navigate around via the new icon row (hover for tooltips) at a narrow viewport (~320px) with several views unlocked to confirm the icon row doesn't overflow.

### Questions or concerns about this change

Still deciding on the final icon art - currently using plain unicode emoji.

### Additional information