### PR TITLE
feat: Add a progress bar for achievements requiring repeated actions

### DIFF
--- a/src/components/Achievement/Achievement.test.tsx
+++ b/src/components/Achievement/Achievement.test.tsx
@@ -43,4 +43,70 @@ describe('<Achievement />', () => {
       screen.getByText(new RegExp(achievementObject.rewardDescription))
     ).toBeInTheDocument()
   })
+
+  test('does not render a progress bar when the achievement has no getProgress', () => {
+    expect(document.querySelector('.ProgressBar')).not.toBeInTheDocument()
+  })
+})
+
+describe('<Achievement /> with getProgress', () => {
+  let achievementObject: farmhand.achievement
+
+  beforeEach(() => {
+    achievementObject = {
+      description: 'the best achievement',
+      id: 'achievement-1',
+      name: 'achievement one',
+      rewardDescription: 'the greatest reward',
+      condition: () => false,
+      reward: state => state,
+      getProgress: () => ({ currentValue: 25, goal: 100 }),
+    }
+
+    const farmhandContextValue = createContextData()
+
+    render(
+      <FarmhandContext.Provider value={farmhandContextValue}>
+        <Achievement
+          achievement={achievementObject}
+          completedAchievements={{}}
+        />
+      </FarmhandContext.Provider>
+    )
+  })
+
+  test('renders a progress bar', () => {
+    expect(document.querySelector('.ProgressBar')).toBeInTheDocument()
+  })
+})
+
+describe('<Achievement /> with getProgress and isComplete', () => {
+  let achievementObject: farmhand.achievement
+
+  beforeEach(() => {
+    achievementObject = {
+      description: 'the best achievement',
+      id: 'achievement-1',
+      name: 'achievement one',
+      rewardDescription: 'the greatest reward',
+      condition: () => false,
+      reward: state => state,
+      getProgress: () => ({ currentValue: 100, goal: 100 }),
+    }
+
+    const farmhandContextValue = createContextData()
+
+    render(
+      <FarmhandContext.Provider value={farmhandContextValue}>
+        <Achievement
+          achievement={achievementObject}
+          completedAchievements={{ 'achievement-1': true }}
+        />
+      </FarmhandContext.Provider>
+    )
+  })
+
+  test('does not render a progress bar once the achievement is complete', () => {
+    expect(document.querySelector('.ProgressBar')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/Achievement/Achievement.tsx
+++ b/src/components/Achievement/Achievement.tsx
@@ -25,6 +25,7 @@ const Achievement = ({
   isComplete?: boolean
 }) => {
   const { description, name, rewardDescription } = achievement
+  const progress = achievement.getProgress?.(gameState)
 
   return (
     <Card
@@ -44,15 +45,13 @@ const Achievement = ({
       />
       <CardContent>
         <p>{description}</p>
-        {!isComplete && achievement.getProgress && (
+        {!isComplete && progress && (
           <Div sx={{ marginTop: '1em' }}>
             <ProgressBar
               {...{
                 percent: Math.min(
                   100,
-                  (achievement.getProgress(gameState).currentValue /
-                    achievement.getProgress(gameState).goal) *
-                    100
+                  (progress.currentValue / progress.goal) * 100
                 ),
               }}
             />

--- a/src/components/Achievement/Achievement.tsx
+++ b/src/components/Achievement/Achievement.tsx
@@ -9,35 +9,59 @@ import BeenhereIcon from '@mui/icons-material/Beenhere.js'
 import { bool, object, shape, string } from 'prop-types'
 
 import FarmhandContext from '../Farmhand/Farmhand.context.js'
+import { Div } from '../Elements/index.js'
+import ProgressBar from '../ProgressBar/index.js'
 
 const Achievement = ({
-  achievement: { description, id, name, rewardDescription },
+  achievement,
   completedAchievements,
+  gameState,
 
-  isComplete = Boolean(completedAchievements[id]),
+  isComplete = Boolean(completedAchievements[achievement.id]),
 }: {
   achievement: farmhand.achievement
   completedAchievements: Partial<Record<string, boolean>>
+  gameState: farmhand.state
   isComplete?: boolean
-}) => (
-  <Card
-    {...{ className: classNames('Achievement', { 'is-complete': isComplete }) }}
-    sx={{
-      '& .MuiSvgIcon-root': { color: isComplete ? '#13b747' : '#666' },
-    }}
-  >
-    <CardHeader
+}) => {
+  const { description, name, rewardDescription } = achievement
+
+  return (
+    <Card
       {...{
-        avatar: isComplete ? <BeenhereIcon /> : <AssignmentLateIcon />,
-        title: name,
-        subheader: <p>Reward: {rewardDescription}</p>,
+        className: classNames('Achievement', { 'is-complete': isComplete }),
       }}
-    />
-    <CardContent>
-      <p>{description}</p>
-    </CardContent>
-  </Card>
-)
+      sx={{
+        '& .MuiSvgIcon-root': { color: isComplete ? '#13b747' : '#666' },
+      }}
+    >
+      <CardHeader
+        {...{
+          avatar: isComplete ? <BeenhereIcon /> : <AssignmentLateIcon />,
+          title: name,
+          subheader: <p>Reward: {rewardDescription}</p>,
+        }}
+      />
+      <CardContent>
+        <p>{description}</p>
+        {!isComplete && achievement.getProgress && (
+          <Div sx={{ marginTop: '1em' }}>
+            <ProgressBar
+              {...{
+                percent: Math.min(
+                  100,
+                  (achievement.getProgress(gameState).currentValue /
+                    achievement.getProgress(gameState).goal) *
+                    100
+                ),
+              }}
+            />
+          </Div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
 
 Achievement.propTypes = {
   achievement: shape({
@@ -47,6 +71,7 @@ Achievement.propTypes = {
     rewardDescription: string.isRequired,
   }).isRequired,
   completedAchievements: object.isRequired,
+  gameState: object.isRequired,
   isComplete: bool,
 }
 
@@ -58,7 +83,7 @@ export default function Consumer(props: {
   return (
     <FarmhandContext.Consumer>
       {({ gameState, handlers }) => (
-        <Achievement {...{ ...gameState, ...handlers, ...props }} />
+        <Achievement {...{ ...gameState, ...handlers, ...props, gameState }} />
       )}
     </FarmhandContext.Consumer>
   )

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -79,12 +79,21 @@ const ProgressBar = ({ percent }: { percent: number }) => {
   }, [percent, prefersReducedMotion])
 
   return (
-    <Div className="ProgressBar" sx={{ margin: '0 auto' }}>
+    <Div
+      className="ProgressBar"
+      sx={{
+        margin: '0 auto',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5em',
+      }}
+    >
       <Div
         className="progress-wrapper"
         sx={{
+          flexGrow: 1,
           height: '1em',
-          background: '#ddd',
+          background: 'rgba(0, 0, 0, 0.15)',
           borderRadius: '0.5em',
           overflow: 'hidden',
         }}
@@ -100,7 +109,7 @@ const ProgressBar = ({ percent }: { percent: number }) => {
           sx={{ height: '100%' }}
         ></Div>
       </Div>
-      <P sx={{ lineHeight: '2em', textAlign: 'center' }}>
+      <P sx={{ lineHeight: '1em', minWidth: '3em', textAlign: 'right' }}>
         <span>{displayedProgress}%</span>
       </P>
     </Div>

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -5,8 +5,31 @@ import { toolLevel, toolType } from '../enums.js'
 
 import { INFINITE_STORAGE_LIMIT } from '../constants.js'
 
-import { achievementsMap } from './achievements.js'
+import { achievementsMap, progressAchievement } from './achievements.js'
 import { carrot } from './crops/index.js'
+
+describe('progressAchievement', () => {
+  test('condition is false and getProgress reflects currentValue below goal', () => {
+    const { condition, getProgress } = progressAchievement(10, () => 9)
+
+    expect(condition({} as any)).toEqual(false)
+    expect(getProgress?.({} as any)).toEqual({ currentValue: 9, goal: 10 })
+  })
+
+  test('condition is true and getProgress reflects currentValue at goal', () => {
+    const { condition, getProgress } = progressAchievement(10, () => 10)
+
+    expect(condition({} as any)).toEqual(true)
+    expect(getProgress?.({} as any)).toEqual({ currentValue: 10, goal: 10 })
+  })
+
+  test('condition is true and getProgress reflects currentValue above goal', () => {
+    const { condition, getProgress } = progressAchievement(10, () => 11)
+
+    expect(condition({} as any)).toEqual(true)
+    expect(getProgress?.({} as any)).toEqual({ currentValue: 11, goal: 10 })
+  })
+})
 
 describe('harvest-crop', () => {
   describe('condition', () => {

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -85,6 +85,18 @@ describe.each(iAmRichVariants)(
 
         expect(achievement.condition(state)).toEqual(false)
       })
+
+      test('reports progress toward the revenue goal', () => {
+        const achievement = achievementsMap[id]
+        const state = {
+          revenue: Number(goal) - 1,
+        } as any
+
+        expect(achievement.getProgress?.(state)).toEqual({
+          currentValue: Number(goal) - 1,
+          goal: Number(goal),
+        })
+      })
     })
   }
 )
@@ -173,6 +185,13 @@ describe('orchardist', () => {
 
     expect(saplings).toEqual({ id: 'apple-sapling', quantity: 50 })
   })
+
+  test('reports progress toward the fruits-picked goal', () => {
+    expect(achievement.getProgress?.(state)).toEqual({
+      currentValue: 999,
+      goal: 1000,
+    })
+  })
 })
 
 describe('piemaker', () => {
@@ -218,6 +237,13 @@ describe('piemaker', () => {
 
     expect(state.money).toEqual(100_000)
   })
+
+  test('reports progress toward the pies-made goal', () => {
+    expect(achievement.getProgress?.(state)).toEqual({
+      currentValue: 99,
+      goal: 100,
+    })
+  })
 })
 
 describe('deforestation', () => {
@@ -250,6 +276,13 @@ describe('deforestation', () => {
     )
 
     expect(wood).toEqual({ id: 'wood', quantity: 500 })
+  })
+
+  test('reports progress toward the trees-chopped goal', () => {
+    expect(achievement.getProgress?.(state)).toEqual({
+      currentValue: 249,
+      goal: 250,
+    })
   })
 })
 
@@ -289,5 +322,12 @@ describe('landscaper', () => {
     )
 
     expect(rainbowMulch).toEqual({ id: 'rainbow-mulch', quantity: 25 })
+  })
+
+  test('reports progress toward the mulch-applied goal', () => {
+    expect(achievement.getProgress?.(state)).toEqual({
+      currentValue: 99,
+      goal: 100,
+    })
   })
 })

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -113,6 +113,7 @@ const achievements: farmhand.achievement[] = [
     )}. Proven farmers get access to the Crop Price Guide, an invaluable tool for making better buying and selling decisions!`,
     rewardDescription: 'Crop Price Guide',
     condition: state => state.revenue >= goal,
+    getProgress: state => ({ currentValue: state.revenue, goal }),
     // Reward is a no-op for this achievement. The value of
     // state.completedAchievements['unlock-crop-price-guide'] (which is
     // automatically set to `true` in the achievement processing logic) is used
@@ -130,7 +131,7 @@ const achievements: farmhand.achievement[] = [
     reward: state => addItemToInventory(state, cowFeed, reward, true),
   }))(),
 
-  ((reward = 100) => ({
+  ((reward = 100, goal = Object.keys(standardCowColors).length) => ({
     id: 'purchase-all-cow-colors',
     name: 'Cows of Many Colors',
     description: 'Show that you love all cows and purchase one of every color.',
@@ -139,6 +140,12 @@ const achievements: farmhand.achievement[] = [
       Object.values(standardCowColors).every(
         color => (state.cowColorsPurchased[color] || 0) > 0
       ),
+    getProgress: state => ({
+      currentValue: Object.values(standardCowColors).filter(
+        color => (state.cowColorsPurchased[color] || 0) > 0
+      ).length,
+      goal,
+    }),
     reward: state => addItemToInventory(state, cowFeed, reward, true),
   }))(),
 
@@ -160,6 +167,10 @@ const achievements: farmhand.achievement[] = [
     }. That's enough to fill a whole pumpkin patch!`,
     rewardDescription: `${reward} units of ${itemsMap['scarecrow'].name}`,
     condition: state => (state.itemsSold.jackolantern || 0) >= goal,
+    getProgress: state => ({
+      currentValue: state.itemsSold.jackolantern || 0,
+      goal,
+    }),
     reward: state =>
       addItemToInventory(state, itemsMap['scarecrow'], reward, true),
   }))(),
@@ -175,6 +186,14 @@ const achievements: farmhand.achievement[] = [
         state.todaysRevenue,
         state.todaysLosses
       ) >= goal,
+    getProgress: state => ({
+      currentValue: getProfitRecord(
+        state.recordSingleDayProfit,
+        state.todaysRevenue,
+        state.todaysLosses
+      ),
+      goal,
+    }),
     reward: state =>
       addItemToInventory(state, itemsMap['fertilizer'], reward, true),
   }))(),
@@ -190,6 +209,14 @@ const achievements: farmhand.achievement[] = [
         state.todaysRevenue,
         state.todaysLosses
       ) >= goal,
+    getProgress: state => ({
+      currentValue: getProfitRecord(
+        state.recordSingleDayProfit,
+        state.todaysRevenue,
+        state.todaysLosses
+      ),
+      goal,
+    }),
     reward: state =>
       addItemToInventory(state, itemsMap['onion-seed'], reward, true),
   }))(),
@@ -205,6 +232,14 @@ const achievements: farmhand.achievement[] = [
         state.todaysRevenue,
         state.todaysLosses
       ) >= goal,
+    getProgress: state => ({
+      currentValue: getProfitRecord(
+        state.recordSingleDayProfit,
+        state.todaysRevenue,
+        state.todaysLosses
+      ),
+      goal,
+    }),
     reward: state =>
       addItemToInventory(state, itemsMap['tomato-seed'], reward, true),
   }))(),
