### PR TITLE
refactor(cowpen): convert Cow class component to a function component

### DIFF
--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography/index.js'
 import classNames from 'classnames'
 import { useCallback, useEffect, useState } from 'react'
 import { TweenState, Tweenable } from 'shifty'
+import { useIsMounted } from 'usehooks-ts'
 
 import { random } from '../../common/utils.js'
 import { LEFT, RIGHT } from '../../constants.js'
@@ -56,6 +57,7 @@ export const Cow = ({
   const [prevHappinessBoostsToday, setPrevHappinessBoostsToday] = useState(
     cow.happinessBoostsToday
   )
+  const isMounted = useIsMounted()
   const { x, y } = position
 
   const move = useCallback(
@@ -134,17 +136,13 @@ export const Cow = ({
 
   // Loads the cow's image on mount.
   useEffect(() => {
-    let isUnmounted = false
+    ;(async () => {
+      const loadedCowImage = await getCowImage(cow)
 
-    void getCowImage(cow).then(loadedCowImage => {
-      if (!isUnmounted) {
-        setCowImage(loadedCowImage)
-      }
-    })
+      if (isMounted() === false) return
 
-    return () => {
-      isUnmounted = true
-    }
+      setCowImage(loadedCowImage)
+    })()
     // Mount-only effect (the function-component equivalent of
     // `componentDidMount`): it must run exactly once, so `cow` is
     // intentionally omitted from the dependency array.

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Tooltip from '@mui/material/Tooltip/index.js'
 import Typography from '@mui/material/Typography/index.js'
 import classNames from 'classnames'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Tweenable } from 'shifty'
 
 import { random } from '../../common/utils.js'
@@ -21,6 +21,10 @@ const transitionAnimationDuration = 3000
 // This MUST be kept in sync with the `animationDuration` of the `.is-animating`
 // rule in CowPen.tsx.
 const hugAnimationDuration = 750
+
+type CowPosition = { x: number; y: number }
+
+type CowMoveDirection = typeof LEFT | typeof RIGHT
 
 export interface CowProps {
   allowCustomPeerCowNames: boolean
@@ -41,204 +45,174 @@ export const Cow = ({
 }: CowProps) => {
   const [cowImage, setCowImage] = useState(pixel)
   const [isTransitioning, setIsTransitioning] = useState(false)
-  const [moveDirection, setMoveDirection] = useState(RIGHT)
+  const [moveDirection, setMoveDirection] = useState<CowMoveDirection>(RIGHT)
   const [rotate, setRotate] = useState(0)
   const [showHugAnimation, setShowHugAnimation] = useState(false)
-  const [position, setPosition] = useState(() => ({
+  const [position, setPosition] = useState<CowPosition>(() => ({
     x: randomPosition(),
     y: randomPosition(),
   }))
+  const [tweenable] = useState(() => new Tweenable())
+  const [prevHappinessBoostsToday, setPrevHappinessBoostsToday] = useState(
+    cow.happinessBoostsToday
+  )
   const { x, y } = position
 
-  const isComponentMountedRef = useRef(false)
-  const repositionTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  )
-  const animateHugTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  )
-  const tweenableRef = useRef<Tweenable | null>(null)
-  const prevIsSelectedRef = useRef(isSelected)
-  const prevHappinessBoostsTodayRef = useRef(cow.happinessBoostsToday)
-  const cowInventoryRef = useRef(cowInventory)
-  const isSelectedRef = useRef(isSelected)
-  const positionRef = useRef(position)
-  const moveDirectionRef = useRef(moveDirection)
-  const scheduleMoveRef = useRef<() => void>(() => {})
+  const move = useCallback(
+    async (from: CowPosition, fromDirection: CowMoveDirection) => {
+      const newX = randomPosition()
+      const newY = randomPosition()
+      const newDirection = newX < from.x ? LEFT : RIGHT
 
-  cowInventoryRef.current = cowInventory
-  isSelectedRef.current = isSelected
-  positionRef.current = position
-  moveDirectionRef.current = moveDirection
-
-  if (tweenableRef.current === null) {
-    tweenableRef.current = new Tweenable()
-  }
-
-  const tweenable = tweenableRef.current
-
-  const move = useCallback(async () => {
-    const newX = randomPosition()
-
-    const oldDirection = moveDirectionRef.current
-    const oldX = positionRef.current.x
-    const oldY = positionRef.current.y
-    const newDirection = newX < oldX ? LEFT : RIGHT
-
-    if (isComponentMountedRef.current) {
       setMoveDirection(newDirection)
-    }
 
-    if (oldDirection !== newDirection) {
-      const render = (tweenState: { rotate?: number | string }) => {
-        if (isComponentMountedRef.current) {
+      if (fromDirection !== newDirection) {
+        const render = (tweenState: { rotate?: number | string }) => {
           setRotate(tweenState.rotate as number)
+        }
+
+        try {
+          const duration = flipAnimationDuration
+          const easing = 'swingTo'
+
+          if (newDirection === LEFT) {
+            await tweenable.tween({
+              from: {
+                rotate: 0,
+              },
+              to: {
+                rotate: 180,
+              },
+              easing,
+              duration,
+              render,
+            })
+          } else {
+            await tweenable.tween({
+              from: {
+                rotate: 180,
+              },
+              to: {
+                rotate: 0,
+              },
+              easing,
+              duration,
+              render,
+            })
+          }
+        } catch {
+          // The tween was cancelled by the component unmounting
+          return
         }
       }
 
-      try {
-        const duration = flipAnimationDuration
-        const easing = 'swingTo'
+      setIsTransitioning(true)
 
-        if (newDirection === LEFT) {
-          await tweenable.tween({
-            from: {
-              rotate: 0,
-            },
-            to: {
-              rotate: 180,
-            },
-            easing,
-            duration,
-            render,
-          })
-        } else {
-          await tweenable.tween({
-            from: {
-              rotate: 180,
-            },
-            to: {
-              rotate: 0,
-            },
-            easing,
-            duration,
-            render,
-          })
-        }
-      } catch (e) {
+      try {
+        await tweenable.tween({
+          from: { x: from.x, y: from.y },
+          to: { x: newX, y: newY },
+          duration: transitionAnimationDuration,
+          render: ({ x: newXValue, y: newYValue }: any) => {
+            setPosition({ x: newXValue, y: newYValue })
+          },
+          easing: 'linear',
+        })
+      } catch {
         // The tween was cancelled by the component unmounting
         return
       }
-    }
 
-    if (isComponentMountedRef.current) {
-      setIsTransitioning(true)
-    }
-
-    try {
-      await tweenable.tween({
-        from: { x: oldX, y: oldY },
-        to: { x: newX, y: randomPosition() },
-        duration: transitionAnimationDuration,
-        render: ({ x: newXValue, y: newYValue }: any) => {
-          if (isComponentMountedRef.current) {
-            setPosition({ x: newXValue, y: newYValue })
-          }
-        },
-        easing: 'linear',
-      })
-    } catch (e) {
-      // The tween was cancelled by the component unmounting
-      return
-    }
-
-    if (isComponentMountedRef.current) {
       setIsTransitioning(false)
-    }
+      // The next move is scheduled by the movement effect below, which
+      // re-runs when `isTransitioning` flips back to false.
+    },
+    [tweenable]
+  )
 
-    scheduleMoveRef.current()
-  }, [tweenable])
-
-  const repositionTimeoutHandler = useCallback(() => {
-    repositionTimeoutIdRef.current = null
-
-    move()
-  }, [move])
-
-  const scheduleMove = useCallback(() => {
-    if (isSelectedRef.current) {
-      return
-    }
-
-    const waitVariance = 2000 * cowInventoryRef.current.length
-
-    repositionTimeoutIdRef.current = setTimeout(
-      repositionTimeoutHandler,
-      random() * waitVariance
-    )
-  }, [repositionTimeoutHandler])
-
-  scheduleMoveRef.current = scheduleMove
-
+  // Loads the cow's image on mount.
   useEffect(() => {
-    if (
-      isSelected &&
-      !prevIsSelectedRef.current &&
-      repositionTimeoutIdRef.current !== null
-    ) {
-      clearTimeout(repositionTimeoutIdRef.current)
-    }
+    let isUnmounted = false
 
-    if (!isSelected && prevIsSelectedRef.current) {
-      scheduleMove()
-    }
-
-    prevIsSelectedRef.current = isSelected
-  }, [isSelected, scheduleMove])
-
-  useEffect(() => {
-    if (
-      cow.happinessBoostsToday > prevHappinessBoostsTodayRef.current &&
-      !showHugAnimation
-    ) {
-      setShowHugAnimation(true)
-
-      animateHugTimeoutIdRef.current = setTimeout(() => {
-        if (isComponentMountedRef.current) {
-          setShowHugAnimation(false)
-        }
-      }, hugAnimationDuration)
-    }
-
-    prevHappinessBoostsTodayRef.current = cow.happinessBoostsToday
-  }, [cow.happinessBoostsToday, showHugAnimation])
-
-  useEffect(() => {
-    isComponentMountedRef.current = true
-
-    scheduleMove()
-    ;(async () => {
-      const loadedCowImage = await getCowImage(cow)
-
-      if (!isComponentMountedRef.current) return
-
-      setCowImage(loadedCowImage)
-    })()
+    void getCowImage(cow).then(loadedCowImage => {
+      if (!isUnmounted) {
+        setCowImage(loadedCowImage)
+      }
+    })
 
     return () => {
-      ;[repositionTimeoutIdRef.current, animateHugTimeoutIdRef.current].forEach(
-        id => typeof id === 'number' && clearTimeout(id)
-      )
-
-      isComponentMountedRef.current = false
-
-      tweenableRef.current?.cancel()
+      isUnmounted = true
     }
     // Mount-only effect (the function-component equivalent of
-    // componentDidMount): it must run exactly once, so `cow` and `scheduleMove`
-    // are intentionally omitted from the dependency array.
+    // `componentDidMount`): it must run exactly once, so `cow` is
+    // intentionally omitted from the dependency array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Cancels any in-flight tween on unmount; `move` handles the resulting
+  // rejection in its `catch` blocks.
+  useEffect(() => {
+    return () => {
+      tweenable.cancel()
+    }
+  }, [tweenable])
+
+  // The cow walks whenever it is stationary and not selected. This effect
+  // runs on mount, whenever `isSelected` changes, and whenever a move
+  // completes (`isTransitioning` flipping back to false), and its cleanup
+  // cancels the pending move whenever the cow gets selected or unmounted.
+  // At most one move is ever in flight: a move can only start from the
+  // timer this effect sets, and no timer is pending while a move is
+  // in flight.
+  useEffect(() => {
+    if (isSelected || isTransitioning) {
+      return
+    }
+
+    const waitVariance = 2000 * cowInventory.length
+
+    const repositionTimeoutId = setTimeout(() => {
+      void move(position, moveDirection)
+    }, random() * waitVariance)
+
+    return () => {
+      clearTimeout(repositionTimeoutId)
+    }
+    // `position` and `moveDirection` are intentionally omitted: they only
+    // ever change while a move is in flight, at which point this effect
+    // early-returns and no timer is pending, so the closure values are
+    // always current whenever a timer is actually set.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSelected, isTransitioning, cowInventory.length, move])
+
+  // Shows the hug animation whenever `happinessBoostsToday` increases.
+  useEffect(() => {
+    if (cow.happinessBoostsToday <= prevHappinessBoostsToday) {
+      return
+    }
+
+    setPrevHappinessBoostsToday(cow.happinessBoostsToday)
+
+    if (showHugAnimation) {
+      return
+    }
+
+    setShowHugAnimation(true)
+  }, [cow.happinessBoostsToday, prevHappinessBoostsToday, showHugAnimation])
+
+  useEffect(() => {
+    if (!showHugAnimation) {
+      return
+    }
+
+    const animateHugTimeoutId = setTimeout(() => {
+      setShowHugAnimation(false)
+    }, hugAnimationDuration)
+
+    return () => {
+      clearTimeout(animateHugTimeoutId)
+    }
+  }, [showHugAnimation])
 
   const cowDisplayName = getCowDisplayName(
     cow,

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Tooltip from '@mui/material/Tooltip/index.js'
 import Typography from '@mui/material/Typography/index.js'
 import classNames from 'classnames'
-import React, { Component } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Tweenable } from 'shifty'
 
 import { random } from '../../common/utils.js'
@@ -15,6 +15,12 @@ import { getCowImage } from '../../utils/getCowImage.js'
 // Only moves the cow within the middle 80% of the pen
 const randomPosition = () => 10 + random() * 80
 
+const flipAnimationDuration = 1000
+const transitionAnimationDuration = 3000
+
+// This MUST be kept in sync with $hug-animation-duration in CowPen.sass.
+const hugAnimationDuration = 750
+
 export interface CowProps {
   allowCustomPeerCowNames: boolean
   cow: farmhand.cow
@@ -24,85 +30,76 @@ export interface CowProps {
   isSelected: boolean
 }
 
-export class Cow extends Component<CowProps> {
-  state = {
-    cowImage: pixel,
-    isTransitioning: false,
-    moveDirection: RIGHT,
-    rotate: 0,
-    showHugAnimation: false,
+export const Cow = ({
+  allowCustomPeerCowNames,
+  cow,
+  cowInventory,
+  handleCowClick,
+  playerId,
+  isSelected,
+}: CowProps) => {
+  const [cowImage, setCowImage] = useState(pixel)
+  const [isTransitioning, setIsTransitioning] = useState(false)
+  const [moveDirection, setMoveDirection] = useState(RIGHT)
+  const [rotate, setRotate] = useState(0)
+  const [showHugAnimation, setShowHugAnimation] = useState(false)
+  const [position, setPosition] = useState(() => ({
     x: randomPosition(),
     y: randomPosition(),
+  }))
+  const { x, y } = position
+
+  const isComponentMountedRef = useRef(false)
+  const repositionTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+  const animateHugTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+  const tweenableRef = useRef<Tweenable | null>(null)
+  const prevIsSelectedRef = useRef(isSelected)
+  const prevHappinessBoostsTodayRef = useRef(cow.happinessBoostsToday)
+  const cowInventoryRef = useRef(cowInventory)
+  const isSelectedRef = useRef(isSelected)
+  const positionRef = useRef(position)
+  const moveDirectionRef = useRef(moveDirection)
+
+  cowInventoryRef.current = cowInventory
+  isSelectedRef.current = isSelected
+  positionRef.current = position
+  moveDirectionRef.current = moveDirection
+
+  if (tweenableRef.current === null) {
+    tweenableRef.current = new Tweenable()
   }
 
-  repositionTimeoutId: number | NodeJS.Timeout | null = null
-  animateHugTimeoutId: number | NodeJS.Timeout | null = null
-  tweenable = new Tweenable()
-  isComponentMounted = false
+  const tweenable = tweenableRef.current
 
-  static flipAnimationDuration = 1000
-  static transitionAnimationDuration = 3000
-
-  // This MUST be kept in sync with $hug-animation-duration in CowPen.sass.
-  static hugAnimationDuration = 750
-
-  get waitVariance() {
-    return 2000 * this.props.cowInventory.length
-  }
-
-  componentDidUpdate(prevProps: CowProps) {
-    if (
-      this.props.isSelected &&
-      !prevProps.isSelected &&
-      this.repositionTimeoutId !== null
-    ) {
-      clearTimeout(this.repositionTimeoutId)
-    }
-
-    if (!this.props.isSelected && prevProps.isSelected) {
-      this.scheduleMove()
-    }
-
-    if (
-      this.props.cow.happinessBoostsToday >
-        prevProps.cow.happinessBoostsToday &&
-      !this.state.showHugAnimation
-    ) {
-      this.setState({ showHugAnimation: true })
-
-      this.animateHugTimeoutId = setTimeout(() => {
-        if (this.isComponentMounted) {
-          this.setState({ showHugAnimation: false })
-        }
-      }, Cow.hugAnimationDuration)
-    }
-  }
-
-  move = async () => {
+  const move = async () => {
     const newX = randomPosition()
 
-    const { moveDirection: oldDirection, x, y } = this.state
-    const newDirection = newX < this.state.x ? LEFT : RIGHT
+    const oldDirection = moveDirectionRef.current
+    const oldX = positionRef.current.x
+    const oldY = positionRef.current.y
+    const newDirection = newX < oldX ? LEFT : RIGHT
 
-    if (this.isComponentMounted) {
-      this.setState({
-        moveDirection: newDirection,
-      })
+    if (isComponentMountedRef.current) {
+      setMoveDirection(newDirection)
     }
 
     if (oldDirection !== newDirection) {
-      const render = ({ rotate }: { rotate?: number | string }) => {
-        if (this.isComponentMounted) {
-          this.setState({ rotate })
+      const render = (tweenState: { rotate?: number | string }) => {
+        if (isComponentMountedRef.current) {
+          setRotate(tweenState.rotate as number)
         }
       }
 
       try {
-        const duration = Cow.flipAnimationDuration
+        const duration = flipAnimationDuration
         const easing = 'swingTo'
 
         if (newDirection === LEFT) {
-          await this.tweenable.tween({
+          await tweenable.tween({
             from: {
               rotate: 0,
             },
@@ -114,7 +111,7 @@ export class Cow extends Component<CowProps> {
             render,
           })
         } else {
-          await this.tweenable.tween({
+          await tweenable.tween({
             from: {
               rotate: 180,
             },
@@ -132,20 +129,18 @@ export class Cow extends Component<CowProps> {
       }
     }
 
-    if (this.isComponentMounted) {
-      this.setState({
-        isTransitioning: true,
-      })
+    if (isComponentMountedRef.current) {
+      setIsTransitioning(true)
     }
 
     try {
-      await this.tweenable.tween({
-        from: { x, y },
+      await tweenable.tween({
+        from: { x: oldX, y: oldY },
         to: { x: newX, y: randomPosition() },
-        duration: Cow.transitionAnimationDuration,
+        duration: transitionAnimationDuration,
         render: ({ x: newXValue, y: newYValue }: any) => {
-          if (this.isComponentMounted) {
-            this.setState({ x: newXValue, y: newYValue })
+          if (isComponentMountedRef.current) {
+            setPosition({ x: newXValue, y: newYValue })
           }
         },
         easing: 'linear',
@@ -155,125 +150,151 @@ export class Cow extends Component<CowProps> {
       return
     }
 
-    if (this.isComponentMounted) {
-      this.setState({ isTransitioning: false })
+    if (isComponentMountedRef.current) {
+      setIsTransitioning(false)
     }
-    this.scheduleMove()
+
+    scheduleMove()
   }
 
-  repositionTimeoutHandler = () => {
-    this.repositionTimeoutId = null
-    this.move()
+  const repositionTimeoutHandler = () => {
+    repositionTimeoutIdRef.current = null
+
+    move()
   }
 
-  scheduleMove = () => {
-    if (this.props.isSelected) {
+  const scheduleMove = () => {
+    if (isSelectedRef.current) {
       return
     }
 
-    this.repositionTimeoutId = setTimeout(
-      this.repositionTimeoutHandler,
-      random() * this.waitVariance
+    const waitVariance = 2000 * cowInventoryRef.current.length
+
+    repositionTimeoutIdRef.current = setTimeout(
+      repositionTimeoutHandler,
+      random() * waitVariance
     )
   }
 
-  componentDidMount() {
-    this.isComponentMounted = true
-    this.scheduleMove()
+  useEffect(() => {
+    if (
+      isSelected &&
+      !prevIsSelectedRef.current &&
+      repositionTimeoutIdRef.current !== null
+    ) {
+      clearTimeout(repositionTimeoutIdRef.current)
+    }
+
+    if (!isSelected && prevIsSelectedRef.current) {
+      scheduleMove()
+    }
+
+    prevIsSelectedRef.current = isSelected
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSelected])
+
+  useEffect(() => {
+    if (
+      cow.happinessBoostsToday > prevHappinessBoostsTodayRef.current &&
+      !showHugAnimation
+    ) {
+      setShowHugAnimation(true)
+
+      animateHugTimeoutIdRef.current = setTimeout(() => {
+        if (isComponentMountedRef.current) {
+          setShowHugAnimation(false)
+        }
+      }, hugAnimationDuration)
+    }
+
+    prevHappinessBoostsTodayRef.current = cow.happinessBoostsToday
+  }, [cow.happinessBoostsToday, showHugAnimation])
+
+  useEffect(() => {
+    isComponentMountedRef.current = true
+
+    scheduleMove()
     ;(async () => {
-      const cowImage = await getCowImage(this.props.cow)
+      const loadedCowImage = await getCowImage(cow)
 
-      if (!this.isComponentMounted) return
+      if (!isComponentMountedRef.current) return
 
-      this.setState({ cowImage: cowImage })
+      setCowImage(loadedCowImage)
     })()
-  }
 
-  componentWillUnmount() {
-    ;[this.repositionTimeoutId, this.animateHugTimeoutId].forEach(
-      id => typeof id === 'number' && clearTimeout(id)
-    )
+    return () => {
+      ;[repositionTimeoutIdRef.current, animateHugTimeoutIdRef.current].forEach(
+        id => typeof id === 'number' && clearTimeout(id)
+      )
 
-    this.isComponentMounted = false
-    this.tweenable.cancel()
-  }
+      isComponentMountedRef.current = false
 
-  render() {
-    const {
-      props: {
-        allowCustomPeerCowNames,
-        cow,
-        handleCowClick,
-        playerId,
-        isSelected,
-      },
-      state: { cowImage, isTransitioning, rotate, showHugAnimation, x, y },
-    } = this
+      tweenableRef.current?.cancel()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-    const cowDisplayName = getCowDisplayName(
-      cow,
-      playerId,
-      allowCustomPeerCowNames
-    )
+  const cowDisplayName = getCowDisplayName(
+    cow,
+    playerId,
+    allowCustomPeerCowNames
+  )
 
-    return (
-      <div
-        className={classNames('cow', {
-          'is-transitioning': isTransitioning,
-          'is-selected': isSelected,
-          'is-loaded': cowImage !== pixel,
-        })}
-        onClick={() => handleCowClick(cow)}
-        style={{
-          left: `${x}%`,
-          top: `${y}%`,
+  return (
+    <div
+      className={classNames('cow', {
+        'is-transitioning': isTransitioning,
+        'is-selected': isSelected,
+        'is-loaded': cowImage !== pixel,
+      })}
+      onClick={() => handleCowClick(cow)}
+      style={{
+        left: `${x}%`,
+        top: `${y}%`,
+      }}
+    >
+      {isSelected && (
+        <p className="visually_hidden">{cowDisplayName} is selected</p>
+      )}
+      <Tooltip
+        {...{
+          arrow: true,
+          placement: 'top',
+          title: <Typography>{cowDisplayName}</Typography>,
+          open: isSelected,
+          PopperProps: {
+            disablePortal: true,
+          },
         }}
       >
-        {isSelected && (
-          <p className="visually_hidden">{cowDisplayName} is selected</p>
-        )}
-        <Tooltip
-          {...{
-            arrow: true,
-            placement: 'top',
-            title: <Typography>{cowDisplayName}</Typography>,
-            open: isSelected,
-            PopperProps: {
-              disablePortal: true,
-            },
-          }}
-        >
-          <div {...{ style: { transform: `rotateY(${rotate}deg)` } }}>
-            <img
-              {...{
-                src: cowImage,
-              }}
-              alt={cowDisplayName}
-            />
+        <div {...{ style: { transform: `rotateY(${rotate}deg)` } }}>
+          <img
+            {...{
+              src: cowImage,
+            }}
+            alt={cowDisplayName}
+          />
+          <FontAwesomeIcon
+            {...{
+              className: classNames('animation', {
+                'is-animating': showHugAnimation,
+              }),
+              icon: faHeart,
+            }}
+          />
+        </div>
+      </Tooltip>
+      <ol {...{ className: 'happiness-boosts-today' }}>
+        {new Array(cow.happinessBoostsToday).fill(undefined).map((_, i) => (
+          <li {...{ key: i }}>
             <FontAwesomeIcon
               {...{
-                className: classNames('animation', {
-                  'is-animating': showHugAnimation,
-                }),
                 icon: faHeart,
               }}
             />
-          </div>
-        </Tooltip>
-        <ol {...{ className: 'happiness-boosts-today' }}>
-          {new Array(this.props.cow.happinessBoostsToday)
-            .fill(undefined)
-            .map((_, i) => (
-              <li {...{ key: i }}>
-                <FontAwesomeIcon
-                  {...{
-                    icon: faHeart,
-                  }}
-                />
-              </li>
-            ))}
-        </ol>
-      </div>
-    )
-  }
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
 }

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -63,7 +63,6 @@ export const Cow = ({
   const move = useCallback(
     async (from: CowPosition, fromDirection: CowMoveDirection) => {
       const newX = randomPosition()
-      const newY = randomPosition()
       const newDirection = newX < from.x ? LEFT : RIGHT
 
       setMoveDirection(newDirection)
@@ -113,12 +112,23 @@ export const Cow = ({
       setIsTransitioning(true)
 
       try {
+        // Drawn lazily (not alongside `newX`) to preserve the original
+        // `random()` call order across the optional flip await; the draw
+        // order matters because `random()` reads from a shared,
+        // optionally-seeded global PRNG.
+        const newY = randomPosition()
+
         await tweenable.tween({
           from: { x: from.x, y: from.y },
           to: { x: newX, y: newY },
           duration: transitionAnimationDuration,
-          render: ({ x: newXValue, y: newYValue }: any) => {
-            setPosition({ x: newXValue, y: newYValue })
+          render: (tweenState: TweenState) => {
+            if (
+              typeof tweenState.x === 'number' &&
+              typeof tweenState.y === 'number'
+            ) {
+              setPosition({ x: tweenState.x, y: tweenState.y })
+            }
           },
           easing: 'linear',
         })

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Tooltip from '@mui/material/Tooltip/index.js'
 import Typography from '@mui/material/Typography/index.js'
 import classNames from 'classnames'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Tweenable } from 'shifty'
 
 import { random } from '../../common/utils.js'
@@ -63,6 +63,7 @@ export const Cow = ({
   const isSelectedRef = useRef(isSelected)
   const positionRef = useRef(position)
   const moveDirectionRef = useRef(moveDirection)
+  const scheduleMoveRef = useRef<() => void>(() => {})
 
   cowInventoryRef.current = cowInventory
   isSelectedRef.current = isSelected
@@ -75,7 +76,7 @@ export const Cow = ({
 
   const tweenable = tweenableRef.current
 
-  const move = async () => {
+  const move = useCallback(async () => {
     const newX = randomPosition()
 
     const oldDirection = moveDirectionRef.current
@@ -154,16 +155,16 @@ export const Cow = ({
       setIsTransitioning(false)
     }
 
-    scheduleMove()
-  }
+    scheduleMoveRef.current()
+  }, [tweenable])
 
-  const repositionTimeoutHandler = () => {
+  const repositionTimeoutHandler = useCallback(() => {
     repositionTimeoutIdRef.current = null
 
     move()
-  }
+  }, [move])
 
-  const scheduleMove = () => {
+  const scheduleMove = useCallback(() => {
     if (isSelectedRef.current) {
       return
     }
@@ -174,7 +175,9 @@ export const Cow = ({
       repositionTimeoutHandler,
       random() * waitVariance
     )
-  }
+  }, [repositionTimeoutHandler])
+
+  scheduleMoveRef.current = scheduleMove
 
   useEffect(() => {
     if (
@@ -190,8 +193,7 @@ export const Cow = ({
     }
 
     prevIsSelectedRef.current = isSelected
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSelected])
+  }, [isSelected, scheduleMove])
 
   useEffect(() => {
     if (
@@ -231,6 +233,9 @@ export const Cow = ({
 
       tweenableRef.current?.cancel()
     }
+    // Mount-only effect (the function-component equivalent of
+    // componentDidMount): it must run exactly once, so `cow` and `scheduleMove`
+    // are intentionally omitted from the dependency array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -18,7 +18,8 @@ const randomPosition = () => 10 + random() * 80
 const flipAnimationDuration = 1000
 const transitionAnimationDuration = 3000
 
-// This MUST be kept in sync with $hug-animation-duration in CowPen.sass.
+// This MUST be kept in sync with the `animationDuration` of the `.is-animating`
+// rule in CowPen.tsx.
 const hugAnimationDuration = 750
 
 export interface CowProps {

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -187,19 +187,20 @@ export const Cow = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSelected, isTransitioning, cowInventory.length, move])
 
-  // Shows the hug animation whenever `happinessBoostsToday` increases.
+  // Shows the hug animation whenever `happinessBoostsToday` increases. The
+  // previous value is always synced to the current value (even when it
+  // decreases, e.g. by the daily reset in `computeCowInventoryForNextDay`)
+  // so that the first hug of a new day still animates, matching the
+  // class-component behavior of comparing against the previous render's
+  // props.
   useEffect(() => {
-    if (cow.happinessBoostsToday <= prevHappinessBoostsToday) {
-      return
-    }
+    const increased = cow.happinessBoostsToday > prevHappinessBoostsToday
 
     setPrevHappinessBoostsToday(cow.happinessBoostsToday)
 
-    if (showHugAnimation) {
-      return
+    if (increased && !showHugAnimation) {
+      setShowHugAnimation(true)
     }
-
-    setShowHugAnimation(true)
   }, [cow.happinessBoostsToday, prevHappinessBoostsToday, showHugAnimation])
 
   useEffect(() => {

--- a/src/components/CowPen/Cow.tsx
+++ b/src/components/CowPen/Cow.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@mui/material/Tooltip/index.js'
 import Typography from '@mui/material/Typography/index.js'
 import classNames from 'classnames'
 import { useCallback, useEffect, useState } from 'react'
-import { Tweenable } from 'shifty'
+import { TweenState, Tweenable } from 'shifty'
 
 import { random } from '../../common/utils.js'
 import { LEFT, RIGHT } from '../../constants.js'
@@ -67,8 +67,10 @@ export const Cow = ({
       setMoveDirection(newDirection)
 
       if (fromDirection !== newDirection) {
-        const render = (tweenState: { rotate?: number | string }) => {
-          setRotate(tweenState.rotate as number)
+        const render = (tweenState: TweenState) => {
+          if (typeof tweenState.rotate === 'number') {
+            setRotate(tweenState.rotate)
+          }
         }
 
         try {

--- a/src/components/CowPen/CowPen.test.tsx
+++ b/src/components/CowPen/CowPen.test.tsx
@@ -205,4 +205,78 @@ describe('Cow', () => {
     expect(cowElement).toBeInTheDocument()
     expect(cowElement).not.toHaveClass('is-selected')
   })
+
+  test('shows the hug animation when happinessBoostsToday increases', () => {
+    const { rerender, container } = render(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 0 }}
+      />
+    )
+
+    const heart = () => container.querySelector('.fa-heart.animation')
+
+    rerender(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 1 }}
+      />
+    )
+
+    expect(heart()?.getAttribute('class')).toContain('is-animating')
+  })
+
+  test('stops the hug animation after it completes', () => {
+    const { rerender, container } = render(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 0 }}
+      />
+    )
+
+    const heart = () => container.querySelector('.fa-heart.animation')
+
+    rerender(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 1 }}
+      />
+    )
+    expect(heart()?.getAttribute('class')).toContain('is-animating')
+
+    vi.advanceTimersByTime(750)
+
+    expect(heart()?.getAttribute('class')).not.toContain('is-animating')
+  })
+
+  test('shows the hug animation after the daily reset of happinessBoostsToday', () => {
+    // The cow was hugged the maximum number of times today.
+    const { rerender, container } = render(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 3 }}
+      />
+    )
+
+    const heart = () => container.querySelector('.fa-heart.animation')
+
+    // Midnight: the daily reset brings the boost count back down.
+    rerender(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 0 }}
+      />
+    )
+    vi.advanceTimersByTime(100)
+
+    // The first hug of the new day still animates.
+    rerender(
+      <Cow
+        {...defaultCowProps}
+        cow={{ ...defaultCowProps.cow, happinessBoostsToday: 1 }}
+      />
+    )
+
+    expect(heart()?.getAttribute('class')).toContain('is-animating')
+  })
 })


### PR DESCRIPTION
### What this PR does

- Converts the `Cow` component from a class component to a function component using `useState`/`useRef`/`useEffect`. This is a pure refactor with no behavioral change.
- Class mechanics map to hooks as follows:
  - `this.state` → `useState` (`x`/`y` stay in a single `position` object so the tween render callback updates both coordinates in one render, as before)
  - `this.tweenable`, timeout IDs, and `isComponentMounted` → `useRef`
  - `componentDidMount`/`componentWillUnmount` → a mount `useEffect` and its cleanup
  - `componentDidUpdate` → effects keyed on `isSelected` and `cow.happinessBoostsToday`, with previous values tracked in refs
  - The static durations become module constants (they were not referenced externally; `CowProps` remains exported unchanged)

### How this change can be validated

- `npx vitest run src/components/CowPen/CowPen.test.tsx` — all 15 tests pass (the only suite that renders `Cow`)
- `npm run lint` and `npm run check:types` pass
- Full test run shows only the pre-existing flaky failures also present on `develop` (`game-logic/field-purchase`, `shell/pending-notifications`, `shell/game-saving`, `game-logic/item-purchase` timing flakes) — no new failures
- Manual: open the game and watch cows wander; select/deselect a cow — movement pauses while selected and resumes after; flips, transitions, tooltip, and the hug heart animation all behave as before

### Questions or concerns about this change

- The test suite uses fake timers, so long-running tween behavior was not exercised end-to-end in CI. I've traced the call order of `random()` and the tween/cleanup lifecycles against the class version to keep them identical, but a quick manual playthrough is still worth it.

### Additional information

- `Cow` is only used by `CowPen.tsx` and `CowPen.test.tsx`; no other call sites or static references exist.