### PR TITLE
feat: Add cow supplies to the Shop's Supplies tab

### DIFF
--- a/e2e/tests/cow-pen/cow-pen.test.ts
+++ b/e2e/tests/cow-pen/cow-pen.test.ts
@@ -59,3 +59,23 @@ test('should purchase a cow pen and a cow, verify hugging and selling works', as
   await expect(hugButton).not.toBeVisible()
   await expect(sellButton).not.toBeVisible()
 })
+
+test("should be able to buy Cow Feed directly from the Shop's Supplies tab", async ({
+  page,
+}) => {
+  // The crops-mature fixture has > $100k
+  await loadFixture(page, 'crops-mature')
+
+  await page.getByText(': Home').click()
+  await page.getByRole('option', { name: ': Shop' }).click()
+  await page.getByRole('tab', { name: 'Supplies' }).click()
+
+  const cowFeedCard = page.locator('.Item').filter({ hasText: 'Cow Feed' })
+  await cowFeedCard.getByPlaceholder('0').dblclick()
+  await cowFeedCard.getByPlaceholder('0').fill('1')
+  await cowFeedCard.getByRole('button', { name: 'Buy' }).click()
+
+  await expect(
+    page.locator('.ContextPane').getByText('Cow Feed', { exact: true })
+  ).toBeVisible()
+})

--- a/src/data/shop-inventory.ts
+++ b/src/data/shop-inventory.ts
@@ -28,6 +28,10 @@ import {
   // Field items
   scarecrow,
   sprinkler,
+
+  // Cow items
+  cowFeed,
+  huggingMachine,
 } from './items.js'
 
 import { fertilizer, mulch } from './recipes.js'
@@ -66,6 +70,10 @@ const inventory: farmhand.item[] = [
   fertilizer,
   scarecrow,
   sprinkler,
+
+  // Cow items
+  cowFeed,
+  huggingMachine,
 ]
 
 export default inventory

--- a/src/utils/getAvailableShopInventory.test.ts
+++ b/src/utils/getAvailableShopInventory.test.ts
@@ -1,4 +1,4 @@
-import { scarecrow } from '../data/items.js'
+import { cowFeed, huggingMachine, scarecrow } from '../data/items.js'
 
 import { getAvailableShopInventory } from './getAvailableShopInventory.js'
 
@@ -11,6 +11,6 @@ describe('getAvailableShopInventory', () => {
         tools: {},
         stageFocusType: {},
       } as any)
-    ).toEqual([scarecrow])
+    ).toEqual([scarecrow, cowFeed, huggingMachine])
   })
 })


### PR DESCRIPTION
### What this PR does

Cow Feed and the Hugging Machine were previously only purchasable from the CowPen screen's own Supplies tab (backed by `src/data/shop-inventory-cow.ts`). This adds both items to the main `src/data/shop-inventory.ts` list, so they now also appear in the main Shop's Supplies tab. Both purchase locations remain available - the CowPen's own Supplies tab is unchanged.

No new category logic was needed: `Shop.tsx`'s `getShopCategory` already buckets anything that isn't a crop or a plantable tree into the "Supplies" tab, and neither item is level-gated in `levels.ts`, so they show up unconditionally, matching their existing CowPen behavior.

Closes #191

### How this change can be validated

- Unit: `npx vitest run src/utils/getAvailableShopInventory.test.ts src/components/Shop src/components/CowPenContextMenu`
- Types/lint: `npm run check:types`, `npm run lint`
- e2e: `npx playwright test e2e/tests/cow-pen/cow-pen.test.ts` (new test: "should be able to buy Cow Feed directly from the Shop's Supplies tab")
- Manual: `npm start`, open Shop, go to Supplies tab, confirm Cow Feed and Hugging Machine are listed and purchasable, and that the CowPen's own Supplies tab still works as before.

### Questions or concerns about this change

None.

### Additional information

https://github.com/user-attachments/assets/3f708122-3269-4654-9146-55d7af65cdde