@@ -215,6 +250,10 @@ const achievements: farmhand.achievement[] = [
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
     condition: state => state.record7dayProfitAverage >= goal,
+    getProgress: state => ({
+      currentValue: state.record7dayProfitAverage,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -224,6 +263,10 @@ const achievements: farmhand.achievement[] = [
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
     condition: state => state.record7dayProfitAverage >= goal,
+    getProgress: state => ({
+      currentValue: state.record7dayProfitAverage,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -233,6 +276,10 @@ const achievements: farmhand.achievement[] = [
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
     condition: state => state.record7dayProfitAverage >= goal,
+    getProgress: state => ({
+      currentValue: state.record7dayProfitAverage,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -242,6 +289,10 @@ const achievements: farmhand.achievement[] = [
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
     condition: state => state.record7dayProfitAverage >= goal,
+    getProgress: state => ({
+      currentValue: state.record7dayProfitAverage,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -251,6 +302,10 @@ const achievements: farmhand.achievement[] = [
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
     condition: state => state.record7dayProfitAverage >= goal,
+    getProgress: state => ({
+      currentValue: state.record7dayProfitAverage,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -260,6 +315,10 @@ const achievements: farmhand.achievement[] = [
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
     condition: state => state.record7dayProfitAverage >= goal,
+    getProgress: state => ({
+      currentValue: state.record7dayProfitAverage,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -274,6 +333,10 @@ const achievements: farmhand.achievement[] = [
     description: `Sell ${integerString(goal)} units of ${goalItem.name}.`,
     rewardDescription: `${integerString(reward)} ${rewardItem.name} units`,
     condition: state => (state.itemsSold[goalItem.id] || 0) >= goal,
+    getProgress: state => ({
+      currentValue: state.itemsSold[goalItem.id] || 0,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -288,6 +351,10 @@ const achievements: farmhand.achievement[] = [
     description: `Sell ${integerString(goal)} units of ${goalItem.name}.`,
     rewardDescription: `${integerString(reward)} ${rewardItem.name} units`,
     condition: state => (state.itemsSold[goalItem.id] || 0) >= goal,
+    getProgress: state => ({
+      currentValue: state.itemsSold[goalItem.id] || 0,
+      goal,
+    }),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -297,6 +364,10 @@ const achievements: farmhand.achievement[] = [
     description: `Sell ${integerString(goal)} ${goalItem.name} units.`,
     rewardDescription: `${integerString(reward)} additional inventory spaces`,
     condition: state => (state.itemsSold[goalItem.id] || 0) >= goal,
+    getProgress: state => ({
+      currentValue: state.itemsSold[goalItem.id] || 0,
+      goal,
+    }),
     reward: state => ({
       ...state,
       inventoryLimit: state.inventoryLimit + reward,
@@ -311,6 +382,7 @@ const achievements: farmhand.achievement[] = [
       I_AM_RICH_BONUSES[0]
     )} bonus`,
     condition: state => state.revenue >= goal,
+    getProgress: state => ({ currentValue: state.revenue, goal }),
     reward: state => state,
   }))(),
 
@@ -322,6 +394,7 @@ const achievements: farmhand.achievement[] = [
       I_AM_RICH_BONUSES[1]
     )} bonus`,
     condition: state => state.revenue >= goal,
+    getProgress: state => ({ currentValue: state.revenue, goal }),
     reward: state => state,
   }))(),
 
@@ -333,6 +406,7 @@ const achievements: farmhand.achievement[] = [
       I_AM_RICH_BONUSES[2]
     )} bonus`,
     condition: state => state.revenue >= goal,
+    getProgress: state => ({ currentValue: state.revenue, goal }),
     reward: state => state,
   }))(),
 
@@ -366,6 +440,10 @@ const achievements: farmhand.achievement[] = [
     rewardDescription: `${reward} units of ${itemsMap['apple-sapling'].name}`,
     condition: state =>
       sumOfPartialRecordValues(state.treeFruitsHarvested) >= goal,
+    getProgress: state => ({
+      currentValue: sumOfPartialRecordValues(state.treeFruitsHarvested),
+      goal,
+    }),
     reward: state =>
       addItemToInventory(state, itemsMap['apple-sapling'], reward, true),
   }))(),
@@ -376,6 +454,10 @@ const achievements: farmhand.achievement[] = [
     description: `Make ${integerString(goal)} pies.`,
     rewardDescription: dollarString(reward),
     condition: state => sumOfPiesMade(state.recipesMade) >= goal,
+    getProgress: state => ({
+      currentValue: sumOfPiesMade(state.recipesMade),
+      goal,
+    }),
     reward: state => addMoney(state, reward),
   }))(),
 
@@ -385,6 +467,7 @@ const achievements: farmhand.achievement[] = [
     description: `Chop down ${integerString(goal)} trees in the Forest.`,
     rewardDescription: `${reward} units of ${itemsMap['wood'].name}`,
     condition: state => state.treesChopped >= goal,
+    getProgress: state => ({ currentValue: state.treesChopped, goal }),
     reward: state => addItemToInventory(state, itemsMap['wood'], reward, true),
   }))(),
 
@@ -396,6 +479,10 @@ const achievements: farmhand.achievement[] = [
     )} bags of mulch (of any type) on trees in the Forest.`,
     rewardDescription: `${reward} units of ${itemsMap['rainbow-mulch'].name}`,
     condition: state => sumOfPartialRecordValues(state.mulchApplied) >= goal,
+    getProgress: state => ({
+      currentValue: sumOfPartialRecordValues(state.mulchApplied),
+      goal,
+    }),
     reward: state =>
       addItemToInventory(state, itemsMap['rainbow-mulch'], reward, true),
   }))(),

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -48,10 +48,23 @@ const PIE_RECIPE_IDS = Object.values(recipesMap)
   .filter(recipe => recipe.isPie)
   .map(recipe => recipe.id)
 
-const sumOfPiesMade = (recipesMade: Partial<Record<string, number>>) =>
-  PIE_RECIPE_IDS.reduce((sum, id) => sum + (recipesMade[id] || 0), 0)
+const sumOfPiesMade = memoize(
+  (recipesMade: Partial<Record<string, number>>) =>
+    PIE_RECIPE_IDS.reduce((sum, id) => sum + (recipesMade[id] || 0), 0),
+  {}
+)
 
 const cowFeed = itemsMap[COW_FEED_ITEM_ID]
+
+// Derives condition and getProgress from a single source of truth so that an
+// achievement's "complete" state and its progress bar can never disagree.
+export const progressAchievement = (
+  goal: number,
+  getCurrentValue: (state: farmhand.state) => number
+): Pick<farmhand.achievement, 'condition' | 'getProgress'> => ({
+  condition: state => getCurrentValue(state) >= goal,
+  getProgress: state => ({ currentValue: getCurrentValue(state), goal }),
+})
 
 const achievements: farmhand.achievement[] = [
   ((reward = 100) => ({
@@ -112,8 +125,7 @@ const achievements: farmhand.achievement[] = [
       goal
     )}. Proven farmers get access to the Crop Price Guide, an invaluable tool for making better buying and selling decisions!`,
     rewardDescription: 'Crop Price Guide',
-    condition: state => state.revenue >= goal,
-    getProgress: state => ({ currentValue: state.revenue, goal }),
+    ...progressAchievement(goal, state => state.revenue),
     // Reward is a no-op for this achievement. The value of
     // state.completedAchievements['unlock-crop-price-guide'] (which is
     // automatically set to `true` in the achievement processing logic) is used
@@ -136,16 +148,13 @@ const achievements: farmhand.achievement[] = [
     name: 'Cows of Many Colors',
     description: 'Show that you love all cows and purchase one of every color.',
     rewardDescription: `${reward} units of ${cowFeed.name}`,
-    condition: state =>
-      Object.values(standardCowColors).every(
-        color => (state.cowColorsPurchased[color] || 0) > 0
-      ),
-    getProgress: state => ({
-      currentValue: Object.values(standardCowColors).filter(
-        color => (state.cowColorsPurchased[color] || 0) > 0
-      ).length,
+    ...progressAchievement(
       goal,
-    }),
+      state =>
+        Object.values(standardCowColors).filter(
+          color => (state.cowColorsPurchased[color] || 0) > 0
+        ).length
+    ),
     reward: state => addItemToInventory(state, cowFeed, reward, true),
   }))(),
 
@@ -166,11 +175,7 @@ const achievements: farmhand.achievement[] = [
       itemsMap['jackolantern'].name
     }. That's enough to fill a whole pumpkin patch!`,
     rewardDescription: `${reward} units of ${itemsMap['scarecrow'].name}`,
-    condition: state => (state.itemsSold.jackolantern || 0) >= goal,
-    getProgress: state => ({
-      currentValue: state.itemsSold.jackolantern || 0,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.itemsSold.jackolantern || 0),
     reward: state =>
       addItemToInventory(state, itemsMap['scarecrow'], reward, true),
   }))(),
@@ -180,20 +185,13 @@ const achievements: farmhand.achievement[] = [
     name: `Daily profit: ${dollarString(goal)}`,
     description: `Earn ${dollarString(goal)} of profit in a single day.`,
     rewardDescription: `${reward} units of ${itemsMap['fertilizer'].name}`,
-    condition: state =>
+    ...progressAchievement(goal, state =>
       getProfitRecord(
         state.recordSingleDayProfit,
         state.todaysRevenue,
         state.todaysLosses
-      ) >= goal,
-    getProgress: state => ({
-      currentValue: getProfitRecord(
-        state.recordSingleDayProfit,
-        state.todaysRevenue,
-        state.todaysLosses
-      ),
-      goal,
-    }),
+      )
+    ),
     reward: state =>
       addItemToInventory(state, itemsMap['fertilizer'], reward, true),
   }))(),
@@ -203,20 +201,13 @@ const achievements: farmhand.achievement[] = [
     name: `Daily profit: ${dollarString(goal)}`,
     description: `Earn ${dollarString(goal)} of profit in a single day.`,
     rewardDescription: `${reward} units of ${itemsMap['onion-seed'].name}`,
-    condition: state =>
+    ...progressAchievement(goal, state =>
       getProfitRecord(
         state.recordSingleDayProfit,
         state.todaysRevenue,
         state.todaysLosses
-      ) >= goal,
-    getProgress: state => ({
-      currentValue: getProfitRecord(
-        state.recordSingleDayProfit,
-        state.todaysRevenue,
-        state.todaysLosses
-      ),
-      goal,
-    }),
+      )
+    ),
     reward: state =>
       addItemToInventory(state, itemsMap['onion-seed'], reward, true),
   }))(),
@@ -226,20 +217,13 @@ const achievements: farmhand.achievement[] = [
     name: `Daily profit: ${dollarString(goal)}`,
     description: `Earn ${dollarString(goal)} of profit in a single day.`,
     rewardDescription: `${reward} units of ${itemsMap['tomato-seed'].name}`,
-    condition: state =>
+    ...progressAchievement(goal, state =>
       getProfitRecord(
         state.recordSingleDayProfit,
         state.todaysRevenue,
         state.todaysLosses
-      ) >= goal,
-    getProgress: state => ({
-      currentValue: getProfitRecord(
-        state.recordSingleDayProfit,
-        state.todaysRevenue,
-        state.todaysLosses
-      ),
-      goal,
-    }),
+      )
+    ),
     reward: state =>
       addItemToInventory(state, itemsMap['tomato-seed'], reward, true),
   }))(),
@@ -249,11 +233,7 @@ const achievements: farmhand.achievement[] = [
     name: `7-day profit average: ${dollarString(goal)}`,
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
-    condition: state => state.record7dayProfitAverage >= goal,
-    getProgress: state => ({
-      currentValue: state.record7dayProfitAverage,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.record7dayProfitAverage),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -262,11 +242,7 @@ const achievements: farmhand.achievement[] = [
     name: `7-day profit average: ${dollarString(goal)}`,
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
-    condition: state => state.record7dayProfitAverage >= goal,
-    getProgress: state => ({
-      currentValue: state.record7dayProfitAverage,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.record7dayProfitAverage),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -275,11 +251,7 @@ const achievements: farmhand.achievement[] = [
     name: `7-day profit average: ${dollarString(goal)}`,
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
-    condition: state => state.record7dayProfitAverage >= goal,
-    getProgress: state => ({
-      currentValue: state.record7dayProfitAverage,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.record7dayProfitAverage),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -288,11 +260,7 @@ const achievements: farmhand.achievement[] = [
     name: `7-day profit average: ${dollarString(goal)}`,
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
-    condition: state => state.record7dayProfitAverage >= goal,
-    getProgress: state => ({
-      currentValue: state.record7dayProfitAverage,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.record7dayProfitAverage),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -301,11 +269,7 @@ const achievements: farmhand.achievement[] = [
     name: `7-day profit average: ${dollarString(goal)}`,
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
-    condition: state => state.record7dayProfitAverage >= goal,
-    getProgress: state => ({
-      currentValue: state.record7dayProfitAverage,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.record7dayProfitAverage),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -314,11 +278,7 @@ const achievements: farmhand.achievement[] = [
     name: `7-day profit average: ${dollarString(goal)}`,
     description: `Reach a 7-day profit average of ${dollarString(goal)}.`,
     rewardDescription: `${reward} units of ${rewardItem.name}`,
-    condition: state => state.record7dayProfitAverage >= goal,
-    getProgress: state => ({
-      currentValue: state.record7dayProfitAverage,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.record7dayProfitAverage),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -332,11 +292,7 @@ const achievements: farmhand.achievement[] = [
     name: `Dairy Master`,
     description: `Sell ${integerString(goal)} units of ${goalItem.name}.`,
     rewardDescription: `${integerString(reward)} ${rewardItem.name} units`,
-    condition: state => (state.itemsSold[goalItem.id] || 0) >= goal,
-    getProgress: state => ({
-      currentValue: state.itemsSold[goalItem.id] || 0,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.itemsSold[goalItem.id] || 0),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -350,11 +306,7 @@ const achievements: farmhand.achievement[] = [
     name: `A Big Average Rainbow`,
     description: `Sell ${integerString(goal)} units of ${goalItem.name}.`,
     rewardDescription: `${integerString(reward)} ${rewardItem.name} units`,
-    condition: state => (state.itemsSold[goalItem.id] || 0) >= goal,
-    getProgress: state => ({
-      currentValue: state.itemsSold[goalItem.id] || 0,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.itemsSold[goalItem.id] || 0),
     reward: state => addItemToInventory(state, rewardItem, reward, true),
   }))(),
 
@@ -363,11 +315,7 @@ const achievements: farmhand.achievement[] = [
     name: `Burger Master`,
     description: `Sell ${integerString(goal)} ${goalItem.name} units.`,
     rewardDescription: `${integerString(reward)} additional inventory spaces`,
-    condition: state => (state.itemsSold[goalItem.id] || 0) >= goal,
-    getProgress: state => ({
-      currentValue: state.itemsSold[goalItem.id] || 0,
-      goal,
-    }),
+    ...progressAchievement(goal, state => state.itemsSold[goalItem.id] || 0),
     reward: state => ({
       ...state,
       inventoryLimit: state.inventoryLimit + reward,
@@ -381,8 +329,7 @@ const achievements: farmhand.achievement[] = [
     rewardDescription: `All sales receive a ${percentageString(
       I_AM_RICH_BONUSES[0]
     )} bonus`,
-    condition: state => state.revenue >= goal,
-    getProgress: state => ({ currentValue: state.revenue, goal }),
+    ...progressAchievement(goal, state => state.revenue),
     reward: state => state,
   }))(),
 
@@ -393,8 +340,7 @@ const achievements: farmhand.achievement[] = [
     rewardDescription: `All sales receive a ${percentageString(
       I_AM_RICH_BONUSES[1]
     )} bonus`,
-    condition: state => state.revenue >= goal,
-    getProgress: state => ({ currentValue: state.revenue, goal }),
+    ...progressAchievement(goal, state => state.revenue),
     reward: state => state,
   }))(),
 
@@ -405,8 +351,7 @@ const achievements: farmhand.achievement[] = [
     rewardDescription: `All sales receive a ${percentageString(
       I_AM_RICH_BONUSES[2]
     )} bonus`,
-    condition: state => state.revenue >= goal,
-    getProgress: state => ({ currentValue: state.revenue, goal }),
+    ...progressAchievement(goal, state => state.revenue),
     reward: state => state,
   }))(),
 
@@ -438,12 +383,9 @@ const achievements: farmhand.achievement[] = [
     name: 'Orchardist',
     description: `Pick ${integerString(goal)} fruits from trees in the Forest.`,
     rewardDescription: `${reward} units of ${itemsMap['apple-sapling'].name}`,
-    condition: state =>
-      sumOfPartialRecordValues(state.treeFruitsHarvested) >= goal,
-    getProgress: state => ({
-      currentValue: sumOfPartialRecordValues(state.treeFruitsHarvested),
-      goal,
-    }),
+    ...progressAchievement(goal, state =>
+      sumOfPartialRecordValues(state.treeFruitsHarvested)
+    ),
     reward: state =>
       addItemToInventory(state, itemsMap['apple-sapling'], reward, true),
   }))(),
@@ -453,11 +395,7 @@ const achievements: farmhand.achievement[] = [
     name: 'Piemaker',
     description: `Make ${integerString(goal)} pies.`,
     rewardDescription: dollarString(reward),
-    condition: state => sumOfPiesMade(state.recipesMade) >= goal,
-    getProgress: state => ({
-      currentValue: sumOfPiesMade(state.recipesMade),
-      goal,
-    }),
+    ...progressAchievement(goal, state => sumOfPiesMade(state.recipesMade)),
     reward: state => addMoney(state, reward),
   }))(),
 
@@ -466,8 +404,7 @@ const achievements: farmhand.achievement[] = [
     name: 'Deforestation',
     description: `Chop down ${integerString(goal)} trees in the Forest.`,
     rewardDescription: `${reward} units of ${itemsMap['wood'].name}`,
-    condition: state => state.treesChopped >= goal,
-    getProgress: state => ({ currentValue: state.treesChopped, goal }),
+    ...progressAchievement(goal, state => state.treesChopped),
     reward: state => addItemToInventory(state, itemsMap['wood'], reward, true),
   }))(),
 
@@ -478,11 +415,9 @@ const achievements: farmhand.achievement[] = [
       goal
     )} bags of mulch (of any type) on trees in the Forest.`,
     rewardDescription: `${reward} units of ${itemsMap['rainbow-mulch'].name}`,
-    condition: state => sumOfPartialRecordValues(state.mulchApplied) >= goal,
-    getProgress: state => ({
-      currentValue: sumOfPartialRecordValues(state.mulchApplied),
-      goal,
-    }),
+    ...progressAchievement(goal, state =>
+      sumOfPartialRecordValues(state.mulchApplied)
+    ),
     reward: state =>
       addItemToInventory(state, itemsMap['rainbow-mulch'], reward, true),
   }))(),

--- a/src/farmhand.d.ts
+++ b/src/farmhand.d.ts
@@ -281,6 +281,12 @@ declare namespace farmhand {
 
   type achievementCondition = (state: state, prevState?: state) => boolean
   type achievementReward = (state: state) => state
+  type achievementProgress = (
+    state: state
+  ) => {
+    currentValue: number
+    goal: number
+  }
 
   interface achievement {
     id: string
@@ -289,6 +295,7 @@ declare namespace farmhand {
     rewardDescription: string
     condition: achievementCondition
     reward: achievementReward
+    getProgress?: achievementProgress
   }
 
   interface level {


### PR DESCRIPTION
### What this PR does

Implements #81: achievements that require repeated actions (e.g. "Sell 10,000 units") now show a progress bar instead of a flat complete/incomplete state.

Rather than the issue's suggested `progressComponent` (a React component stored on the achievement data), each achievement gets an optional `getProgress(state)` function returning `{ currentValue, goal }`, reusing the `goal` it already has for its `condition`. This keeps `src/data/achievements.ts` as plain data (no React) and reuses the existing `ProgressBar` component. Added it to the ~20 achievements that are genuinely "do it N times"; one-shot/time-gated/exact-match achievements are unaffected.

Also tweaked `ProgressBar` itself (shared by these new bars and the existing aggregate bar): percent label now sits beside the bar instead of below it, and the empty-track color is a translucent overlay instead of a flat gray that clashed with the app's warm card backgrounds. This was a subject design change, open to feedback.

### How this change can be validated

- `npx vitest run src/data/achievements.test.ts src/components/Achievement/Achievement.test.tsx src/components/ProgressBar/ProgressBar.test.tsx src/components/AchievementsView/AchievementsView.test.tsx`
- `npx tsc --noEmit`
- Manually: `window.farmhand.setState({ treeFruitsHarvested: { apple: 400 } })` in the browser console, then open Achievements (`a`) and confirm Orchardist shows a 40% bar.

### Questions or concerns about this change

Open to feedback on which achievements should/shouldn't get a bar — I skipped a few borderline cases like Financial Freedom (tracks a shrinking loan balance, not a growing counter).

Also wondering if we want to floor the % that we display. Showing things like "54.17%" seems needlessly specific.

### Additional information

<img width="442" height="863" alt="image" src="https://github.com/user-attachments/assets/94c1d1a7-e6e9-40c5-8914-5d93e992a7da" />

<img width="442" height="863" alt="Screenshot from 2026-07-31 21-51-10" src="https://github.com/user-attachments/assets/4814019b-bb26-45d7-b939-79236c18ef25" />


