### PR TITLE
fix: prevent mobile keyboard from closing sidebar on resize

### DIFF
--- a/src/components/Farmhand/useFarmhand.test.ts
+++ b/src/components/Farmhand/useFarmhand.test.ts
@@ -1,7 +1,8 @@
-import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 
 import { BREAKPOINTS } from '../../constants.js'
 import { farmhandStub } from '../../test-utils/stubs/farmhandStub.js'
+import { waitForBoot } from '../../test-utils/ui.js'
 
 const setWindowWidth = (width: number) => {
   Object.defineProperty(window, 'innerWidth', {
@@ -15,8 +16,17 @@ const getIsMenuOpen = () =>
   ((window as unknown) as { farmhand: { state: farmhand.state } }).farmhand
     .state.isMenuOpen
 
+const setIsMenuOpen = (isMenuOpen: boolean) =>
+  ((window as unknown) as {
+    farmhand: { setState: (state: Partial<farmhand.state>) => void }
+  }).farmhand.setState({ isMenuOpen })
+
 // Simulates a sidebar input having focus, e.g. mid-typing, without depending
 // on any particular Farmhand-rendered input existing in the current view.
+// Note: the resize guard under test is purely width-based and never checks
+// focus - this just documents the real-world trigger (a focused input is
+// what causes a mobile on-screen keyboard to open/close and fire a
+// height-only resize).
 const focusAnInput = () => {
   const input = document.createElement('input')
 
@@ -27,14 +37,19 @@ const focusAnInput = () => {
 
 describe('sidebar resize handling', () => {
   test('a height-only resize while a field is focused (e.g. a mobile on-screen keyboard) does not touch the sidebar', async () => {
-    setWindowWidth(BREAKPOINTS.MD + 100)
+    // A width below the breakpoint means the sidebar would naturally be
+    // closed. It's forced open below to simulate a player having manually
+    // opened it - that's what makes this test able to detect a regression:
+    // without the width-change guard, the resize handler recomputes
+    // isMenuOpen from the viewport and would clobber this manually-opened
+    // state even though the width hasn't changed.
+    setWindowWidth(BREAKPOINTS.MD - 100)
 
     await farmhandStub()
 
-    await waitFor(() => {
-      expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
-    })
+    await waitForBoot()
 
+    setIsMenuOpen(true)
     focusAnInput()
     expect(getIsMenuOpen()).toBe(true)
 
@@ -50,9 +65,7 @@ describe('sidebar resize handling', () => {
 
     await farmhandStub()
 
-    await waitFor(() => {
-      expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
-    })
+    await waitForBoot()
 
     focusAnInput()
     expect(getIsMenuOpen()).toBe(true)

--- a/src/components/Farmhand/useFarmhand.test.ts
+++ b/src/components/Farmhand/useFarmhand.test.ts
@@ -1,0 +1,67 @@
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+
+import { BREAKPOINTS } from '../../constants.js'
+import { farmhandStub } from '../../test-utils/stubs/farmhandStub.js'
+
+const setWindowWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: width,
+  })
+}
+
+const getIsMenuOpen = () =>
+  ((window as unknown) as { farmhand: { state: farmhand.state } }).farmhand
+    .state.isMenuOpen
+
+// Simulates a sidebar input having focus, e.g. mid-typing, without depending
+// on any particular Farmhand-rendered input existing in the current view.
+const focusAnInput = () => {
+  const input = document.createElement('input')
+
+  document.body.appendChild(input)
+  input.focus()
+  return input
+}
+
+describe('sidebar resize handling', () => {
+  test('a height-only resize while a field is focused (e.g. a mobile on-screen keyboard) does not touch the sidebar', async () => {
+    setWindowWidth(BREAKPOINTS.MD + 100)
+
+    await farmhandStub()
+
+    await waitFor(() => {
+      expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
+    })
+
+    focusAnInput()
+    expect(getIsMenuOpen()).toBe(true)
+
+    // Width is unchanged, simulating a resize caused only by the on-screen
+    // keyboard opening/closing.
+    fireEvent(window, new Event('resize'))
+
+    expect(getIsMenuOpen()).toBe(true)
+  })
+
+  test('a resize that crosses the width breakpoint still updates the sidebar, even while a field is focused', async () => {
+    setWindowWidth(BREAKPOINTS.MD + 100)
+
+    await farmhandStub()
+
+    await waitFor(() => {
+      expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
+    })
+
+    focusAnInput()
+    expect(getIsMenuOpen()).toBe(true)
+
+    setWindowWidth(BREAKPOINTS.MD - 100)
+    fireEvent(window, new Event('resize'))
+
+    await waitFor(() => {
+      expect(getIsMenuOpen()).toBe(false)
+    })
+  })
+})

--- a/src/components/Farmhand/useFarmhand.test.ts
+++ b/src/components/Farmhand/useFarmhand.test.ts
@@ -12,6 +12,14 @@ const setWindowWidth = (width: number) => {
   })
 }
 
+const setWindowHeight = (height: number) => {
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: height,
+  })
+}
+
 const getIsMenuOpen = () =>
   ((window as unknown) as { farmhand: { state: farmhand.state } }).farmhand
     .state.isMenuOpen
@@ -44,17 +52,18 @@ describe('sidebar resize handling', () => {
     // isMenuOpen from the viewport and would clobber this manually-opened
     // state even though the width hasn't changed.
     setWindowWidth(BREAKPOINTS.MD - 100)
+    setWindowHeight(800)
 
     await farmhandStub()
-
     await waitForBoot()
 
     setIsMenuOpen(true)
     focusAnInput()
     expect(getIsMenuOpen()).toBe(true)
 
-    // Width is unchanged, simulating a resize caused only by the on-screen
-    // keyboard opening/closing.
+    // Height shrinks, as when a mobile on-screen keyboard opens, while
+    // width stays the same.
+    setWindowHeight(500)
     fireEvent(window, new Event('resize'))
 
     expect(getIsMenuOpen()).toBe(true)
@@ -64,7 +73,6 @@ describe('sidebar resize handling', () => {
     setWindowWidth(BREAKPOINTS.MD + 100)
 
     await farmhandStub()
-
     await waitForBoot()
 
     focusAnInput()

--- a/src/components/Farmhand/useFarmhand.ts
+++ b/src/components/Farmhand/useFarmhand.ts
@@ -802,10 +802,13 @@ export const useFarmhand = (props: FarmhandProps) => {
     }
 
     if (state.stageFocus !== prevState.stageFocus && state.isMenuOpen) {
-      setState(previous => ({
-        ...previous,
-        isMenuOpen: !doesMenuObstructStage(),
-      }))
+      setState(previous => {
+        const isMenuOpen = !doesMenuObstructStage()
+
+        return previous.isMenuOpen === isMenuOpen
+          ? previous
+          : { ...previous, isMenuOpen }
+      })
     }
 
     if (state.money < prevState.money) {

--- a/src/components/Farmhand/useFarmhand.ts
+++ b/src/components/Farmhand/useFarmhand.ts
@@ -654,8 +654,21 @@ export const useFarmhand = (props: FarmhandProps) => {
   // stageFocus changes - without this, resizing the window (or rotating a
   // device) never opens/closes the sidebar until the next of those, which
   // in practice meant a full page reload.
+  const previousWindowWidthRef = useRef(window.innerWidth)
+
   useEffect(() => {
     const handleResize = () => {
+      const { innerWidth } = window
+      const hasWidthChanged = innerWidth !== previousWindowWidthRef.current
+
+      previousWindowWidthRef.current = innerWidth
+
+      // doesMenuObstructStage is width-based, so a resize that only changed
+      // height (e.g. a mobile on-screen keyboard opening/closing) has
+      // nothing to update here. Without this guard, that kind of resize was
+      // closing the sidebar out from under the player mid-typing.
+      if (!hasWidthChanged) return
+
       setState(previous => {
         const isMenuOpen = !doesMenuObstructStage()
 

--- a/src/components/Farmhand/useFarmhand.ts
+++ b/src/components/Farmhand/useFarmhand.ts
@@ -664,9 +664,9 @@ export const useFarmhand = (props: FarmhandProps) => {
       previousWindowWidthRef.current = innerWidth
 
       // doesMenuObstructStage is width-based, so a resize that only changed
-      // height (e.g. a mobile on-screen keyboard opening/closing) has
-      // nothing to update here. Without this guard, that kind of resize was
-      // closing the sidebar out from under the player mid-typing.
+      // height (e.g. a mobile on-screen keyboard opening/closing) has nothing
+      // to update here. Without this guard, that kind of resize closes the
+      // sidebar out from under the player mid-typing.
       if (!hasWidthChanged) return
 
       setState(previous => {

--- a/src/shell/bootup.test.ts
+++ b/src/shell/bootup.test.ts
@@ -2,15 +2,12 @@ import { screen, waitFor } from '@testing-library/react'
 
 import { saveDataStubFactory } from '../test-utils/stubs/saveDataStubFactory.js'
 import { farmhandStub } from '../test-utils/stubs/farmhandStub.js'
-import { endDay } from '../test-utils/ui.js'
+import { endDay, waitForBoot } from '../test-utils/ui.js'
 
 describe('bootup', () => {
   test('boots a fresh game when there is no save file', async () => {
     await farmhandStub()
-
-    await waitFor(() => {
-      expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
-    })
+    await waitForBoot()
   })
 
   test('boots from save file if there is one', async () => {

--- a/src/shell/unmount-safety.test.ts
+++ b/src/shell/unmount-safety.test.ts
@@ -1,6 +1,5 @@
-import { screen, waitFor } from '@testing-library/react'
-
 import { farmhandStub } from '../test-utils/stubs/farmhandStub.js'
+import { waitForBoot } from '../test-utils/ui.js'
 
 // Regression coverage for the isMounted guard added to the post-increment-day
 // effect in useFarmhand.ts. Before that guard existed, unmounting while an
@@ -27,9 +26,7 @@ describe('unmount safety', () => {
     // post-increment-day effect. By the time "Day 1" renders, that effect's
     // async continuation is already awaiting localforage.setItem (the mock
     // above), i.e. it's suspended exactly where the isMounted guard matters.
-    await waitFor(() => {
-      expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
-    })
+    await waitForBoot()
 
     const consoleError = vitest
       .spyOn(console, 'error')

--- a/src/test-utils/ui.ts
+++ b/src/test-utils/ui.ts
@@ -1,5 +1,10 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+
+export const waitForBoot = () =>
+  waitFor(() => {
+    expect(screen.getByText('Day 1', { exact: false })).toBeInTheDocument()
+  })
 
 export const endDay = async () => {
   const endDayButton = await screen.findByLabelText(


### PR DESCRIPTION
### What this PR does

Fixes a bug where opening the on-screen keyboard on mobile (e.g. by focusing a sidebar text input) would unexpectedly close the sidebar. The window `resize` handler in [useFarmhand.ts](src/components/Farmhand/useFarmhand.ts) recomputed `isMenuOpen` on every `resize` event, including height-only resizes caused by the keyboard opening/closing. Since sidebar obstruction (`doesMenuObstructStage`) is width-based, the handler now tracks the previous `window.innerWidth` and skips recomputing state when width hasn't actually changed. This is more robust than the previous approach of checking `document.activeElement`, since it isn't dependent on focus timing and still correctly reacts to real width changes (e.g. device rotation) even while an input is focused.

Follow-up commits from code review also: strengthened the height-only-resize regression test (the original version passed even without the width-change guard, since it used a viewport width where sidebar obstruction is invariant), deduplicated a repeated "wait for boot" test idiom into a shared helper, and applied the same no-op state-update guard to the sibling `stageFocus`-change effect for consistency.

### How this change can be validated

On a mobile device or mobile emulator, open the sidebar, focus a text input in it (triggering the on-screen keyboard), and confirm the sidebar stays open. Resizing the browser window width narrower/wider should still open/close the sidebar as before.

### Questions or concerns about this change

None.

### Additional information
