### PR TITLE
fix: restore gap between cow bloodline circles

### DIFF
--- a/src/components/CowCard/Bloodline/Bloodline.tsx
+++ b/src/components/CowCard/Bloodline/Bloodline.tsx
@@ -13,7 +13,7 @@ const Bloodline = ({
 }: {
   colorsInBloodline: Partial<Record<farmhand.cowColors, boolean>>
 }) => (
-  <Ul className="Bloodline" sx={{ display: 'flex', margin: '1em 0' }}>
+  <Ul className="Bloodline" sx={{ display: 'flex', gap: '0.5em', margin: '1em 0' }}>
     {Object.keys(colorsInBloodline)
       .sort()
       .map(color => (
@@ -35,7 +35,6 @@ const Bloodline = ({
               height: dotSize,
               width: dotSize,
               marginBottom: 0,
-              marginRight: '0.5em',
               marginTop: 0,
             }}
           />


### PR DESCRIPTION
Fixes a visual regression in the cow bloodline display where the spacing between the color circles was lost. The fix shifts the spacing responsibility from child `marginRight` to a parent `gap: 0.5em` in the `Ul` flex container.

---
*PR created automatically by Jules for task [16517274547305070480](https://jules.google.com/task/16517274547305070480) started by @jeremyckahn*